### PR TITLE
New swiftlint rule to manage proper placing of override keyword

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,6 @@ disabled_rules:
 custom_rules:
   override_func: # rule identifier
     name: "override in func" # rule name. optional.
-    regex: "(override open) | (override public)" # matching pattern
+    regex: "override (open|public|private|internal|fileprivate)" # matching pattern
     message: "Use like open override or public override instead" # violation message. optional.
     severity: warning # violation severity. optional.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,3 +5,9 @@ disabled_rules:
 - line_length
 - type_body_length
 - file_length
+custom_rules:
+  override_func: # rule identifier
+    name: "override in func" # rule name. optional.
+    regex: "(override open) | (override public)" # matching pattern
+    message: "Use like open override or public override instead" # violation message. optional.
+    severity: warning # violation severity. optional.


### PR DESCRIPTION
This pull request is to handle new swiftlint rule mentioned in #193 issue.
Currently, this rule will take care of override open or override public written in the code and show a warning message. 