### PR TITLE
Update the Slack Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * [**Requirements**](#requirements)
 * [**Code of Conduct**](https://github.com/MessageKit/MessageKit/blob/master/Code_of_Conduct.md)
 * [**What's Next**](#whats-next)
+* [**Join the Slack Group**](#join-the-slack-group)
 * [**Apps using this library**](#apps-using-this-library)
 * [**License**](#license)
 
@@ -45,7 +46,7 @@ pod 'MessageKit'
 Great! Look over these things first.
 - Please read our [Code of Conduct](https://github.com/MessageKit/MessageKit/blob/master/Code_of_Conduct.md)
 - Check the [Contributing Guide Lines](https://github.com/MessageKit/MessageKit/blob/master/CONTRIBUTING.md).
-- Come join us on [Slack](https://join.slack.com/t/messagekit/shared_invite/MjI0NDkxNjgwMzA3LTE1MDIzMTU0MjUtMzJhZDZlNTkxMA) and 🗣 don't be a stranger. 
+- Come join us on [Slack](https://join.slack.com/t/messagekit/shared_invite/MjI4NzIzNzMyMzU0LTE1MDMwODIzMDUtYzllYzIyNTU4MA) and 🗣 don't be a stranger. 
 - Check out the [current issues](https://github.com/MessageKit/MessageKit/issues) and see if you can tackle any of those. 
 - Download the project and check out the current code base. Suggest any improvements by opening a new issue. 
 - Check out the [What's Next](#whats-next) section :point_down: to see where we are headed.
@@ -57,6 +58,10 @@ Great! Look over these things first.
 ## What's Next?
 
 Check out the [Releases](https://github.com/MessageKit/MessageKit/releases) to see what we are working on next.
+
+## Join the Slack Group
+
+Click here to join [Slack](https://join.slack.com/t/messagekit/shared_invite/MjI4NzIzNzMyMzU0LTE1MDMwODIzMDUtYzllYzIyNTU4MA)
 
 ### Apps using this library
 


### PR DESCRIPTION
Update the Slack Link to a link that never expires. And add it to the table of contents.