### PR TITLE
Update header/footer dequeueing for new reuseIdentifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - `additionalTopContentInset` property to `MessagesColectionViewController` to allow users to account for extra subviews.
 [#218](https://github.com/MessageKit/MessageKit/pull/218) by [@SD10](https://github.com/SD10).
 
-
 ### Fixed
 
 -  `MessageInputBar` now correctly sizes itself when breaking its max height or pasting in large amounts of text
@@ -64,6 +63,13 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - **Breaking Change** `InputTextView`'s `UITextViewDelegate` is now set to `self`
 [#173](https://github.com/MessageKit/MessageKit/pull/173) by [@nathantannar4](https://github.com/nathantannar4).
+
+- **Breaking Change** `MessagesDisplayDelegate` `messageHeaderView(for:at:in)` and `messageFooterView(for:at:in)` to return non-optionals.
+[#229](https://github.com/MessageKit/MessageKit/pull/229) by [@SD10](https://github.com/SD10).
+
+- **Breaking Change** `MessagesCollectionView` `dequeueMessageHeaderView(withIdentifier:for:)` & `dequeueMessageFooterView(widthIdentifier:for:)`
+have been renamed to `dequeueReusableHeaderView(CollectionViewReusable.Type,for:)` & `dequeueReusableFooterView(CollectionViewReusable.Type,for:)`.
+[#229](https://github.com/MessageKit/MessageKit/pull/229) by [@SD10](https://github.com/SD10).
 
 - `configure` method of all `MessageCollectionViewCell` types to be marked as `open`.
 [#200](https://github.com/MessageKit/MessageKit/pull/200) by [@SD10](https://github.com/sd10).

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -235,10 +235,6 @@ extension ConversationViewController: MessagesDisplayDelegate {
 //        return .custom(configurationClosure)
     }
 
-    func messageFooterView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageFooterView? {
-        return messagesCollectionView.dequeueMessageFooterView(for: indexPath)
-    }
-
 }
 
 // MARK: - MessagesLayoutDelegate

--- a/Sources/MessageKit+Availability.swift
+++ b/Sources/MessageKit+Availability.swift
@@ -38,6 +38,16 @@ public extension MessagesCollectionView {
         return nil
     }
 
+    @available(*, deprecated: 0.9.0, message: "Removed in MessageKit 0.9.0. Please use dequeueReusableHeaderView")
+    public func dequeueMessageHeaderView(withReuseIdentifier identifier: String = "MessageHeaderView", for indexPath: IndexPath) -> MessageHeaderView {
+        return dequeueReusableHeaderView(MessageHeaderView.self, for: indexPath)
+    }
+
+    @available(*, deprecated: 0.9.0, message: "Removed in MessageKit 0.9.0. Please use dequeueReusableFooterView")
+    public func dequeueMessageFooterView(withReuseIdentifier identifier: String = "MessageFooterView", for indexPath: IndexPath) -> MessageFooterView {
+        return dequeueReusableFooterView(MessageFooterView.self, for: indexPath)
+    }
+
 }
 
 // MARK: - MessagesCollectionViewFlowLayout

--- a/Sources/MessagesCollectionView.swift
+++ b/Sources/MessagesCollectionView.swift
@@ -64,14 +64,4 @@ open class MessagesCollectionView: UICollectionView {
         scrollToItem(at: indexPath, at: .bottom, animated: animated)
     }
 
-    open func dequeueMessageHeaderView(withReuseIdentifier identifier: String = "MessageHeaderView", for indexPath: IndexPath) -> MessageHeaderView {
-        let header = dequeueReusableSupplementaryView(ofKind: UICollectionElementKindSectionHeader, withReuseIdentifier: identifier, for: indexPath)
-        return header as? MessageHeaderView ?? MessageHeaderView()
-    }
-
-    open func dequeueMessageFooterView(withReuseIdentifier identifier: String = "MessageFooterView", for indexPath: IndexPath) -> MessageFooterView {
-        let footer = dequeueReusableSupplementaryView(ofKind: UICollectionElementKindSectionFooter, withReuseIdentifier: identifier, for: indexPath)
-        return footer as? MessageFooterView ?? MessageFooterView()
-    }
-
 }

--- a/Sources/MessagesDisplayDelegate.swift
+++ b/Sources/MessagesDisplayDelegate.swift
@@ -32,11 +32,11 @@ public protocol MessagesDisplayDelegate: class {
     
     func backgroundColor(for message: MessageType, at  indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor
     
-    func messageHeaderView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageHeaderView?
+    func messageHeaderView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageHeaderView
 
     func shouldDisplayHeader(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> Bool
     
-    func messageFooterView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageFooterView?
+    func messageFooterView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageFooterView
 
 }
 
@@ -56,9 +56,9 @@ public extension MessagesDisplayDelegate {
         return dataSource.isFromCurrentSender(message: message) ? .outgoingGreen : .incomingGray
     }
     
-    func messageHeaderView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageHeaderView? {
-        let header = messagesCollectionView.dequeueMessageHeaderView(withReuseIdentifier: "MessageDateHeaderView", for: indexPath) as? MessageDateHeaderView
-        header?.dateLabel.text = MessageKitDateFormatter.shared.string(from: message.sentDate)
+    func messageHeaderView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageHeaderView {
+        let header = messagesCollectionView.dequeueReusableHeaderView(MessageDateHeaderView.self, for: indexPath)
+        header.dateLabel.text = MessageKitDateFormatter.shared.string(from: message.sentDate)
         return header
     }
 
@@ -72,8 +72,8 @@ public extension MessagesDisplayDelegate {
         return timeIntervalSinceLastMessage >= messagesCollectionView.showsDateHeaderAfterTimeInterval
     }
 
-    func messageFooterView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageFooterView? {
-        return nil
+    func messageFooterView(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageFooterView {
+        return messagesCollectionView.dequeueReusableFooterView(MessageFooterView.self, for: indexPath)
     }
 
 }

--- a/Sources/MessagesViewController.swift
+++ b/Sources/MessagesViewController.swift
@@ -172,15 +172,15 @@ extension MessagesViewController: UICollectionViewDataSource {
 
         switch message.data {
         case .text, .attributedText:
-            let cell = collectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
+            let cell = messagesCollectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         case .photo, .video:
-    	    let cell = collectionView.dequeueReusableCell(MediaMessageCell.self, for: indexPath)
+    	    let cell = messagesCollectionView.dequeueReusableCell(MediaMessageCell.self, for: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         case .location:
-    	    let cell = collectionView.dequeueReusableCell(LocationMessageCell.self, for: indexPath)
+    	    let cell = messagesCollectionView.dequeueReusableCell(LocationMessageCell.self, for: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         }
@@ -197,9 +197,9 @@ extension MessagesViewController: UICollectionViewDataSource {
 
         switch kind {
         case UICollectionElementKindSectionHeader:
-            return displayDelegate.messageHeaderView(for: message, at: indexPath, in: messagesCollectionView) ?? MessageHeaderView()
+            return displayDelegate.messageHeaderView(for: message, at: indexPath, in: messagesCollectionView)
         case UICollectionElementKindSectionFooter:
-            return displayDelegate.messageFooterView(for: message, at: indexPath, in: messagesCollectionView) ?? MessageFooterView()
+            return displayDelegate.messageFooterView(for: message, at: indexPath, in: messagesCollectionView)
         default:
             fatalError("Unrecognized element of kind: \(kind)")
         }

--- a/Sources/UICollectionView+Extensions.swift
+++ b/Sources/UICollectionView+Extensions.swift
@@ -1,19 +1,35 @@
-//
-//  UICollectionView+Extensions.swift
-//  MessageKit
-//
-//  Created by Frederic Barthelemy on 10/3/17.
-//  Copyright © 2017 MessageKit. All rights reserved.
-//
+/*
+ MIT License
+
+ Copyright (c) 2017 MessageKit
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
 
 import Foundation
 
 /// Optional Cell Protocol to Simplify registration/cell type loading in a generic way
-protocol CollectionViewReusable: class {
+public protocol CollectionViewReusable: class {
     static func reuseIdentifier() -> String
 }
 
-extension UICollectionView {
+public extension MessagesCollectionView {
     /// Registers a particular cell using its reuse-identifier
     func register<CellType: UICollectionViewCell & CollectionViewReusable>(_ cellClass: CellType.Type) {
 	    register(cellClass, forCellWithReuseIdentifier: CellType.reuseIdentifier())
@@ -32,5 +48,23 @@ extension UICollectionView {
     	    fatalError("Unable to dequeue \(String(describing: cellClass)) with reuseId of \(cellClass.reuseIdentifier())")
 	    }
 	    return cell
+    }
+
+    /// Generically dequeues a header of the correct type allowing you to avoid scattering your code with guard-let-else-fatal
+    func dequeueReusableHeaderView<ViewType: UICollectionReusableView & CollectionViewReusable>(_ viewClass: ViewType.Type, for indexPath: IndexPath) -> ViewType {
+        let view = dequeueReusableSupplementaryView(ofKind: UICollectionElementKindSectionHeader, withReuseIdentifier: viewClass.reuseIdentifier(), for: indexPath)
+        guard let viewType = view as? ViewType else {
+            fatalError("Unable to dequeue \(String(describing: viewClass)) with reuseId of \(viewClass.reuseIdentifier())")
+        }
+        return viewType
+    }
+
+    /// Generically dequeues a footer of the correct type allowing you to avoid scattering your code with guard-let-else-fatal
+    func dequeueReusableFooterView<ViewType: UICollectionReusableView & CollectionViewReusable>(_ viewClass: ViewType.Type, for indexPath: IndexPath) -> ViewType {
+        let view = dequeueReusableSupplementaryView(ofKind: UICollectionElementKindSectionFooter, withReuseIdentifier: viewClass.reuseIdentifier(), for: indexPath)
+        guard let viewType = view as? ViewType else {
+            fatalError("Unable to dequeue \(String(describing: viewClass)) with reuseId of \(viewClass.reuseIdentifier())")
+        }
+        return viewType
     }
 }


### PR DESCRIPTION
- Deprecates the old header/footer dequeuing methods
- Changes the delegate methods to return non-optionals
- Moves extensions for `UICollectionView` -> `MessagesCollectionView`

### TODO:
- [x] Requires CHANGELOG entry