### PR TITLE
Closes #72 & #130

### DIFF
--- a/Sources/TextMessageCell.swift
+++ b/Sources/TextMessageCell.swift
@@ -47,6 +47,7 @@ open class TextMessageCell: MessageCollectionViewCell<MessageLabel> {
 
         guard let attributes = layoutAttributes as? MessagesCollectionViewLayoutAttributes else { return }
         messageContentView.textInsets = attributes.messageLabelInsets
+        messageContentView.font = attributes.messageLabelFont
     }
 
     override open func prepareForReuse() {


### PR DESCRIPTION
The font used by the `MessagesCollectionViewFlowLayout` was no longer being applied to the cell. Causing the spacing for the `messageContentView` to be off.