### PR TITLE
Allow MessageLabelDelegate to specify enabled data detectors

### DIFF
--- a/Sources/MessageCollectionViewCell.swift
+++ b/Sources/MessageCollectionViewCell.swift
@@ -39,7 +39,7 @@ open class MessageCollectionViewCell<ContentView: UIView>: UICollectionViewCell 
 
     open var cellTopLabel: MessageLabel = {
         let topLabel = MessageLabel()
-        topLabel.enabledDetectors = []
+        topLabel.defaultEnabledDetectors = []
         return topLabel
     }()
 
@@ -52,7 +52,7 @@ open class MessageCollectionViewCell<ContentView: UIView>: UICollectionViewCell 
 
     open var cellBottomLabel: MessageLabel = {
         let bottomLabel = MessageLabel()
-        bottomLabel.enabledDetectors = []
+        bottomLabel.defaultEnabledDetectors = []
         return bottomLabel
     }()
 

--- a/Sources/MessageLabel.swift
+++ b/Sources/MessageLabel.swift
@@ -55,7 +55,7 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
 
     open weak var delegate: MessageLabelDelegate?
 
-    open var enabledDetectors: [DetectorType] = [.phoneNumber, .address, .date, .url]
+    open var defaultEnabledDetectors: [DetectorType] = [.phoneNumber, .address, .date, .url]
 
     open override var attributedText: NSAttributedString? {
         didSet {
@@ -243,6 +243,7 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
             return
         }
 
+        let enabledDetectors = delegate?.enabledDetectors() ?? defaultEnabledDetectors
         guard let checkingResults = parse(text: attributedText, for: enabledDetectors), checkingResults.isEmpty == false else {
             let textWithParagraphAttributes = addParagraphStyleAttribute(to: attributedText)
             textStorage.setAttributedString(textWithParagraphAttributes)

--- a/Sources/MessageLabelDelegate.swift
+++ b/Sources/MessageLabelDelegate.swift
@@ -25,7 +25,9 @@
 import Foundation
 
 public protocol MessageLabelDelegate: class {
-
+    // If nil, fallback to default detectors
+    func enabledDetectors() -> [DetectorType]?
+ 
     func didSelectAddress(_ addressComponents: [String: String])
 
     func didSelectDate(_ date: Date)
@@ -37,6 +39,8 @@ public protocol MessageLabelDelegate: class {
 }
 
 public extension MessageLabelDelegate {
+
+    func enabledDetectors() -> [DetectorType]? { return nil }
 
     func didSelectAddress(_ addressComponents: [String: String]) {}
 


### PR DESCRIPTION
In my use case, I don't want to show data detectors, and this change allows delegates to list what they want, or simply return nil to keep the default behavior