### PR TITLE
Issue #164: Setting avatars asynchronously

### DIFF
--- a/Sources/MessageCollectionViewCell.swift
+++ b/Sources/MessageCollectionViewCell.swift
@@ -133,8 +133,13 @@ open class MessageCollectionViewCell<ContentView: UIView>: UICollectionViewCell 
             let avatar = dataSource.avatar(for: message, at: indexPath, in: messagesCollectionView)
             let topLabelText = dataSource.cellTopLabelAttributedText(for: message, at: indexPath)
             let bottomLabelText = dataSource.cellBottomLabelAttributedText(for: message, at: indexPath)
-
-            avatarView.set(avatar: avatar)
+            
+            if let configureAvatar = dataSource.configureAvatarView(avatarView, for: message, at: indexPath, in: messagesCollectionView) {
+                configureAvatar()
+            } else {
+                avatarView.set(avatar: avatar)
+            }
+            
             cellTopLabel.attributedText = topLabelText
             cellBottomLabel.attributedText = bottomLabelText
         }

--- a/Sources/MessagesDataSource.swift
+++ b/Sources/MessagesDataSource.swift
@@ -39,7 +39,9 @@ public protocol MessagesDataSource: class {
     func cellTopLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString?
 
     func cellBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString?
-
+    
+    func configureAvatarView(_ avatarView: AvatarView, for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> (() -> Void)?
+    
 }
 
 public extension MessagesDataSource {
@@ -60,4 +62,7 @@ public extension MessagesDataSource {
         return nil
     }
 
+    func configureAvatarView(_ avatarView: AvatarView, for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> (() -> Void)? {
+        return nil
+    }
 }


### PR DESCRIPTION
I've added an additional `MessagesDatasourceDelegate` method that returns an optional closure. If the closure is returned, we'll call the closure when configuring the cell, otherwise we use `avatarView.set(avatar: avatar)` with the avatar returned from the non-optional delegate method - `avatar(for: message...)`.