### PR TITLE
[WIP] [Example] Feature/attributed text bubble

### DIFF
--- a/Example/Sources/MockMessage.swift
+++ b/Example/Sources/MockMessage.swift
@@ -39,4 +39,11 @@ struct MockMessage: MessageType {
         self.sentDate = Date()
     }
 
+    init(text: NSAttributedString, sender: Sender, messageId: String) {
+        data = .attributedText(text)
+        self.sender = sender
+        self.messageId = messageId
+        self.sentDate = Date()
+    }
+
 }

--- a/Example/Sources/SampleData.swift
+++ b/Example/Sources/SampleData.swift
@@ -40,7 +40,27 @@ struct SampleData {
         let msg7 = MockMessage(text: "Remembering that I'll be dead soon is the most important tool I've ever encountered to help me make the big choices in life. Because almost everything - all external expectations, all pride, all fear of embarrassment or failure - these things just fall away in the face of death, leaving only what is truly important.", sender: Jobs, messageId: UUID().uuidString)
         let msg8 = MockMessage(text: "Price is rarely the most important thing. A cheap product might sell some units. Somebody gets it home and they feel great when they pay the money, but then they get it home and use it and the joy is gone.", sender: Cook, messageId: UUID().uuidString)
 
-        return [msg1, msg2, msg3, msg4, msg5, msg6, msg7, msg8]
+        let msg9Text = NSString(string: "Use .attributedText() to add bold, italic, colored text and more...")
+        let msg9AttributedText = NSMutableAttributedString(string: String(msg9Text))
+
+        if #available(iOS 9.0, *) {
+            msg9AttributedText.addAttributes([NSFontAttributeName: UIFont.monospacedDigitSystemFont(ofSize: UIFont.systemFontSize, weight: UIFontWeightBold)], range: msg9Text.range(of: ".attributedText()"))
+        } else {
+            msg9AttributedText.addAttributes([NSUnderlineStyleAttributeName: NSUnderlineStyle.styleSingle], range: msg9Text.range(of: ".attributedText()"))
+        }
+
+        msg9AttributedText.addAttributes([NSFontAttributeName: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize)],
+                                         range: msg9Text.range(of: "bold"))
+
+        msg9AttributedText.addAttributes([NSFontAttributeName: UIFont.italicSystemFont(ofSize: UIFont.systemFontSize)],
+                                         range: msg9Text.range(of: "italic"))
+
+        msg9AttributedText.addAttributes([NSForegroundColorAttributeName: UIColor.red],
+                                         range: msg9Text.range(of: "colored"))
+
+        let msg9 = MockMessage(text: msg9AttributedText, sender: Jobs, messageId: UUID().uuidString)
+        
+        return [msg1, msg2, msg3, msg4, msg5, msg6, msg7, msg8, msg9]
     }
     
     func getCurrentSender() -> Sender {

--- a/Sources/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/MessagesCollectionViewFlowLayout.swift
@@ -57,6 +57,13 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
         return MessagesCollectionViewLayoutAttributes.self
     }
 
+    fileprivate static let placeholderMessageLabel: MessageLabel = MessageLabel()
+
+    fileprivate static func sizeThatFits(text: NSAttributedString, and size: CGSize) -> CGSize {
+        placeholderMessageLabel.attributedText = text
+        return placeholderMessageLabel.sizeThatFits(size)
+    }
+
     // MARK: - Initializers
 
     override public init() {
@@ -273,7 +280,7 @@ extension MessagesCollectionViewFlowLayout {
         case .text(let text):
             estimatedHeight = text.height(considering: availableWidth, and: messageLabelFont)
         case .attributedText(let text):
-            estimatedHeight = text.height(considering: availableWidth)
+            estimatedHeight = MessagesCollectionViewFlowLayout.sizeThatFits(text: text, and: CGSize(width: availableWidth, height: .greatestFiniteMagnitude)).height
         }
 
         let finalHeight = estimatedHeight.rounded(.up) + verticalMessageInsets
@@ -295,7 +302,7 @@ extension MessagesCollectionViewFlowLayout {
         case .text(let text):
             estimatedWidth = text.width(considering: containerHeight, and: messageLabelFont)
         case .attributedText(let text):
-            estimatedWidth = text.width(considering: containerHeight)
+            estimatedWidth = MessagesCollectionViewFlowLayout.sizeThatFits(text: text, and: CGSize(width: .greatestFiniteMagnitude, height: containerHeight)).width
         }
 
         let widthToUse = estimatedWidth.rounded(.up) > availableWidth ? availableWidth : estimatedWidth


### PR DESCRIPTION
So I'm having trouble getting `NSAttributedString`'s method `boundingRect(size:options:context)` to return a proper size for the `MessageContainerView` when a `MessageLabel` is using attributed text.

The method `sizeThatFits` of `UIView` is returning the proper size. However, the `MessagesCollectionViewFlowLayout` needs this size to determine the height of the cell. Therefore, to use this in the layout object we would have to initialize a temporary `UILabel`, set the attributed text on it, and then call `sizeThatFits` to retrieve the size fitting that text. 

This works fine, but I don't like the overhead of having to initialize a UILabel just to get the size and then throw it away 🤔

I've given `MessagesCollectionViewFlowLayout` a type property - `placeHolderMessagesLabel` in hopes of not having to constantly initialize one in the body of the sizing methods. I'm not sure what the implications of this are 😞

Any feedback would be much appreciated - lurkers? @MacMeDan, @fbartho?

EDIT: The label should probably just be a private instance property and it would just float around for the lifetime of the `MessagesCollectionViewFlowLayout` 😂 
 