### PR TITLE
Fix override keyword placement in function declaration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,6 @@ disabled_rules:
 custom_rules:
   override_func: # rule identifier
     name: "override in func" # rule name. optional.
-    regex: "(override open) | (override public)" # matching pattern
+    regex: "override (open|public|private|internal|fileprivate)" # matching pattern
     message: "Use like open override or public override instead" # violation message. optional.
     severity: warning # violation severity. optional.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,3 +5,9 @@ disabled_rules:
 - line_length
 - type_body_length
 - file_length
+custom_rules:
+  override_func: # rule identifier
+    name: "override in func" # rule name. optional.
+    regex: "(override open) | (override public)" # matching pattern
+    message: "Use like open override or public override instead" # violation message. optional.
+    severity: warning # violation severity. optional.

--- a/Sources/AvatarView.swift
+++ b/Sources/AvatarView.swift
@@ -74,7 +74,7 @@ open class AvatarView: UIView {
     }
 
     // MARK: - Initializers
-    override public init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
         prepareView()
     }

--- a/Sources/InputTextView.swift
+++ b/Sources/InputTextView.swift
@@ -58,13 +58,13 @@ open class InputTextView: UITextView, UITextViewDelegate {
         }
     }
 
-    override open var font: UIFont! {
+    open override var font: UIFont! {
         didSet {
             placeholderLabel.font = font
         }
     }
 
-    override open var textAlignment: NSTextAlignment {
+    open override var textAlignment: NSTextAlignment {
         didSet {
             placeholderLabel.textAlignment = textAlignment
         }
@@ -96,7 +96,7 @@ open class InputTextView: UITextView, UITextViewDelegate {
         self.init(frame: .zero)
     }
 
-    override public init(frame: CGRect, textContainer: NSTextContainer?) {
+    public override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
         setup()
     }

--- a/Sources/LocationMessageCell.swift
+++ b/Sources/LocationMessageCell.swift
@@ -31,7 +31,7 @@ open class LocationMessageCell: MessageCollectionViewCell<UIImageView> {
 
     open var activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .gray)
 
-    override open func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
+    open override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
         super.configure(with: message, at: indexPath, and: messagesCollectionView)
 
         switch message.data {

--- a/Sources/MediaMessageCell.swift
+++ b/Sources/MediaMessageCell.swift
@@ -53,7 +53,7 @@ open class MediaMessageCell: MessageCollectionViewCell<UIImageView> {
         setupConstraints()
     }
 
-    override open func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
+    open override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
         super.configure(with: message, at: indexPath, and: messagesCollectionView)
         switch message.data {
         case .photo(let image):

--- a/Sources/MessageCollectionViewCell.swift
+++ b/Sources/MessageCollectionViewCell.swift
@@ -62,7 +62,7 @@ open class MessageCollectionViewCell<ContentView: UIView>: UICollectionViewCell 
 
     // MARK: - Initializer
 
-    override public init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
         setupSubviews()
         setupGestureRecognizers()
@@ -85,7 +85,7 @@ open class MessageCollectionViewCell<ContentView: UIView>: UICollectionViewCell 
 
     }
 
-    override open func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
+    open override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
         super.apply(layoutAttributes)
 
         guard let attributes = layoutAttributes as? MessagesCollectionViewLayoutAttributes else { return }
@@ -103,7 +103,7 @@ open class MessageCollectionViewCell<ContentView: UIView>: UICollectionViewCell 
 
     }
 
-    override open func prepareForReuse() {
+    open override func prepareForReuse() {
         cellTopLabel.text = nil
         cellTopLabel.attributedText = nil
         cellBottomLabel.text = nil

--- a/Sources/MessageInputBar.swift
+++ b/Sources/MessageInputBar.swift
@@ -125,7 +125,7 @@ open class MessageInputBar: UIView {
         }
     }
     
-    override open var intrinsicContentSize: CGSize {
+    open override var intrinsicContentSize: CGSize {
         let maxSize = CGSize(width: inputTextView.bounds.width, height: .greatestFiniteMagnitude)
         let sizeToFit = inputTextView.sizeThatFits(maxSize)
         var heightToFit = sizeToFit.height.rounded() + padding.top + padding.bottom

--- a/Sources/MessagesCollectionView.swift
+++ b/Sources/MessagesCollectionView.swift
@@ -48,7 +48,7 @@ open class MessagesCollectionView: UICollectionView {
 
     // MARK: - Initializers
 
-    override public init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
+    public override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
         super.init(frame: frame, collectionViewLayout: layout)
         backgroundColor = .white
     }

--- a/Sources/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/MessagesCollectionViewFlowLayout.swift
@@ -59,13 +59,13 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
         return collectionView.frame.width - sectionInset.left - sectionInset.right
     }
 
-    override open class var layoutAttributesClass: AnyClass {
+    open override class var layoutAttributesClass: AnyClass {
         return MessagesCollectionViewLayoutAttributes.self
     }
 
     // MARK: - Initializers
 
-    override public init() {
+    public override init() {
 
         messageLabelFont = UIFont.preferredFont(forTextStyle: .body)
         messageToViewEdgePadding = 30.0
@@ -86,7 +86,7 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
     // MARK: - Layout Attributes
 
-    override open func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+    open override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
 
         guard let attributesArray = super.layoutAttributesForElements(in: rect) as? [MessagesCollectionViewLayoutAttributes] else { return nil }
 
@@ -99,7 +99,7 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
         return attributesArray
     }
 
-    override open func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+    open override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
 
         guard let attributes = super.layoutAttributesForItem(at: indexPath) as? MessagesCollectionViewLayoutAttributes else { return nil }
 
@@ -147,7 +147,7 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
     // MARK: - Invalidation Context
 
-    override open func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+    open override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
 
         return collectionView?.bounds.width != newBounds.width || collectionView?.bounds.height != newBounds.height
 

--- a/Sources/MessagesViewController.swift
+++ b/Sources/MessagesViewController.swift
@@ -34,11 +34,11 @@ open class MessagesViewController: UIViewController {
 
     private var isFirstLayout: Bool = true
 
-    override open var canBecomeFirstResponder: Bool {
+    open override var canBecomeFirstResponder: Bool {
         return true
     }
 
-    override open var inputAccessoryView: UIView? {
+    open override var inputAccessoryView: UIView? {
         return messageInputBar
     }
 

--- a/Sources/PlayButtonView.swift
+++ b/Sources/PlayButtonView.swift
@@ -38,7 +38,7 @@ open class PlayButtonView: UIView {
         return CGSize(width: frame.width/2, height: frame.height/2)
     }
 
-    override open var frame: CGRect {
+    open override var frame: CGRect {
         didSet {
             updateTriangleConstraints()
             applyCornerRadius()
@@ -46,7 +46,7 @@ open class PlayButtonView: UIView {
         }
     }
 
-    override open var bounds: CGRect {
+    open override var bounds: CGRect {
         didSet {
             updateTriangleConstraints()
             applyCornerRadius()
@@ -56,7 +56,7 @@ open class PlayButtonView: UIView {
 
     // MARK: - Initializers
 
-    override public init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
 
         setupSubviews()

--- a/Sources/TextMessageCell.swift
+++ b/Sources/TextMessageCell.swift
@@ -28,7 +28,7 @@ open class TextMessageCell: MessageCollectionViewCell<MessageLabel> {
 
     // MARK: - Properties
 
-    override open weak var delegate: MessageCellDelegate? {
+    open override weak var delegate: MessageCellDelegate? {
         didSet {
             messageContentView.delegate = delegate
         }
@@ -42,7 +42,7 @@ open class TextMessageCell: MessageCollectionViewCell<MessageLabel> {
 
     // MARK: - Methods
 
-    override open func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
+    open override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
         super.apply(layoutAttributes)
 
         guard let attributes = layoutAttributes as? MessagesCollectionViewLayoutAttributes else { return }
@@ -50,13 +50,13 @@ open class TextMessageCell: MessageCollectionViewCell<MessageLabel> {
         messageContentView.font = attributes.messageLabelFont
     }
 
-    override open func prepareForReuse() {
+    open override func prepareForReuse() {
         super.prepareForReuse()
         messageContentView.attributedText = nil
         messageContentView.text = nil
     }
 
-    override public func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
+    public override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
         super.configure(with: message, at: indexPath, and: messagesCollectionView)
 
         if let displayDelegate = messagesCollectionView.messagesDisplayDelegate {


### PR DESCRIPTION
This pull request contains changes suggested in #195. Changes contain new swiflint rule in .swiftlint.yml file and warnings corrections according to the new rule.