### PR TITLE
Message text color2

### DIFF
--- a/MessageKit.xcodeproj/project.pbxproj
+++ b/MessageKit.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		171D5AB91F36712B0053DF69 /* InputTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171D5AB81F36712B0053DF69 /* InputTextView.swift */; };
 		372F6AEB1F36C15600B57FBD /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372F6AEA1F36C15600B57FBD /* AvatarView.swift */; };
 		372F6AEF1F36C61000B57FBD /* AvatarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372F6AEE1F36C61000B57FBD /* AvatarViewTests.swift */; };
+		376AD1821F4258D80083072A /* TestMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376AD1811F4258D80083072A /* TestMessageModel.swift */; };
+		376AD1861F4259270083072A /* MessagesDisplayDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376AD1851F4259270083072A /* MessagesDisplayDataSourceTests.swift */; };
 		37C936981F38F6AC00853DF2 /* Avatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C936971F38F6AC00853DF2 /* Avatar.swift */; };
 		882D75841DE507320033F95F /* MessagesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882D75831DE507320033F95F /* MessagesDataSource.swift */; };
 		888CEBFC1D3FD525005178DE /* MessagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888CEBFB1D3FD525005178DE /* MessagesViewController.swift */; };
@@ -51,6 +53,8 @@
 		171D5AB81F36712B0053DF69 /* InputTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputTextView.swift; sourceTree = "<group>"; };
 		372F6AEA1F36C15600B57FBD /* AvatarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		372F6AEE1F36C61000B57FBD /* AvatarViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarViewTests.swift; sourceTree = "<group>"; };
+		376AD1811F4258D80083072A /* TestMessageModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMessageModel.swift; sourceTree = "<group>"; };
+		376AD1851F4259270083072A /* MessagesDisplayDataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessagesDisplayDataSourceTests.swift; sourceTree = "<group>"; };
 		37C936971F38F6AC00853DF2 /* Avatar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Avatar.swift; sourceTree = "<group>"; };
 		882D75831DE507320033F95F /* MessagesDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessagesDataSource.swift; sourceTree = "<group>"; };
 		888CEBFB1D3FD525005178DE /* MessagesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessagesViewController.swift; sourceTree = "<group>"; };
@@ -100,6 +104,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		376AD1801F4258C50083072A /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				376AD1811F4258D80083072A /* TestMessageModel.swift */,
+			);
+			name = "Support Files";
+			sourceTree = "<group>";
+		};
 		88916B181CF0DF2F00469F91 = {
 			isa = PBXGroup;
 			children = (
@@ -138,6 +150,8 @@
 				88916B421CF0DF5900469F91 /* Info.plist */,
 				88916B431CF0DF5900469F91 /* MessageKitTests.swift */,
 				372F6AEE1F36C61000B57FBD /* AvatarViewTests.swift */,
+				376AD1851F4259270083072A /* MessagesDisplayDataSourceTests.swift */,
+				376AD1801F4258C50083072A /* Support Files */,
 			);
 			path = Tests;
 			sourceTree = SOURCE_ROOT;
@@ -355,6 +369,7 @@
 				B015E81F1F259D8E007EDFB6 /* MessageInputBarDelegate.swift in Sources */,
 				B0655A2A1F23D77200542A83 /* Sender.swift in Sources */,
 				B074EE931F35587100ABB8C8 /* MessageHeaderView.swift in Sources */,
+				376AD1821F4258D80083072A /* TestMessageModel.swift in Sources */,
 				B0655A4D1F244C0600542A83 /* MessageCollectionViewCell.swift in Sources */,
 				B0655A2E1F23D8BC00542A83 /* MessagesCollectionView.swift in Sources */,
 				B074EE951F35588A00ABB8C8 /* MessageFooterView.swift in Sources */,
@@ -375,6 +390,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				88916B451CF0DF5900469F91 /* MessageKitTests.swift in Sources */,
+				376AD1861F4259270083072A /* MessagesDisplayDataSourceTests.swift in Sources */,
 				372F6AEF1F36C61000B57FBD /* AvatarViewTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MessageKit.xcodeproj/project.pbxproj
+++ b/MessageKit.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		372F6AEF1F36C61000B57FBD /* AvatarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372F6AEE1F36C61000B57FBD /* AvatarViewTests.swift */; };
 		376AD1821F4258D80083072A /* TestMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376AD1811F4258D80083072A /* TestMessageModel.swift */; };
 		376AD1861F4259270083072A /* MessagesDisplayDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376AD1851F4259270083072A /* MessagesDisplayDataSourceTests.swift */; };
+		376AD1881F4259D20083072A /* TestMessagesViewControllerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376AD1871F4259D20083072A /* TestMessagesViewControllerModel.swift */; };
 		37C936981F38F6AC00853DF2 /* Avatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C936971F38F6AC00853DF2 /* Avatar.swift */; };
 		882D75841DE507320033F95F /* MessagesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882D75831DE507320033F95F /* MessagesDataSource.swift */; };
 		888CEBFC1D3FD525005178DE /* MessagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888CEBFB1D3FD525005178DE /* MessagesViewController.swift */; };
@@ -55,6 +56,7 @@
 		372F6AEE1F36C61000B57FBD /* AvatarViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarViewTests.swift; sourceTree = "<group>"; };
 		376AD1811F4258D80083072A /* TestMessageModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMessageModel.swift; sourceTree = "<group>"; };
 		376AD1851F4259270083072A /* MessagesDisplayDataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessagesDisplayDataSourceTests.swift; sourceTree = "<group>"; };
+		376AD1871F4259D20083072A /* TestMessagesViewControllerModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMessagesViewControllerModel.swift; sourceTree = "<group>"; };
 		37C936971F38F6AC00853DF2 /* Avatar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Avatar.swift; sourceTree = "<group>"; };
 		882D75831DE507320033F95F /* MessagesDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessagesDataSource.swift; sourceTree = "<group>"; };
 		888CEBFB1D3FD525005178DE /* MessagesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessagesViewController.swift; sourceTree = "<group>"; };
@@ -108,6 +110,7 @@
 			isa = PBXGroup;
 			children = (
 				376AD1811F4258D80083072A /* TestMessageModel.swift */,
+				376AD1871F4259D20083072A /* TestMessagesViewControllerModel.swift */,
 			);
 			name = "Support Files";
 			sourceTree = "<group>";
@@ -367,6 +370,7 @@
 				B09643861F286C9E004D0129 /* String+Extensions.swift in Sources */,
 				B0655A281F23D71400542A83 /* MessageDirection.swift in Sources */,
 				B015E81F1F259D8E007EDFB6 /* MessageInputBarDelegate.swift in Sources */,
+				376AD1881F4259D20083072A /* TestMessagesViewControllerModel.swift in Sources */,
 				B0655A2A1F23D77200542A83 /* Sender.swift in Sources */,
 				B074EE931F35587100ABB8C8 /* MessageHeaderView.swift in Sources */,
 				376AD1821F4258D80083072A /* TestMessageModel.swift in Sources */,

--- a/Sources/MessagesCollectionView.swift
+++ b/Sources/MessagesCollectionView.swift
@@ -33,8 +33,6 @@ open class MessagesCollectionView: UICollectionView {
     open weak var messagesLayoutDelegate: MessagesLayoutDelegate?
 
     open weak var messageCellDelegate: MessageCellDelegate?
-    
-    open weak var messagesDisplayDataSource: MessagesDisplayDataSource?
 
     private var indexPathForLastItem: IndexPath? {
 

--- a/Sources/MessagesCollectionView.swift
+++ b/Sources/MessagesCollectionView.swift
@@ -33,6 +33,8 @@ open class MessagesCollectionView: UICollectionView {
     open weak var messagesLayoutDelegate: MessagesLayoutDelegate?
 
     open weak var messageCellDelegate: MessageCellDelegate?
+    
+    open weak var messagesDisplayDataSource: MessagesDisplayDataSource?
 
     private var indexPathForLastItem: IndexPath? {
 

--- a/Sources/MessagesDisplayDataSource.swift
+++ b/Sources/MessagesDisplayDataSource.swift
@@ -25,41 +25,52 @@
 import Foundation
 
 public protocol MessagesDisplayDataSource: class, MessagesDataSource {
-
-    func messageColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor
-
-    func avatar(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> Avatar
-
+    
+    func textColor(for message: MessageType, at indexPath: IndexPath) -> UIColor
+    
+    func backgroundColor(for message: MessageType, at  indexPath: IndexPath) -> UIColor
+    
+    func avatar(for message: MessageType) -> Avatar
+    
     func messageHeaderView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageHeaderView?
-
+    
     func messageFooterView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageFooterView?
-
+    
     func cellTopLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString?
-
+    
     func cellBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString?
-
+    
 }
 
-public extension MessagesDisplayDataSource {
-
-    func messageColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
+// "where Self: MessagesViewController" make these methods a `default` implimentation for any view that subclasses of MessagesViewController
+public extension MessagesDisplayDataSource where Self: MessagesViewController {
+    
+    func textColor(for message: MessageType, at indexPath: IndexPath) -> UIColor {
+        return isFromCurrentSender(message: message) ? .white : .black
+    }
+    
+    func backgroundColor(for message: MessageType, at  indexPath: IndexPath) -> UIColor {
         return isFromCurrentSender(message: message) ? .outgoingGreen : .incomingGray
     }
-
+    
+    func avatar(for message: MessageType) -> Avatar {
+        return Avatar()
+    }
+    
     func messageHeaderView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageHeaderView? {
         return nil
     }
-
+    
     func messageFooterView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageFooterView? {
         return nil
     }
-
+    
     func cellTopLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
         return nil
     }
-
+    
     func cellBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
         return nil
     }
-
+    
 }

--- a/Sources/MessagesDisplayDataSource.swift
+++ b/Sources/MessagesDisplayDataSource.swift
@@ -26,11 +26,11 @@ import Foundation
 
 public protocol MessagesDisplayDataSource: class, MessagesDataSource {
     
-    func textColor(for message: MessageType, at indexPath: IndexPath) -> UIColor
+    func textColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor
     
-    func backgroundColor(for message: MessageType, at  indexPath: IndexPath) -> UIColor
+    func backgroundColor(for message: MessageType, at  indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor
     
-    func avatar(for message: MessageType) -> Avatar
+    func avatar(for message: MessageType, at  indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> Avatar
     
     func messageHeaderView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageHeaderView?
     
@@ -45,15 +45,15 @@ public protocol MessagesDisplayDataSource: class, MessagesDataSource {
 // "where Self: MessagesViewController" make these methods a `default` implimentation for any view that subclasses of MessagesViewController
 public extension MessagesDisplayDataSource where Self: MessagesViewController {
     
-    func textColor(for message: MessageType, at indexPath: IndexPath) -> UIColor {
+    func textColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
         return isFromCurrentSender(message: message) ? .white : .black
     }
     
-    func backgroundColor(for message: MessageType, at  indexPath: IndexPath) -> UIColor {
+    func backgroundColor(for message: MessageType, at  indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
         return isFromCurrentSender(message: message) ? .outgoingGreen : .incomingGray
     }
     
-    func avatar(for message: MessageType) -> Avatar {
+    func avatar(for message: MessageType, at  indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> Avatar {
         return Avatar()
     }
     

--- a/Sources/MessagesViewController.swift
+++ b/Sources/MessagesViewController.swift
@@ -165,9 +165,9 @@ extension MessagesViewController: UICollectionViewDataSource {
         guard let displayDataSource = messagesDataSource as? MessagesDisplayDataSource else { return cell }
 
         let message = displayDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
-        let messageColor = displayDataSource.backgroundColor(for: message, at: indexPath)
-        let textColor = displayDataSource.textColor(for: message, at: indexPath)
-        let avatar = displayDataSource.avatar(for: message)
+        let messageColor = displayDataSource.backgroundColor(for: message, at: indexPath, in: messagesCollectionView)
+        let textColor = displayDataSource.textColor(for: message, at: indexPath, in: messagesCollectionView)
+        let avatar = displayDataSource.avatar(for: message, at: indexPath, in: messagesCollectionView)
         let topLabelText = displayDataSource.cellTopLabelAttributedText(for: message, at: indexPath)
         let bottomLabelText = displayDataSource.cellBottomLabelAttributedText(for: message, at: indexPath)
 

--- a/Sources/MessagesViewController.swift
+++ b/Sources/MessagesViewController.swift
@@ -1,26 +1,27 @@
 /*
-MIT License
+ MIT License
+ 
+ Copyright (c) 2017 MessageKit
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
 
-Copyright (c) 2017 MessageKit
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-*/
 
 import UIKit
 

--- a/Sources/MessagesViewController.swift
+++ b/Sources/MessagesViewController.swift
@@ -165,14 +165,16 @@ extension MessagesViewController: UICollectionViewDataSource {
         guard let displayDataSource = messagesDataSource as? MessagesDisplayDataSource else { return cell }
 
         let message = displayDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
-        let messageColor = displayDataSource.messageColor(for: message, at: indexPath, in: messagesCollectionView)
-        let avatar = displayDataSource.avatar(for: message, at: indexPath, in: messagesCollectionView)
+        let messageColor = displayDataSource.backgroundColor(for: message, at: indexPath)
+        let textColor = displayDataSource.textColor(for: message, at: indexPath)
+        let avatar = displayDataSource.avatar(for: message)
         let topLabelText = displayDataSource.cellTopLabelAttributedText(for: message, at: indexPath)
         let bottomLabelText = displayDataSource.cellBottomLabelAttributedText(for: message, at: indexPath)
 
         cell.cellTopLabel.attributedText = topLabelText
         cell.cellBottomLabel.attributedText = bottomLabelText
         cell.avatarView.set(avatar: avatar)
+        cell.messageLabel.textColor = textColor
         cell.messageContainerView.backgroundColor = messageColor
         cell.configure(with: message)
 

--- a/Tests/MessagesDisplayDataSourceTests.swift
+++ b/Tests/MessagesDisplayDataSourceTests.swift
@@ -28,22 +28,19 @@ class MessagesDisplayDataSourceTests: XCTestCase {
     }
     
     func testMessageTextColorDefaultState() {
-        XCTAssertEqual(testClass.textColor(for: testClass.messageList[0], at: IndexPath(item: 0, section: 0)), UIColor.white)
-        XCTAssertEqual(testClass.textColor(for: testClass.messageList[1], at: IndexPath(item: 1, section: 0)), UIColor.black)
+        XCTAssertEqual(testClass.textColor(for: testClass.messageList[0], at: IndexPath(item: 0, section: 0), in: testClass.messagesCollectionView), UIColor.white)
+        XCTAssertEqual(testClass.textColor(for: testClass.messageList[1], at: IndexPath(item: 1, section: 0), in: testClass.messagesCollectionView), UIColor.black)
     }
     
     func testBackGroundColorDefaultState() {
-        XCTAssertEqual(testClass.backgroundColor(for: testClass.messageList[0], at:  IndexPath(item: 0, section: 0)), UIColor.outgoingGreen)
-        XCTAssertNotEqual(testClass.backgroundColor(for: testClass.messageList[0], at:  IndexPath(item: 0, section: 0)), UIColor.incomingGray)
-        XCTAssertEqual(testClass.backgroundColor(for: testClass.messageList[1], at:  IndexPath(item: 1, section: 0)), UIColor.incomingGray)
-        XCTAssertNotEqual(testClass.backgroundColor(for: testClass.messageList[1], at:  IndexPath(item: 1, section: 0)), UIColor.outgoingGreen)
+        XCTAssertEqual(testClass.backgroundColor(for: testClass.messageList[0], at:  IndexPath(item: 0, section: 0), in: testClass.messagesCollectionView), UIColor.outgoingGreen)
+        XCTAssertNotEqual(testClass.backgroundColor(for: testClass.messageList[0], at:  IndexPath(item: 0, section: 0), in: testClass.messagesCollectionView), UIColor.incomingGray)
+        XCTAssertEqual(testClass.backgroundColor(for: testClass.messageList[1], at:  IndexPath(item: 1, section: 0), in: testClass.messagesCollectionView), UIColor.incomingGray)
+        XCTAssertNotEqual(testClass.backgroundColor(for: testClass.messageList[1], at:  IndexPath(item: 1, section: 0), in: testClass.messagesCollectionView), UIColor.outgoingGreen)
     }
     
     func testAvatarDefaultState() {
-        XCTAssertNotNil(testClass.avatar(for: testClass.messageList[0]).initals)
-        XCTAssertNotNil(testClass.avatar(for: testClass.messageList[1]).initals)
-        XCTAssertEqual(testClass.avatar(for: testClass.messageList[0]).initals, "?")
-        XCTAssertEqual(testClass.avatar(for: testClass.messageList[1]).initals, "?")
+        XCTAssertNotNil(testClass.avatar(for: testClass.messageList[0], at: IndexPath(item: 0, section: 0), in: testClass.messagesCollectionView).initals)
     }
     
     func testCellTopLabelDefaultState() {

--- a/Tests/MessagesDisplayDataSourceTests.swift
+++ b/Tests/MessagesDisplayDataSourceTests.swift
@@ -28,30 +28,22 @@ class MessagesDisplayDataSourceTests: XCTestCase {
     }
     
     func testMessageTextColorDefaultState() {
-        XCTAssertEqual(testClass.textColorFor(testClass.messageList[0]), UIColor.white)
-        XCTAssertEqual(testClass.textColorFor(testClass.messageList[1]), UIColor.black)
+        XCTAssertEqual(testClass.textColor(for: testClass.messageList[0], at: IndexPath(item: 0, section: 0)), UIColor.white)
+        XCTAssertEqual(testClass.textColor(for: testClass.messageList[1], at: IndexPath(item: 1, section: 0)), UIColor.black)
     }
     
     func testBackGroundColorDefaultState() {
-        XCTAssertEqual(testClass.backgroundColorFor(testClass.messageList[0]), UIColor.outgoingGreen)
-        XCTAssertNotEqual(testClass.backgroundColorFor(testClass.messageList[0]), UIColor.incomingGray)
-        XCTAssertEqual(testClass.backgroundColorFor(testClass.messageList[1]), UIColor.incomingGray)
-        XCTAssertNotEqual(testClass.backgroundColorFor(testClass.messageList[1]), UIColor.outgoingGreen)
+        XCTAssertEqual(testClass.backgroundColor(for: testClass.messageList[0], at:  IndexPath(item: 0, section: 0)), UIColor.outgoingGreen)
+        XCTAssertNotEqual(testClass.backgroundColor(for: testClass.messageList[0], at:  IndexPath(item: 0, section: 0)), UIColor.incomingGray)
+        XCTAssertEqual(testClass.backgroundColor(for: testClass.messageList[1], at:  IndexPath(item: 1, section: 0)), UIColor.incomingGray)
+        XCTAssertNotEqual(testClass.backgroundColor(for: testClass.messageList[1], at:  IndexPath(item: 1, section: 0)), UIColor.outgoingGreen)
     }
     
     func testAvatarDefaultState() {
-        XCTAssertNotNil(testClass.avatarForMessage(testClass.messageList[0]))
-        XCTAssertEqual(testClass.avatarForMessage(testClass.messageList[0]).initals, "?")
-        XCTAssertNotNil(testClass.avatarForMessage(testClass.messageList[1]))
-        XCTAssertEqual(testClass.avatarForMessage(testClass.messageList[1]).initals, "?")
-    }
-    
-    func testHeaderDefaultState() {
-        XCTAssertNil(testClass.headerForMessage(testClass.messageList[0], at: IndexPath(item: 0, section: 0), in: testClass.messagesCollectionView))
-    }
-    
-    func testFooterDefaultState() {
-        XCTAssertNil(testClass.footerForMessage(testClass.messageList[0], at: IndexPath(item: 0, section: 0), in: testClass.messagesCollectionView))
+        XCTAssertNotNil(testClass.avatar(for: testClass.messageList[0]).initals)
+        XCTAssertNotNil(testClass.avatar(for: testClass.messageList[1]).initals)
+        XCTAssertEqual(testClass.avatar(for: testClass.messageList[0]).initals, "?")
+        XCTAssertEqual(testClass.avatar(for: testClass.messageList[1]).initals, "?")
     }
     
     func testCellTopLabelDefaultState() {

--- a/Tests/MessagesDisplayDataSourceTests.swift
+++ b/Tests/MessagesDisplayDataSourceTests.swift
@@ -1,0 +1,64 @@
+//
+//  MessagesDisplayDataSourceTests.swift
+//  MessageKit
+//
+//  Created by Dan Leonard on 8/14/17.
+//  Copyright © 2017 MessageKit. All rights reserved.
+//
+
+import XCTest
+@testable import MessageKit
+
+class MessagesDisplayDataSourceTests: XCTestCase {
+    
+    let testClass = TestMessagesViewControllerModel()
+    override func setUp() {
+        super.setUp()
+        // Ensures that the messageList has been set.
+        testClass.viewDidLoad()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testInit() {
+        XCTAssertNotNil(testClass)
+        XCTAssertNotNil(testClass.messageList)
+    }
+    
+    func testMessageTextColorDefaultState() {
+        XCTAssertEqual(testClass.textColorFor(testClass.messageList[0]), UIColor.white)
+        XCTAssertEqual(testClass.textColorFor(testClass.messageList[1]), UIColor.black)
+    }
+    
+    func testBackGroundColorDefaultState() {
+        XCTAssertEqual(testClass.backgroundColorFor(testClass.messageList[0]), UIColor.outgoingGreen)
+        XCTAssertNotEqual(testClass.backgroundColorFor(testClass.messageList[0]), UIColor.incomingGray)
+        XCTAssertEqual(testClass.backgroundColorFor(testClass.messageList[1]), UIColor.incomingGray)
+        XCTAssertNotEqual(testClass.backgroundColorFor(testClass.messageList[1]), UIColor.outgoingGreen)
+    }
+    
+    func testAvatarDefaultState() {
+        XCTAssertNotNil(testClass.avatarForMessage(testClass.messageList[0]))
+        XCTAssertEqual(testClass.avatarForMessage(testClass.messageList[0]).initals, "?")
+        XCTAssertNotNil(testClass.avatarForMessage(testClass.messageList[1]))
+        XCTAssertEqual(testClass.avatarForMessage(testClass.messageList[1]).initals, "?")
+    }
+    
+    func testHeaderDefaultState() {
+        XCTAssertNil(testClass.headerForMessage(testClass.messageList[0], at: IndexPath(item: 0, section: 0), in: testClass.messagesCollectionView))
+    }
+    
+    func testFooterDefaultState() {
+        XCTAssertNil(testClass.footerForMessage(testClass.messageList[0], at: IndexPath(item: 0, section: 0), in: testClass.messagesCollectionView))
+    }
+    
+    func testCellTopLabelDefaultState() {
+        XCTAssertNil(testClass.cellTopLabelAttributedText(for: testClass.messageList[0], at: IndexPath(item: 0, section: 0)))
+    }
+    
+    func testCellBottomLabelDefaultState() {
+        XCTAssertNil(testClass.cellBottomLabelAttributedText(for: testClass.messageList[0], at: IndexPath(item: 0, section: 0)))
+    }
+}

--- a/Tests/MessagesDisplayDataSourceTests.swift
+++ b/Tests/MessagesDisplayDataSourceTests.swift
@@ -1,10 +1,27 @@
-//
-//  MessagesDisplayDataSourceTests.swift
-//  MessageKit
-//
-//  Created by Dan Leonard on 8/14/17.
-//  Copyright © 2017 MessageKit. All rights reserved.
-//
+/*
+ MIT License
+ 
+ Copyright (c) 2017 MessageKit
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
 
 import XCTest
 @testable import MessageKit

--- a/Tests/TestMessageModel.swift
+++ b/Tests/TestMessageModel.swift
@@ -1,0 +1,23 @@
+//
+//  TestMessageModel.swift
+//  MessageKit
+//
+//  Created by Dan Leonard on 8/14/17.
+//  Copyright © 2017 MessageKit. All rights reserved.
+//
+
+import Foundation
+struct TestMessage: MessageType {
+    var messageId: String
+    var sender: Sender
+    var sentDate: Date
+    var data: MessageData
+    
+    init(text: String, sender: Sender, messageId: String) {
+        data = .text(text)
+        self.sender = sender
+        self.messageId = messageId
+        self.sentDate = Date()
+    }
+    
+}

--- a/Tests/TestMessageModel.swift
+++ b/Tests/TestMessageModel.swift
@@ -1,10 +1,28 @@
-//
-//  TestMessageModel.swift
-//  MessageKit
-//
-//  Created by Dan Leonard on 8/14/17.
-//  Copyright © 2017 MessageKit. All rights reserved.
-//
+/*
+ MIT License
+ 
+ Copyright (c) 2017 MessageKit
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+
 
 import Foundation
 struct TestMessage: MessageType {

--- a/Tests/TestMessagesViewControllerModel.swift
+++ b/Tests/TestMessagesViewControllerModel.swift
@@ -21,7 +21,7 @@ class TestMessagesViewControllerModel: MessagesViewController, MessagesDisplayDa
     override func viewDidLoad() {
         super.viewDidLoad()
         messageList = [testMessage1, testMessage2]
-        self.messagesCollectionView.messagesDisplayDataSource = self
+        self.messagesCollectionView.messagesDataSource = self
     }
 }
 

--- a/Tests/TestMessagesViewControllerModel.swift
+++ b/Tests/TestMessagesViewControllerModel.swift
@@ -1,13 +1,31 @@
-//
-//  TestMessagesViewControllerModel.swift
-//  MessageKit
-//
-//  Created by Dan Leonard on 8/14/17.
-//  Copyright © 2017 MessageKit. All rights reserved.
-//
+/*
+ MIT License
+ 
+ Copyright (c) 2017 MessageKit
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+
 
 import Foundation
-import Foundation
+
 class TestMessagesViewControllerModel: MessagesViewController, MessagesDisplayDataSource {
     
     var messageList: [TestMessage] = []

--- a/Tests/TestMessagesViewControllerModel.swift
+++ b/Tests/TestMessagesViewControllerModel.swift
@@ -1,0 +1,42 @@
+//
+//  TestMessagesViewControllerModel.swift
+//  MessageKit
+//
+//  Created by Dan Leonard on 8/14/17.
+//  Copyright © 2017 MessageKit. All rights reserved.
+//
+
+import Foundation
+import Foundation
+class TestMessagesViewControllerModel: MessagesViewController, MessagesDisplayDataSource {
+    
+    var messageList: [TestMessage] = []
+    
+    static let sender1 = Sender(id: "1", displayName: "Dan")
+    static let sender2 = Sender(id: "2", displayName: "jobs")
+    
+    let testMessage1 = TestMessage(text: "Hi", sender: sender1, messageId: "asdf")
+    let testMessage2 = TestMessage(text: "sup", sender: sender2, messageId: "dddf")
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        messageList = [testMessage1, testMessage2]
+        self.messagesCollectionView.messagesDisplayDataSource = self
+    }
+}
+
+// - MARK: MessagesDataSource conformace
+extension TestMessagesViewControllerModel: MessagesDataSource {
+    
+    func currentSender() -> Sender {
+        return Sender(id: "1", displayName: "Dan")
+    }
+    
+    func numberOfMessages(in messagesCollectionView: MessagesCollectionView) -> Int {
+        return messageList.count
+    }
+    
+    func messageForItem(at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageType {
+        return messageList[indexPath.section]
+    }
+}


### PR DESCRIPTION
Closes #64 
Adds Tests for the `MessagesDisplayDataSource` protocol
Makes `MessagesDisplayDataSource` have a default implementation.
Adds a `textColor` method for setting the color of the text for an individual message.  