### PR TITLE
Make header and footer view initializers public

### DIFF
--- a/Sources/MessageDateHeaderView.swift
+++ b/Sources/MessageDateHeaderView.swift
@@ -32,7 +32,7 @@ open class MessageDateHeaderView: MessageHeaderView {
 
     // MARK: - Initializers
 
-    override init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
         addSubview(dateLabel)
         dateLabel.fillSuperview()
@@ -41,7 +41,7 @@ open class MessageDateHeaderView: MessageHeaderView {
         dateLabel.textColor = .darkGray
     }
     
-    required public init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/Sources/MessageFooterView.swift
+++ b/Sources/MessageFooterView.swift
@@ -32,7 +32,7 @@ open class MessageFooterView: UICollectionReusableView {
         super.init(frame: frame)
     }
 
-    required public init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/Sources/MessageHeaderView.swift
+++ b/Sources/MessageHeaderView.swift
@@ -30,11 +30,11 @@ open class MessageHeaderView: UICollectionReusableView {
 
     static let identifier = "MessageHeaderView"
 
-    override init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
     }
 
-    required public init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 


### PR DESCRIPTION
In order to subclass MessageHeaderView and MessageFooterView, the initializers need to be marked public. Tangential, but I vote we stick with this order moving forward:
`<protection level> <designation>`