### PR TITLE
Simplify Cell/Header/Footer Class Registration

### DIFF
--- a/MessageKit.xcodeproj/project.pbxproj
+++ b/MessageKit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		171D5AB91F36712B0053DF69 /* InputTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171D5AB81F36712B0053DF69 /* InputTextView.swift */; };
+		2EB618EF1F8462CA007FBA0E /* UICollectionView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB618EE1F8462CA007FBA0E /* UICollectionView+Extensions.swift */; };
 		372F6AEB1F36C15600B57FBD /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372F6AEA1F36C15600B57FBD /* AvatarView.swift */; };
 		372F6AEF1F36C61000B57FBD /* AvatarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372F6AEE1F36C61000B57FBD /* AvatarViewTests.swift */; };
 		376AD1821F4258D80083072A /* TestMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376AD1811F4258D80083072A /* TestMessageModel.swift */; };
@@ -74,6 +75,7 @@
 
 /* Begin PBXFileReference section */
 		171D5AB81F36712B0053DF69 /* InputTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputTextView.swift; sourceTree = "<group>"; };
+		2EB618EE1F8462CA007FBA0E /* UICollectionView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Extensions.swift"; sourceTree = "<group>"; };
 		372F6AEA1F36C15600B57FBD /* AvatarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		372F6AEE1F36C61000B57FBD /* AvatarViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarViewTests.swift; sourceTree = "<group>"; };
 		376AD1811F4258D80083072A /* TestMessageModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMessageModel.swift; sourceTree = "<group>"; };
@@ -218,6 +220,7 @@
 			children = (
 				38C867991F50EA1000811974 /* UIView+Extensions.swift */,
 				B09643851F286C9E004D0129 /* String+Extensions.swift */,
+				2EB618EE1F8462CA007FBA0E /* UICollectionView+Extensions.swift */,
 				B096438F1F289142004D0129 /* UIColor+Extensions.swift */,
 				B0AA1F521F44388900BAE583 /* NSAttributedString+Extensions.swift */,
 				B0147C821F5BE9220035B36E /* Bundle+Extensions.swift */,
@@ -456,6 +459,7 @@
 				B09643861F286C9E004D0129 /* String+Extensions.swift in Sources */,
 				B015E81F1F259D8E007EDFB6 /* MessageInputBarDelegate.swift in Sources */,
 				B01280F31F4E8798004BCD3E /* MessageLabelDelegate.swift in Sources */,
+				2EB618EF1F8462CA007FBA0E /* UICollectionView+Extensions.swift in Sources */,
 				B0147C981F61AF930035B36E /* LabelAlignment.swift in Sources */,
 				376AD1881F4259D20083072A /* TestMessagesViewControllerModel.swift in Sources */,
 				B0655A2A1F23D77200542A83 /* Sender.swift in Sources */,

--- a/Sources/LocationMessageCell.swift
+++ b/Sources/LocationMessageCell.swift
@@ -26,6 +26,7 @@ import UIKit
 import MapKit
 
 open class LocationMessageCell: MessageCollectionViewCell<UIImageView> {
+	open override class func reuseIdentifier() -> String { return "messagekit.cell.location" }
 
     // MARK: - Properties
 

--- a/Sources/MediaMessageCell.swift
+++ b/Sources/MediaMessageCell.swift
@@ -25,6 +25,7 @@
 import UIKit
 
 open class MediaMessageCell: MessageCollectionViewCell<UIImageView> {
+	open override class func reuseIdentifier() -> String { return "messagekit.cell.mediamessage" }
 
     // MARK: - Properties
 

--- a/Sources/MessageCollectionViewCell.swift
+++ b/Sources/MessageCollectionViewCell.swift
@@ -24,7 +24,8 @@
 
 import UIKit
 
-open class MessageCollectionViewCell<ContentView: UIView>: UICollectionViewCell {
+open class MessageCollectionViewCell<ContentView: UIView>: UICollectionViewCell, CollectionViewReusable {
+	open class func reuseIdentifier() -> String { return "messagekit.cell.base-cell" }
 
     // MARK: - Properties
 

--- a/Sources/MessageDateHeaderView.swift
+++ b/Sources/MessageDateHeaderView.swift
@@ -25,6 +25,7 @@
 import UIKit
 
 open class MessageDateHeaderView: MessageHeaderView {
+	open override class func reuseIdentifier() -> String { return "messagekit.header.date" }
 
     // MARK: - Properties
 

--- a/Sources/MessageFooterView.swift
+++ b/Sources/MessageFooterView.swift
@@ -24,7 +24,8 @@
 
 import UIKit
 
-open class MessageFooterView: UICollectionReusableView {
+open class MessageFooterView: UICollectionReusableView, CollectionViewReusable {
+	open class func reuseIdentifier() -> String { return "messagekit.footer.base" }
 
     // MARK: - Initializers
 

--- a/Sources/MessageHeaderView.swift
+++ b/Sources/MessageHeaderView.swift
@@ -24,11 +24,10 @@
 
 import UIKit
 
-open class MessageHeaderView: UICollectionReusableView {
+open class MessageHeaderView: UICollectionReusableView, CollectionViewReusable {
+	open class func reuseIdentifier() -> String { return "messagekit.header.base" }
 
     // MARK: - Properties
-
-    static let identifier = "MessageHeaderView"
 
     public override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Sources/MessagesViewController.swift
+++ b/Sources/MessagesViewController.swift
@@ -107,26 +107,13 @@ open class MessagesViewController: UIViewController {
 
     private func registerReusableViews() {
 
-        messagesCollectionView.register(TextMessageCell.self,
-                                        forCellWithReuseIdentifier: "TextMessageCell")
+        messagesCollectionView.register(TextMessageCell.self)
+        messagesCollectionView.register(MediaMessageCell.self)
+        messagesCollectionView.register(LocationMessageCell.self)
 
-        messagesCollectionView.register(MediaMessageCell.self,
-                                        forCellWithReuseIdentifier: "MediaMessageCell")
-
-        messagesCollectionView.register(LocationMessageCell.self,
-                                        forCellWithReuseIdentifier: "LocationMessageCell")
-
-        messagesCollectionView.register(MessageFooterView.self,
-                                        forSupplementaryViewOfKind: UICollectionElementKindSectionFooter,
-                                        withReuseIdentifier: "MessageFooterView")
-
-        messagesCollectionView.register(MessageHeaderView.self,
-                                        forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
-                                        withReuseIdentifier: "MessageHeaderView")
-
-        messagesCollectionView.register(MessageDateHeaderView.self,
-                                        forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
-                                        withReuseIdentifier: "MessageDateHeaderView")
+        messagesCollectionView.register(MessageFooterView.self, forSupplementaryViewOfKind: UICollectionElementKindSectionFooter)
+        messagesCollectionView.register(MessageHeaderView.self, forSupplementaryViewOfKind: UICollectionElementKindSectionHeader)
+        messagesCollectionView.register(MessageDateHeaderView.self, forSupplementaryViewOfKind: UICollectionElementKindSectionHeader)
 
     }
 
@@ -186,21 +173,15 @@ extension MessagesViewController: UICollectionViewDataSource {
 
         switch message.data {
         case .text, .attributedText:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "TextMessageCell", for: indexPath) as? TextMessageCell else {
-                fatalError("Unable to dequeue TextMessageCell")
-            }
+            let cell = collectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         case .photo, .video:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MediaMessageCell", for: indexPath) as? MediaMessageCell else {
-                fatalError("Unable to dequeue MediaMessageCell")
-            }
+			let cell = collectionView.dequeueReusableCell(MediaMessageCell.self, for: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         case .location:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "LocationMessageCell", for: indexPath) as? LocationMessageCell else {
-                fatalError("Unable to dequeue LocationMessageCell")
-            }
+			let cell = collectionView.dequeueReusableCell(LocationMessageCell.self, for: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         }

--- a/Sources/TextMessageCell.swift
+++ b/Sources/TextMessageCell.swift
@@ -25,6 +25,7 @@
 import UIKit
 
 open class TextMessageCell: MessageCollectionViewCell<MessageLabel> {
+	open override class func reuseIdentifier() -> String { return "messagekit.cell.text" }
 
     // MARK: - Properties
 

--- a/Sources/UICollectionView+Extensions.swift
+++ b/Sources/UICollectionView+Extensions.swift
@@ -1,0 +1,36 @@
+//
+//  UICollectionView+Extensions.swift
+//  MessageKit
+//
+//  Created by Frederic Barthelemy on 10/3/17.
+//  Copyright © 2017 MessageKit. All rights reserved.
+//
+
+import Foundation
+
+/// Optional Cell Protocol to Simplify registration/cell type loading in a generic way
+protocol CollectionViewReusable: class {
+	static func reuseIdentifier() -> String
+}
+
+extension UICollectionView {
+	/// Registers a particular cell using its reuse-identifier
+	func register<CellType: UICollectionViewCell & CollectionViewReusable>(_ cellClass: CellType.Type) {
+		register(cellClass, forCellWithReuseIdentifier: CellType.reuseIdentifier())
+	}
+
+	/// Registers a reusable view for a specific SectionKind
+	func register<ViewType: UICollectionReusableView & CollectionViewReusable>(_ headerFooterClass: ViewType.Type, forSupplementaryViewOfKind kind: String) {
+		register(headerFooterClass,
+		         forSupplementaryViewOfKind: kind,
+		         withReuseIdentifier: ViewType.reuseIdentifier())
+	}
+
+	/// Generically dequeues a cell of the correct type allowing you to avoid scattering your code with guard-let-else-fatal
+	func dequeueReusableCell<CellType: UICollectionViewCell & CollectionViewReusable>(_ cellClass: CellType.Type, for indexPath: IndexPath) -> CellType {
+		guard let cell = dequeueReusableCell(withReuseIdentifier: cellClass.reuseIdentifier(), for: indexPath) as? CellType else {
+			fatalError("Unable to dequeue \(String(describing: cellClass)) with reuseId of \(cellClass.reuseIdentifier())")
+		}
+		return cell
+	}
+}


### PR DESCRIPTION
- Adds an optional protocol & UICollectionView extension for registering cells/headers/footers
- Also simplify / remove boilerplate from dequeueing reusable cells, in a generic, typesafe-way.

Future Exercises:
- Clean up header/footer dequeuing to fit into this generic style.