### PR TITLE
Focusing on the "why" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Why?
 
-UX is important, but people often forget about Developer UX. MessageKit is a framework geared towards making a chat interface easy for both users and developers.
+UX is important-- but people often forget about Developer UX. MessageKit is a framework geared towards making a chat interface easy for both users and developers.
 
 ## What is it?
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # MessageKit
 
-[![Build Status](https://travis-ci.org/MessageKit/MessageKit.svg)](https://travis-ci.org/MessageKit/MessageKit) [![codecov](https://codecov.io/gh/MessageKit/MessageKit/branch/master/graph/badge.svg)](https://codecov.io/gh/MessageKit/MessageKit)
+## Why?
 
-**In-progress**, this project is intended to be a Swift rewrite of the recently deprecated [JSQMessagesViewController](https://github.com/jessesquires/JSQMessagesViewController).
+UX is important, but people often forget about Developer UX. MessageKit is a framework geared towards making a chat interface easy for both users and developers.
+
+## What is it?
+
+The project started when [JSQMessagesViewController](https://github.com/jessesquires/JSQMessagesViewController) was deprecated. This project is still **in progress** and intended to be a complete overhaul of [JSQMessagesViewController](https://github.com/jessesquires/JSQMessagesViewController) written entirely in Swift.
+
+[![Build Status](https://travis-ci.org/MessageKit/MessageKit.svg)](https://travis-ci.org/MessageKit/MessageKit) [![codecov](https://codecov.io/gh/MessageKit/MessageKit/branch/master/graph/badge.svg)](https://codecov.io/gh/MessageKit/MessageKit)
 
 ## Want to contribute?
 


### PR DESCRIPTION
Project managers are always telling us to "focus on the why", so that's what my initial change to the README did. 

Developer UX is forgotten far too often, and I'd like to remind the MessageKit community. Rather than focusing on creating a super-robust and customizable framework, let's create a super easy-to-use Message-UI that is **EVEN EASIER** than JSQ was! 

Swifty Methods! Code so easy to use that documentation is hardly even necessary! Let's do it!