### PR TITLE
[WIP] [Fixed] iPhone X inputAccessoryView layout issue

### DIFF
--- a/Sources/MessageInputBar.swift
+++ b/Sources/MessageInputBar.swift
@@ -25,6 +25,17 @@
 import UIKit
 
 open class MessageInputBar: UIView {
+
+    // MARK: - iPhone X Layout Fix
+    // Could be fixed by Apple soon
+    // https://stackoverflow.com/questions/46282987/iphone-x-how-to-handle-view-controller-inputaccessoryview
+    open override func didMoveToWindow() {
+        if #available(iOS 11.0, *) {
+            if let window = window {
+                bottomAnchor.constraintLessThanOrEqualToSystemSpacingBelow(window.safeAreaLayoutGuide.bottomAnchor, multiplier: 1.0).isActive = true
+            }
+        }
+    }
     
     public enum UIStackViewPosition {
         case left, right, bottom

--- a/Sources/MessagesViewController.swift
+++ b/Sources/MessagesViewController.swift
@@ -116,11 +116,16 @@ open class MessagesViewController: UIViewController {
 
     private func setupConstraints() {
         messagesCollectionView.translatesAutoresizingMaskIntoConstraints = false
-
         let top = messagesCollectionView.topAnchor.constraint(equalTo: view.topAnchor, constant: topLayoutGuide.length)
         let leading = messagesCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor)
         let trailing = messagesCollectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        let bottom = messagesCollectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        var bottom = messagesCollectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+
+        // iPhone X workaround
+        if #available(iOS 11.0, *) {
+            view.backgroundColor = messageInputBar.backgroundColor
+            bottom = messagesCollectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        }
 
         NSLayoutConstraint.activate([top, bottom, trailing, leading])
     }


### PR DESCRIPTION
### TODO:
- [ ] CHANGELOG entry

Would solve #207

Not sure if this is expected behavior for inputAccessoryView. Looks like there is a radar here:
http://www.openradar.me/34411433

The view background color is set to the color of the `MessageInputBar`