### PR TITLE
[Added] UIEdgeInsets associated value to LabelAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 ### Added
+- **Breaking Change** `UIEdgeInsets` associated value to all `LabelAlignment` enum cases. 
+[#166](https://github.com/MessageKit/MessageKit/pull/166) by [@SD10](https://github.com/SD10).
+
 - `LocationMessageDisplayDelegate` to customize a location messages appearance and add a `MKAnnotationView` to location message snapshots. 
 [#150](https://github.com/MessageKit/MessageKit/pull/150) by [@etoledom](https://github.com/etoledom).
 
@@ -25,6 +28,10 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - **Breaking Change** `messageLabelInsets` now defaults to a `left` inset of 18 for incoming messages
  and a `right` inset of 18 for outgoing messages. 
 [#162](https://github.com/MessageKit/MessageKit/pull/162) by [@SD10](https://github.com/SD10). 
+
+### Removed
+- **Breaking Change** `cellTopLabelInsets` and `cellBottomLabelInsets` from `MessagesCollectionViewFlowLayout`.
+[#166](https://github.com/MessageKit/MessageKit/pull/166) by [@SD10](https://github.com/SD10).
 
 ----------------
 

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -234,6 +234,22 @@ extension ConversationViewController: MessagesDisplayDelegate {
 
 extension ConversationViewController: MessagesLayoutDelegate {
 
+    func cellTopLabelAlignment(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LabelAlignment {
+        if isFromCurrentSender(message: message) {
+            return .messageTrailing(UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10))
+        } else {
+            return .messageLeading(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0))
+        }
+    }
+
+    func cellBottomLabelAlignment(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LabelAlignment {
+        if isFromCurrentSender(message: message) {
+            return .messageLeading(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0))
+        } else {
+            return .messageTrailing(UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10))
+        }
+    }
+
     func avatarAlignment(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> AvatarAlignment {
         return .messageBottom
     }

--- a/Sources/LabelAlignment.swift
+++ b/Sources/LabelAlignment.swift
@@ -22,14 +22,24 @@
  SOFTWARE.
  */
 
-import Foundation
+import UIKit
 
 public enum LabelAlignment {
 
-    case cellTrailing
-    case cellLeading
-    case cellCenter
-    case messageTrailing
-    case messageLeading
-    
+    case cellTrailing(UIEdgeInsets)
+    case cellLeading(UIEdgeInsets)
+    case cellCenter(UIEdgeInsets)
+    case messageTrailing(UIEdgeInsets)
+    case messageLeading(UIEdgeInsets)
+
+    public var insets: UIEdgeInsets {
+        switch self {
+        case .cellTrailing(let insets): return insets
+        case .cellLeading(let insets): return insets
+        case .cellCenter(let insets): return insets
+        case .messageTrailing(let insets): return insets
+        case .messageLeading(let insets): return insets
+        }
+    }
+
 }

--- a/Sources/MessageKit+Availability.swift
+++ b/Sources/MessageKit+Availability.swift
@@ -69,6 +69,15 @@ public extension MessagesCollectionViewFlowLayout {
         return UIEdgeInsets(top: 7, left: 14, bottom: 7, right: 14)
     }
 
+    @available(*, deprecated: 0.9.0, message: "Removed in MessageKit 0.9.0. Please use associated value of LabelAlignment")
+    public var cellTopLabelInsets: UIEdgeInsets {
+        return .zero
+    }
+    @available(*, deprecated: 0.9.0, message: "Removed in MessageKit 0.9.0. Please use associated value of LabelAlignment")
+    public var cellBottomLabelInsets: UIEdgeInsets {
+        return .zero
+    }
+
 }
 
 // MARK: - CellLabelPosition
@@ -81,7 +90,7 @@ public enum CellLabelPosition {
     case cellCenter
     case messageTrailing
     case messageLeading
-    
+
 }
 
 // MARK: - Avatar Position
@@ -94,7 +103,7 @@ public enum AvatarPosition {
     case messageCenter
     case messageBottom
     case cellBottom
-    
+
 }
 
 // MARK: - MessagesLayoutDelegate
@@ -159,5 +168,5 @@ public extension AvatarView {
     public func getImage() -> UIImage? {
         return imageView.image
     }
-    
+
 }

--- a/Sources/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/MessagesCollectionViewFlowLayout.swift
@@ -446,7 +446,7 @@ extension MessagesCollectionViewFlowLayout {
     private func cellBottomLabelInsets(for message: MessageType, at indexPath: IndexPath) -> UIEdgeInsets {
         guard let messagesCollectionView = messagesCollectionView else { return .zero }
         guard let layoutDelegate = messagesCollectionView.messagesLayoutDelegate else { return .zero }
-        let labelAlignment = layoutDelegate.cellTopLabelAlignment(for: message, at: indexPath, in: messagesCollectionView)
+        let labelAlignment = layoutDelegate.cellBottomLabelAlignment(for: message, at: indexPath, in: messagesCollectionView)
         return labelAlignment.insets
     }
 

--- a/Sources/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/MessagesCollectionViewFlowLayout.swift
@@ -32,9 +32,6 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
     open var messageLabelFont: UIFont
     open var messageToViewEdgePadding: CGFloat
 
-    open var cellTopLabelInsets: UIEdgeInsets
-    open var cellBottomLabelInsets: UIEdgeInsets
-
     open var avatarAlwaysLeading: Bool {
         willSet {
             if newValue {
@@ -72,9 +69,6 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
         messageLabelFont = UIFont.preferredFont(forTextStyle: .body)
         messageToViewEdgePadding = 30.0
-
-        cellTopLabelInsets = .zero
-        cellBottomLabelInsets = .zero
 
         avatarAlwaysLeading = false
         avatarAlwaysTrailing = false
@@ -125,6 +119,8 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
         let indexPath = attributes.indexPath
         let message = dataSource.messageForItem(at: indexPath, in: messagesCollectionView)
         let messageInsets = messageLabelInsets(for: message, at: indexPath)
+        let topLabelInsets = cellTopLabelInsets(for: message, at: indexPath)
+        let bottomLabelInsets = cellBottomLabelInsets(for: message, at: indexPath)
 
         // First we set all the sizes so we can pass the attributes object around to calculate the origins
         attributes.messageContainerFrame = CGRect(origin: .zero, size: messageContainerSize(for: message, at: indexPath))
@@ -134,8 +130,8 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
         attributes.messageLabelFont = messageLabelFont
         attributes.messageLabelInsets = messageInsets
-        attributes.cellTopLabelInsets = cellTopLabelInsets
-        attributes.cellBottomLabelInsets = cellBottomLabelInsets
+        attributes.cellTopLabelInsets = topLabelInsets
+        attributes.cellBottomLabelInsets = bottomLabelInsets
         attributes.avatarHorizontalAlignment = avatarHorizontalAlignment(for: message)
 
         let layoutDelegate = messagesCollectionView.messagesLayoutDelegate
@@ -342,14 +338,12 @@ extension MessagesCollectionViewFlowLayout {
 
     // MARK: - Cell Top Label Calculations
 
-    /// The total value of the horizontal insets for the cell top label.
-    private var topLabelHorizontalInsets: CGFloat {
-        return cellTopLabelInsets.left + cellTopLabelInsets.right
-    }
-
-    /// The total value of the vertical insets for the cell top label.
-    private var topLabelVerticalInsets: CGFloat {
-        return cellTopLabelInsets.top + cellTopLabelInsets.bottom
+    /// The insets for the cell's top label.
+    private func cellTopLabelInsets(for message: MessageType, at indexPath: IndexPath) -> UIEdgeInsets {
+        guard let messagesCollectionView = messagesCollectionView else { return .zero }
+        guard let layoutDelegate = messagesCollectionView.messagesLayoutDelegate else { return .zero }
+        let labelAlignment = layoutDelegate.cellTopLabelAlignment(for: message, at: indexPath, in: messagesCollectionView)
+        return labelAlignment.insets
     }
 
     /// The max width available for the cell top label.
@@ -361,6 +355,7 @@ extension MessagesCollectionViewFlowLayout {
         let labelHorizontal = layoutDelegate.cellTopLabelAlignment(for: message, at: indexPath, in: messagesCollectionView)
         let avatarVertical = layoutDelegate.avatarAlignment(for: message, at: indexPath, in: messagesCollectionView)
         let avatarHorizontal = avatarHorizontalAlignment(for: message)
+        let topLabelHorizontalInsets = labelHorizontal.insets.left + labelHorizontal.insets.right
 
         var avatarWidth = layoutDelegate.avatarSize(for: message, at: indexPath, in: messagesCollectionView).width
 
@@ -401,6 +396,10 @@ extension MessagesCollectionViewFlowLayout {
 
         let maxWidth = topLabelMaxWidth(for: message, at: indexPath)
         var size = labelSize(for: topLabelText, considering: maxWidth)
+
+        let topLabelInsets = cellTopLabelInsets(for: message, at: indexPath)
+        let topLabelHorizontalInsets = topLabelInsets.left + topLabelInsets.right
+        let topLabelVerticalInsets = topLabelInsets.top + topLabelInsets.bottom
 
         size.width += topLabelHorizontalInsets
         size.height += topLabelVerticalInsets
@@ -443,14 +442,12 @@ extension MessagesCollectionViewFlowLayout {
 
     // MARK: - Cell Bottom Label Calculations
 
-    /// The total value of the horizontal insets for the cell bottom label
-    private var bottomLabelHorizontalInsets: CGFloat {
-        return cellBottomLabelInsets.left + cellBottomLabelInsets.right
-    }
-
-    /// The total value of the vertical insets for the cell bottom label.
-    private var bottomLabelVerticalInsets: CGFloat {
-        return cellBottomLabelInsets.top + cellBottomLabelInsets.bottom
+    /// The insets for the cell's top label.
+    private func cellBottomLabelInsets(for message: MessageType, at indexPath: IndexPath) -> UIEdgeInsets {
+        guard let messagesCollectionView = messagesCollectionView else { return .zero }
+        guard let layoutDelegate = messagesCollectionView.messagesLayoutDelegate else { return .zero }
+        let labelAlignment = layoutDelegate.cellTopLabelAlignment(for: message, at: indexPath, in: messagesCollectionView)
+        return labelAlignment.insets
     }
 
     /// The max with available for the cell bottom label.
@@ -462,6 +459,7 @@ extension MessagesCollectionViewFlowLayout {
         let labelHorizontal = layoutDelegate.cellBottomLabelAlignment(for: message, at: indexPath, in: messagesCollectionView)
         let avatarVertical = layoutDelegate.avatarAlignment(for: message, at: indexPath, in: messagesCollectionView)
         let avatarHorizontal = avatarHorizontalAlignment(for: message)
+        let bottomLabelHorizontalInsets = labelHorizontal.insets.left + labelHorizontal.insets.right
 
         var avatarWidth = layoutDelegate.avatarSize(for: message, at: indexPath, in: messagesCollectionView).width
 
@@ -503,6 +501,10 @@ extension MessagesCollectionViewFlowLayout {
 
         let maxWidth = bottomLabelMaxWidth(for: message, at: indexPath)
         var size = labelSize(for: bottomLabelText, considering: maxWidth)
+
+        let bottomLabelInsets = cellBottomLabelInsets(for: message, at: indexPath)
+        let bottomLabelHorizontalInsets = bottomLabelInsets.left + bottomLabelInsets.right
+        let bottomLabelVerticalInsets = bottomLabelInsets.top + bottomLabelInsets.bottom
 
         size.width += bottomLabelHorizontalInsets
         size.height += bottomLabelVerticalInsets

--- a/Sources/MessagesLayoutDelegate.swift
+++ b/Sources/MessagesLayoutDelegate.swift
@@ -54,13 +54,13 @@ public extension MessagesLayoutDelegate {
     }
 
     func cellTopLabelAlignment(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LabelAlignment {
-        guard let dataSource = messagesCollectionView.messagesDataSource else { return .cellCenter }
-        return dataSource.isFromCurrentSender(message: message) ? .messageTrailing : .messageLeading
+        guard let dataSource = messagesCollectionView.messagesDataSource else { return .cellCenter(.zero) }
+        return dataSource.isFromCurrentSender(message: message) ? .messageTrailing(.zero) : .messageLeading(.zero)
     }
 
     func cellBottomLabelAlignment(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LabelAlignment {
-        guard let dataSource = messagesCollectionView.messagesDataSource else { return .cellCenter }
-        return dataSource.isFromCurrentSender(message: message) ? .messageLeading : .messageTrailing
+        guard let dataSource = messagesCollectionView.messagesDataSource else { return .cellCenter(.zero) }
+        return dataSource.isFromCurrentSender(message: message) ? .messageLeading(.zero) : .messageTrailing(.zero)
     }
 
     func avatarSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize {


### PR DESCRIPTION
This resolves #161.

`cellTopLabelInsets` and `cellBottomLabel` insets have been removed from `MessagesCollectionViewFlowLayout`. You can now set the insets dynamically through an associated value on the `LabelAlignment` enum.

### TODO:
- [x] Update CHANGELOG.md