### PR TITLE
[Fix] Allow dynamic setting of messageLabelInsets #159

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,22 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - `LocationMessageDisplayDelegate` to customize a location messages appearance and add a `MKAnnotationView` to location message snapshots. 
 [#150](https://github.com/MessageKit/MessageKit/pull/150) by [@etoledom](https://github.com/etoledom).
 
+- `messageLabelInsets(for:indexPath:messagesCollectionView` method to `MessagesLayoutDelegate`. 
+[#162](https://github.com/MessageKit/MessageKit/pull/162) by [@SD10](https://github.com/SD10).
+
 ### Changed
 - **Breaking Change** `snapshotOptionsForLocation` method is now part of `LocationMessageDisplayDelegate`. 
 [#150](https://github.com/MessageKit/MessageKit/pull/150) by [@etoledom](https://github.com/etoledom).
+
 - **Breaking Change** `setMapSnapshotImage` now includes an `annotationView: MKAnnotationView?` argument. 
 [#150](https://github.com/MessageKit/MessageKit/pull/150) by [@etoledom](https://github.com/etoledom).
+
+- **Breaking Change** `messageLabelInsets` has been made into a method on `MessagesLayoutDelegate`. 
+[#162](https://github.com/MessageKit/MessageKit/pull/162) by [@SD10](https://github.com/SD10).
+
+- **Breaking Change** `messageLabelInsets` now defaults to a `left` inset of 18 for incoming messages
+ and a `right` inset of 18 for outgoing messages. 
+[#162](https://github.com/MessageKit/MessageKit/pull/162) by [@SD10](https://github.com/SD10). 
 
 ----------------
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MessageKit (0.8.1)
+  - MessageKit (0.8.2)
 
 DEPENDENCIES:
   - MessageKit (from `../MessageKit.podspec`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../MessageKit.podspec
 
 SPEC CHECKSUMS:
-  MessageKit: 8a9dff1216b4f0762aec49a712c00219685e2e90
+  MessageKit: 61520afc3c0d43fdc8a5ab2e18cdadbf64f7473e
 
 PODFILE CHECKSUM: 9ac65b8dedf0e1b63fea245b089b6645c4e66309
 

--- a/Sources/MessageKit+Availability.swift
+++ b/Sources/MessageKit+Availability.swift
@@ -54,14 +54,19 @@ public extension MessagesCollectionViewFlowLayout {
         return .zero
     }
 
-    @available(*, deprecated: 0.7.0, message: "Removed in MessageKit 0.7.0. Please use `cellTopLabelPosition(for:indexPath:messagesCollectionView)")
+    @available(*, deprecated: 0.7.0, message: "Removed in MessageKit 0.7.0. Please use cellTopLabelPosition(for:indexPath:messagesCollectionView)")
     public var topLabelExtendsPastAvatar: Bool {
         return false
     }
 
-    @available(*, deprecated: 0.7.0, message: "Removed in MessageKit 0.7.0. Please use `cellBottomLabelPosition(for:indexPath:messagesCollectionView)")
+    @available(*, deprecated: 0.7.0, message: "Removed in MessageKit 0.7.0. Please use cellBottomLabelPosition(for:indexPath:messagesCollectionView)")
     public var bottomLabelExtendsPastAvatar: Bool {
         return false
+    }
+
+    @available(*, deprecated: 0.9.0, message: "Removed in MessageKit 0.9.0. Please use messageLabelInsets(for:indexPath:messagesCollectionView)")
+    public var messageLabelInsets: UIEdgeInsets {
+        return UIEdgeInsets(top: 7, left: 14, bottom: 7, right: 14)
     }
 
 }

--- a/Sources/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/MessagesCollectionViewFlowLayout.swift
@@ -30,7 +30,6 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
     // MARK: - Properties
 
     open var messageLabelFont: UIFont
-    open var messageLabelInsets: UIEdgeInsets
     open var messageToViewEdgePadding: CGFloat
 
     open var cellTopLabelInsets: UIEdgeInsets
@@ -72,7 +71,6 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
     override public init() {
 
         messageLabelFont = UIFont.preferredFont(forTextStyle: .body)
-        messageLabelInsets = UIEdgeInsets(top: 7, left: 14, bottom: 7, right: 14)
         messageToViewEdgePadding = 30.0
 
         cellTopLabelInsets = .zero
@@ -126,6 +124,7 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
         let indexPath = attributes.indexPath
         let message = dataSource.messageForItem(at: indexPath, in: messagesCollectionView)
+        let messageInsets = messageLabelInsets(for: message, at: indexPath)
 
         // First we set all the sizes so we can pass the attributes object around to calculate the origins
         attributes.messageContainerFrame = CGRect(origin: .zero, size: messageContainerSize(for: message, at: indexPath))
@@ -134,7 +133,7 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
         attributes.avatarFrame = CGRect(origin: .zero, size: avatarSize(for: message, at: indexPath))
 
         attributes.messageLabelFont = messageLabelFont
-        attributes.messageLabelInsets = messageLabelInsets
+        attributes.messageLabelInsets = messageInsets
         attributes.cellTopLabelInsets = cellTopLabelInsets
         attributes.cellBottomLabelInsets = cellBottomLabelInsets
         attributes.avatarHorizontalAlignment = avatarHorizontalAlignment(for: message)
@@ -260,14 +259,11 @@ extension MessagesCollectionViewFlowLayout {
 
     // MARK: - Message Container Calculations
 
-    /// The total value of the horizontal insets for the message label.
-    private var messageHorizontalInsets: CGFloat {
-        return messageLabelInsets.left + messageLabelInsets.right
-    }
-
-    /// The total value of the vertical insets for the message label.
-    private var messageVerticalInsets: CGFloat {
-        return messageLabelInsets.top + messageLabelInsets.bottom
+    /// The insets for the text of the MessageLabel
+    private func messageLabelInsets(for message: MessageType, at indexPath: IndexPath) -> UIEdgeInsets {
+        guard let messagesCollectionView = messagesCollectionView else { return .zero }
+        guard let layoutDelegate = messagesCollectionView.messagesLayoutDelegate else { return .zero }
+        return layoutDelegate.messageLabelInset(for: message, at: indexPath, in: messagesCollectionView)
     }
 
     /// The max width available for the message container.
@@ -278,6 +274,9 @@ extension MessagesCollectionViewFlowLayout {
         // Only apply padding if avatar width is greater than zero
         if avatarWidth > 0 { avatarWidth += avatarMessagePadding }
 
+        let messageInsets = messageLabelInsets(for: message, at: indexPath)
+        let messageHorizontalInsets = messageInsets.left + messageInsets.right
+
         let availableWidth = itemWidth - avatarWidth - messageToViewEdgePadding - messageHorizontalInsets
 
         return availableWidth
@@ -287,6 +286,9 @@ extension MessagesCollectionViewFlowLayout {
     fileprivate func messageContainerSize(for message: MessageType, at indexPath: IndexPath) -> CGSize {
 
         let maxWidth = messageContainerMaxWidth(for: message, at: indexPath)
+        let messageInsets = messageLabelInsets(for: message, at: indexPath)
+        let messageHorizontalInsets = messageInsets.left + messageInsets.right
+        let messageVerticalInsets = messageInsets.top + messageInsets.bottom
 
         var messageContainerSize: CGSize = .zero
 

--- a/Sources/MessagesLayoutDelegate.swift
+++ b/Sources/MessagesLayoutDelegate.swift
@@ -26,6 +26,8 @@ import Foundation
 
 public protocol MessagesLayoutDelegate: class {
 
+    func messageLabelInset(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIEdgeInsets
+
     func avatarAlignment(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> AvatarAlignment
 
     func cellTopLabelAlignment(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LabelAlignment
@@ -41,6 +43,11 @@ public protocol MessagesLayoutDelegate: class {
 }
 
 public extension MessagesLayoutDelegate {
+
+    func messageLabelInset(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIEdgeInsets {
+        guard let dataSource = messagesCollectionView.messagesDataSource else { return .zero }
+        return dataSource.isFromCurrentSender(message: message) ? UIEdgeInsets(top: 7, left: 14, bottom: 7, right: 18) : UIEdgeInsets(top: 7, left: 18, bottom: 7, right: 14)
+    }
 
     func avatarAlignment(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> AvatarAlignment {
         return .cellBottom


### PR DESCRIPTION
This deprecates `messageLabelInsets` and moves it into a method for `MessagesLayoutDelegate`. This allows users to take into account the size of the tail when setting the insets.

Will resolve #159.