### PR TITLE
[Added] additionalTopContentInset property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - `scrollsToBottomOnFirstLayout` property to automatically scroll to the bottom of `MessagesCollectionView` on first load.
 [#213](https://github.com/MessageKit/MessageKit/pull/213) by [@FraDeliro](https://github.com/FraDeliro).
 
+- `additionalTopContentInset` property to `MessagesColectionViewController` to allow users to account for extra subviews.
+[#218](https://github.com/MessageKit/MessageKit/pull/218) by [@SD10](https://github.com/SD10).
+
 ### Fixed
 
 -  `MessageInputBar` now correctly sizes itself when breaking its max height or pasting in large amounts of text

--- a/Sources/MessagesViewController.swift
+++ b/Sources/MessagesViewController.swift
@@ -34,6 +34,13 @@ open class MessagesViewController: UIViewController {
     
     open var scrollsToBottomOnFirstLayout: Bool = false
 
+    open var additionalTopContentInset: CGFloat = 0 {
+        didSet {
+            let inset = topLayoutGuide.length + additionalTopContentInset
+            messagesCollectionView.contentInset.top = inset
+        }
+    }
+
     private var isFirstLayout: Bool = true
 
     open override var canBecomeFirstResponder: Bool {
@@ -69,6 +76,7 @@ open class MessagesViewController: UIViewController {
         // Hack to prevent animation of the contentInset after viewDidAppear
         if isFirstLayout {
             addKeyboardObservers()
+            messagesCollectionView.contentInset.top = additionalTopContentInset + topLayoutGuide.length
             messagesCollectionView.contentInset.bottom = messageInputBar.frame.height
             messagesCollectionView.scrollIndicatorInsets.bottom = messageInputBar.frame.height
             isFirstLayout = false


### PR DESCRIPTION
Some background around this. I wanted to get away from managing the `top` inset of `MessagesCollectionView` to allow users to add subviews on top of the view and account for their size. However, this is the only way to support allowing the messages to scroll under a translucent nav bar. 

#117 