### PR TITLE
A workaround solution for the render issue with MessageInputBar

### DIFF
--- a/Example/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/ChatExample.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 				TargetAttributes = {
 					882B5E321CF7D4B900B6E160 = {
 						CreatedOnToolsVersion = 7.3.1;
+						DevelopmentTeam = 9EUCWD26TP;
 						LastSwiftMigration = 0800;
 					};
 					882B5E481CF7D4B900B6E160 = {
@@ -507,6 +508,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = 9EUCWD26TP;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -521,6 +523,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = 9EUCWD26TP;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Example/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/ChatExample.xcodeproj/project.pbxproj
@@ -258,7 +258,6 @@
 				TargetAttributes = {
 					882B5E321CF7D4B900B6E160 = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 9EUCWD26TP;
 						LastSwiftMigration = 0800;
 					};
 					882B5E481CF7D4B900B6E160 = {
@@ -508,7 +507,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 9EUCWD26TP;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -523,7 +522,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 9EUCWD26TP;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -39,8 +39,7 @@ class ConversationViewController: MessagesViewController {
         messagesCollectionView.messageCellDelegate = self
         messagesCollectionView.messageLabelDelegate = self
         messageInputBar.delegate = self
-        
-//        setupInputBar()
+        //setupInputBar()
     }
     
     func setupInputBar() {

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -40,7 +40,7 @@ class ConversationViewController: MessagesViewController {
         messagesCollectionView.messageLabelDelegate = self
         messageInputBar.delegate = self
         
-        setupInputBar()
+//        setupInputBar()
     }
     
     func setupInputBar() {

--- a/Sources/Bundle+Extensions.swift
+++ b/Sources/Bundle+Extensions.swift
@@ -32,5 +32,4 @@ extension Bundle {
         return Bundle(url: resourceUrl)!
     }
 
-
 }

--- a/Sources/InputBarItem.swift
+++ b/Sources/InputBarItem.swift
@@ -135,10 +135,12 @@ open class InputBarButtonItem: UIButton {
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
+        setup()
     }
     
     open func setup() {
+        
         contentVerticalAlignment = .center
         contentHorizontalAlignment = .center
         imageView?.contentMode = .scaleAspectFit

--- a/Sources/InputTextView.swift
+++ b/Sources/InputTextView.swift
@@ -37,6 +37,12 @@ open class InputTextView: UITextView {
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
+    
+    open override var text: String! {
+        didSet {
+            placeholderLabel.isHidden = !text.isEmpty
+        }
+    }
 
     private var placeholderLabelConstraintSet: NSLayoutConstraintSet?
 
@@ -84,7 +90,8 @@ open class InputTextView: UITextView {
     }
 
     required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
+        setup()
     }
 
     open func setup() {

--- a/Sources/MessageInputBar.swift
+++ b/Sources/MessageInputBar.swift
@@ -206,7 +206,8 @@ open class MessageInputBar: UIView {
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
+        setup()
     }
     
     deinit {
@@ -218,7 +219,7 @@ open class MessageInputBar: UIView {
     open func setup() {
         
         backgroundColor = .inputBarGray
-        autoresizingMask = [.flexibleHeight, .flexibleBottomMargin]
+        autoresizingMask = [.flexibleHeight]
         setupSubviews()
         setupConstraints()
         setupObservers()
@@ -448,5 +449,11 @@ open class MessageInputBar: UIView {
         delegate?.messageInputBar(self, didPressSendButtonWith: inputTextView.text)
         textViewDidChange()
     }
+}
 
+extension MessageInputBar {
+    
+    func createCopy() -> MessageInputBar? {
+        return NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: self)) as? MessageInputBar
+    }
 }

--- a/Sources/MessagesViewController.swift
+++ b/Sources/MessagesViewController.swift
@@ -31,6 +31,7 @@ open class MessagesViewController: UIViewController {
 	open var messagesCollectionView = MessagesCollectionView(frame: .zero, collectionViewLayout: MessagesCollectionViewFlowLayout())
 
     open var messageInputBar = MessageInputBar()
+
     private var messageInputBarCopy: MessageInputBar?
     
 	override open var canBecomeFirstResponder: Bool {
@@ -62,26 +63,22 @@ open class MessagesViewController: UIViewController {
         registerReusableFooters()
 
 		setupDelegates()
-        
-        // https://stackoverflow.com/questions/31049651/uitextview-as-inputaccessoryview-doesnt-render-text-until-after-animation
-        // Calling this on the root view avoids a side effect where the inputAccessoryView dissapears after tap
-        //view.snapshotView(afterScreenUpdates: true)
+
 	}
 
-    override open func viewDidLayoutSubviews() {
-        messagesCollectionView.contentInset = UIEdgeInsets(top: topLayoutGuide.length, left: 0, bottom: messageInputBar.frame.height, right: 0)
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupMessageInputBarCopy()
     }
 
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         addKeyboardObservers()
-        messageInputBarCopy?.removeFromSuperview()
-        messageInputBarCopy = nil
+        removeMessageInputBarCopy()
     }
-    
-    open override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        setupMessageInputBarCopy()
+
+    override open func viewDidLayoutSubviews() {
+        messagesCollectionView.contentInset = UIEdgeInsets(top: topLayoutGuide.length, left: 0, bottom: messageInputBar.frame.height, right: 0)
     }
 
     // MARK: - Initializers
@@ -134,11 +131,19 @@ open class MessagesViewController: UIViewController {
                                               toItem: bottomLayoutGuide, attribute: .top, multiplier: 1, constant: 0))
 	}
 
+    // MARK: - MessageInputBar
+    // Fixes bug where MessageInputBar text renders after viewDidAppear
+
     private func setupMessageInputBarCopy() {
         messageInputBarCopy = messageInputBar.createCopy()
         guard let copy = messageInputBarCopy else { return }
         view.addSubview(copy)
         copy.addConstraints(nil, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor, topConstant: 0, leftConstant: 0, bottomConstant: 0, rightConstant: 0, widthConstant: 0, heightConstant: 0)
+    }
+
+    private func removeMessageInputBarCopy() {
+        messageInputBarCopy?.removeFromSuperview()
+        messageInputBarCopy = nil
     }
 }
 

--- a/Sources/MessagesViewController.swift
+++ b/Sources/MessagesViewController.swift
@@ -30,14 +30,15 @@ open class MessagesViewController: UIViewController {
 
 	open var messagesCollectionView = MessagesCollectionView(frame: .zero, collectionViewLayout: MessagesCollectionViewFlowLayout())
 
-	open var messageInputBar = MessageInputBar()
-
+    open var messageInputBar = MessageInputBar()
+    private var messageInputBarCopy: MessageInputBar?
+    
 	override open var canBecomeFirstResponder: Bool {
 		return true
 	}
 
 	override open var inputAccessoryView: UIView? {
-		return messageInputBar
+        return messageInputBar
 	}
 
     open override var shouldAutorotate: Bool {
@@ -65,7 +66,6 @@ open class MessagesViewController: UIViewController {
         // https://stackoverflow.com/questions/31049651/uitextview-as-inputaccessoryview-doesnt-render-text-until-after-animation
         // Calling this on the root view avoids a side effect where the inputAccessoryView dissapears after tap
         //view.snapshotView(afterScreenUpdates: true)
-
 	}
 
     override open func viewDidLayoutSubviews() {
@@ -75,6 +75,13 @@ open class MessagesViewController: UIViewController {
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         addKeyboardObservers()
+        messageInputBarCopy?.removeFromSuperview()
+        messageInputBarCopy = nil
+    }
+    
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupMessageInputBarCopy()
     }
 
     // MARK: - Initializers
@@ -127,6 +134,12 @@ open class MessagesViewController: UIViewController {
                                               toItem: bottomLayoutGuide, attribute: .top, multiplier: 1, constant: 0))
 	}
 
+    private func setupMessageInputBarCopy() {
+        messageInputBarCopy = messageInputBar.createCopy()
+        guard let copy = messageInputBarCopy else { return }
+        view.addSubview(copy)
+        copy.addConstraints(nil, left: view.leftAnchor, bottom: view.bottomAnchor, right: view.rightAnchor, topConstant: 0, leftConstant: 0, bottomConstant: 0, rightConstant: 0, widthConstant: 0, heightConstant: 0)
+    }
 }
 
 // MARK: - UICollectionViewDelegate & UICollectionViewDelegateFlowLayout Conformance


### PR DESCRIPTION
It seems as though when using a UINavigationController there is an issue with the rendering of an inputAccessoryView. This workaround creates a copy during the animation and then deletes it.