### PR TITLE
Update README with Carthage installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ See [VISION.md](https://github.com/MessageKit/MessageKit/blob/master/VISION.md) 
 pod 'MessageKit'
 ````
 
+### [Carthage](https://github.com/Carthage/Carthage)
+
+To integrate MessageKit using Carthage, add the following to your `Cartfile`:
+
+````ruby
+github "MessageKit/MessageKit"
+````
 
 ## Requirements
 


### PR DESCRIPTION
Carthage simply requires the Xcode scheme to be shared, which was already the case. This PR updates the README with formal installation instructions.