### PR TITLE
[Added] .custom case to MessageStyle enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 ### Added
+- **Breaking Change** `.custom((MessageContainerView)->Void)` case to `MessageStyle` enum. 
+[#163](https://github.com/MessageKit/MessageKit/pull/163) by [@SD10](https://github.com/SD10).
+
 - **Breaking Change** `UIEdgeInsets` associated value to all `LabelAlignment` enum cases. 
 [#166](https://github.com/MessageKit/MessageKit/pull/166) by [@SD10](https://github.com/SD10).
 

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -222,6 +222,8 @@ extension ConversationViewController: MessagesDisplayDelegate {
     func messageStyle(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageStyle {
         let corner: MessageStyle.TailCorner = isFromCurrentSender(message: message) ? .bottomRight : .bottomLeft
         return .bubbleTail(corner, .curved)
+//        let configurationClosure = { (view: MessageContainerView) in}
+//        return .custom(configurationClosure)
     }
 
     func messageFooterView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageFooterView? {

--- a/Sources/MessageContainerView.swift
+++ b/Sources/MessageContainerView.swift
@@ -69,6 +69,11 @@ open class MessageContainerView: UIImageView {
             mask = nil
             image = nil
             tintColor = nil
+        case .custom(let configurationClosure):
+            mask = nil
+            image = nil
+            tintColor = nil
+            configurationClosure(self)
         }
     }
 

--- a/Sources/MessageStyle.swift
+++ b/Sources/MessageStyle.swift
@@ -69,6 +69,7 @@ public enum MessageStyle {
     case bubbleOutline(UIColor)
     case bubbleTail(TailCorner, TailStyle)
     case bubbleTailOutline(UIColor, TailCorner, TailStyle)
+    case custom((MessageContainerView) -> Void)
 
     // MARK: - Public
 
@@ -79,7 +80,7 @@ public enum MessageStyle {
         guard var image = UIImage(contentsOfFile: path) else { return nil }
 
         switch self {
-        case .none:
+        case .none, .custom:
             return nil
         case .bubble, .bubbleOutline:
             break
@@ -103,7 +104,7 @@ public enum MessageStyle {
             return "bubble_full" + tailStyle.imageNameSuffix
         case .bubbleTailOutline(_, _, let tailStyle):
             return "bubble_outlined" + tailStyle.imageNameSuffix
-        case .none:
+        case .none, .custom:
             return nil
         }
     }


### PR DESCRIPTION
This adds a new case to the `MessageStyle` enum called `.custom((MessageContainerView) -> Void)`. It passes the user a reference to the view for them to configure it with their own style.

![screen shot 2017-09-25 at 3 43 05 pm](https://user-images.githubusercontent.com/7445580/30830467-c1653906-a209-11e7-92f4-c71c8f41f11a.png)

This resolves #160 

### TODO:
- [x] Update CHANGELOG.md
- [x] ~Update Documentation~
