### PR TITLE
Change send button UI and implemented disabled logic.

### DIFF
--- a/Sources/MessageInputBar.swift
+++ b/Sources/MessageInputBar.swift
@@ -47,7 +47,12 @@ open class MessageInputBar: UIView, UITextViewDelegate {
 
         let sendButton = UIButton()
         sendButton.setTitle("Send", for: .normal)
-        sendButton.setTitleColor(.lightGray, for: .normal)
+        sendButton.setTitleColor(.sendButtonBlue, for: .normal)
+        sendButton.setTitleColor(UIColor.sendButtonBlue.withAlphaComponent(0.3), for: .highlighted)
+        sendButton.setTitleColor(.lightGray, for: .disabled)
+        sendButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .headline)
+        sendButton.isEnabled = false
+
         return sendButton
     }()
 
@@ -91,6 +96,8 @@ open class MessageInputBar: UIView, UITextViewDelegate {
     }
 
     public func textViewDidChange(_ textView: UITextView) {
+        let trimmedText = textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        sendButton.isEnabled = !trimmedText.isEmpty && textView.text != "New Message"
         invalidateIntrinsicContentSize()
     }
 

--- a/Sources/UIColor+Extensions.swift
+++ b/Sources/UIColor+Extensions.swift
@@ -32,4 +32,6 @@ extension UIColor {
 
     static let inputBarGray = UIColor(colorLiteralRed: 247/255, green: 247/255, blue: 247/255, alpha: 1.0)
 
+    static let sendButtonBlue = UIColor(colorLiteralRed: 15/255, green: 135/255, blue: 255/255, alpha: 1.0)
+
 }


### PR DESCRIPTION
Now the `sendButton` is disabled when the `textView` is empty and when there's the `placeholder` text showed.