### PR TITLE
NSLayoutConstraint Usage Tweaks

### DIFF
--- a/Sources/MessagesViewController.swift
+++ b/Sources/MessagesViewController.swift
@@ -115,17 +115,14 @@ open class MessagesViewController: UIViewController {
        
         messagesCollectionView.translatesAutoresizingMaskIntoConstraints = false
 
-        view.addConstraint(NSLayoutConstraint(item: messagesCollectionView, attribute: .top, relatedBy: .equal,
-                                              toItem: view, attribute: .top, multiplier: 1, constant: 0))
+		let constraints: [NSLayoutConstraint] = [
+			messagesCollectionView.topAnchor.constraint(equalTo: view.topAnchor),
+			messagesCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+			messagesCollectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
 
-        view.addConstraint(NSLayoutConstraint(item: messagesCollectionView, attribute: .leading, relatedBy: .equal,
-                                              toItem: view, attribute: .leading, multiplier: 1, constant: 0))
-
-        view.addConstraint(NSLayoutConstraint(item: messagesCollectionView, attribute: .trailing, relatedBy: .equal,
-                                              toItem: view, attribute: .trailing, multiplier: 1, constant: 0))
-
-        view.addConstraint(NSLayoutConstraint(item: messagesCollectionView, attribute: .bottom, relatedBy: .equal,
-                                              toItem: bottomLayoutGuide, attribute: .top, multiplier: 1, constant: 0))
+			messagesCollectionView.bottomAnchor.constraint(equalTo: bottomLayoutGuide.topAnchor),
+		]
+		NSLayoutConstraint.activate(constraints)
 	}
 
     // MARK: - MessageInputBar

--- a/Sources/NSConstraintLayoutSet.swift
+++ b/Sources/NSConstraintLayoutSet.swift
@@ -48,22 +48,19 @@ public class NSLayoutConstraintSet {
         self.width = width
         self.height = height
     }
-    
-    private func forEach(_ body: (NSLayoutConstraint) -> Void) {
-        let constraints = [top, bottom, left, right, centerX, centerY, width, height]
-        for constraint in constraints {
-            if let constraint = constraint {
-                body(constraint)
-            }
-        }
-    }
+
+	/// All of the currently configured constraints
+	private var availableConstraints: [NSLayoutConstraint] {
+		return [top, bottom, left, right, centerX, centerY, width, height]
+			.flatMap {$0}
+	}
     
     /// Activates all of the non-nil constraints
     ///
     /// - Returns: Self
     @discardableResult
     func activate() -> Self {
-        forEach { $0.isActive = true }
+        NSLayoutConstraint.activate(availableConstraints)
         return self
     }
     
@@ -72,7 +69,7 @@ public class NSLayoutConstraintSet {
     /// - Returns: Self
     @discardableResult
     func deactivate() -> Self {
-        forEach { $0.isActive = false }
+        NSLayoutConstraint.deactivate(availableConstraints)
         return self
     }
 }

--- a/Sources/UIView+Extensions.swift
+++ b/Sources/UIView+Extensions.swift
@@ -31,10 +31,14 @@ extension UIView {
             return
         }
         translatesAutoresizingMaskIntoConstraints = false
-        leftAnchor.constraint(equalTo: superview.leftAnchor).isActive = true
-        rightAnchor.constraint(equalTo: superview.rightAnchor).isActive = true
-        topAnchor.constraint(equalTo: superview.topAnchor).isActive = true
-        bottomAnchor.constraint(equalTo: superview.bottomAnchor).isActive = true
+
+		let constraints: [NSLayoutConstraint] = [
+			leftAnchor.constraint(equalTo: superview.leftAnchor),
+			rightAnchor.constraint(equalTo: superview.rightAnchor),
+			topAnchor.constraint(equalTo: superview.topAnchor),
+			bottomAnchor.constraint(equalTo: superview.bottomAnchor),
+			]
+		NSLayoutConstraint.activate(constraints)
     }
 
     @discardableResult
@@ -83,7 +87,7 @@ extension UIView {
             constraints.append(constraint)
         }
         
-        constraints.forEach { $0.isActive = true }
+        NSLayoutConstraint.activate(constraints)
         return constraints
     }
 }


### PR DESCRIPTION
- Move some constraint construction calls to their equivalent but simpler layoutAnchor forms
- Move from directly manipulating `isActive` to using `NSLayoutConstraint.activate()/deactivate()` -- as per [AppleDocs](https://developer.apple.com/documentation/uikit/nslayoutconstraint/1526955-activate)
>Typically, using this method is more efficient than activating each constraint individually.