### PR TITLE
[Added] TextMessageDisplayDelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - **Breaking Change** `.emoji(String)` case to `MessageData` enum. 
 [#222](https://github.com/MessageKit/MessageKit/pull/222) by [@SirArkimdes](https://github.com/SirArkimedes).
 
+- **Breaking Change** `TextMessageDisplayDelegate` to handle `enabledDetecors(for:at:in)` and moves `textColor(for:at:in)` to this namespace.
+[#230](https://github.com/MessageKit/MessageKit/pull/230) by [@SD10](https://github.com/sd10)
+
 - `LocationMessageDisplayDelegate` to customize a location messages appearance and add a `MKAnnotationView` to location message snapshots. 
 [#150](https://github.com/MessageKit/MessageKit/pull/150) by [@etoledom](https://github.com/etoledom).
 

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -28,7 +28,7 @@ open class MessagesViewController: UIViewController {
 
     // MARK: - Properties
 
-    open var messagesCollectionView = MessagesCollectionView(frame: .zero, collectionViewLayout: MessagesCollectionViewFlowLayout())
+    open var messagesCollectionView = MessagesCollectionView()
 
     open var messageInputBar = MessageInputBar()
     
@@ -165,8 +165,13 @@ extension MessagesViewController: UICollectionViewDataSource {
 
     open func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
 
-        guard let messagesCollectionView = collectionView as? MessagesCollectionView else { return UICollectionViewCell() }
-        guard let messagesDataSource = messagesCollectionView.messagesDataSource else { fatalError("Please set messagesDataSource") }
+        guard let messagesCollectionView = collectionView as? MessagesCollectionView else {
+            fatalError("Managed collectionView: \(collectionView.debugDescription) is not a MessagesCollectionView.")
+        }
+
+        guard let messagesDataSource = messagesCollectionView.messagesDataSource else {
+            fatalError("MessagesDataSource has not been set.")
+        }
 
         let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
 
@@ -189,9 +194,17 @@ extension MessagesViewController: UICollectionViewDataSource {
 
     open func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
 
-        guard let messagesCollectionView = collectionView as? MessagesCollectionView else { return UICollectionReusableView() }
-        guard let dataSource = messagesCollectionView.messagesDataSource else { return UICollectionReusableView() }
-        guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else { return UICollectionReusableView() }
+        guard let messagesCollectionView = collectionView as? MessagesCollectionView else {
+            fatalError("Managed collectionView: \(collectionView.debugDescription) is not a MessagesCollectionView.")
+        }
+
+        guard let dataSource = messagesCollectionView.messagesDataSource else {
+            fatalError("MessagesDataSource has not been set.")
+        }
+
+        guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {
+            fatalError("MessagesDisplayDelegate has not been set.")
+        }
 
         let message = dataSource.messageForItem(at: indexPath, in: messagesCollectionView)
 

--- a/Sources/Protocols/MessagesDisplayDelegate.swift
+++ b/Sources/Protocols/MessagesDisplayDelegate.swift
@@ -24,9 +24,28 @@
 
 import Foundation
 
-public protocol MessagesDisplayDelegate: class {
-    
+public protocol TextMessageDisplayDelegate: class {
+
     func textColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor
+
+    func enabledDetectors(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> [DetectorType]
+
+}
+
+public extension TextMessageDisplayDelegate {
+
+    func textColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
+        guard let dataSource = messagesCollectionView.messagesDataSource else { return .darkText }
+        return dataSource.isFromCurrentSender(message: message) ? .white : .darkText
+    }
+
+    func enabledDetectors(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> [DetectorType] {
+        return [.url, .address, .phoneNumber, .date]
+    }
+
+}
+
+public protocol MessagesDisplayDelegate: class {
 
     func messageStyle(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageStyle
     
@@ -41,12 +60,7 @@ public protocol MessagesDisplayDelegate: class {
 }
 
 public extension MessagesDisplayDelegate {
-    
-    func textColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
-        guard let dataSource = messagesCollectionView.messagesDataSource else { return .darkText }
-        return dataSource.isFromCurrentSender(message: message) ? .white : .darkText
-    }
-    
+
     func messageStyle(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageStyle {
         return .bubble
     }

--- a/Sources/Views/Cells/TextMessageCell.swift
+++ b/Sources/Views/Cells/TextMessageCell.swift
@@ -60,9 +60,11 @@ open class TextMessageCell: MessageCollectionViewCell<MessageLabel> {
     open override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
         super.configure(with: message, at: indexPath, and: messagesCollectionView)
 
-        if let displayDelegate = messagesCollectionView.messagesDisplayDelegate {
+        if let displayDelegate = messagesCollectionView.messagesDisplayDelegate as? TextMessageDisplayDelegate {
             let textColor = displayDelegate.textColor(for: message, at: indexPath, in: messagesCollectionView)
+            let detectors = displayDelegate.enabledDetectors(for: message, at: indexPath, in: messagesCollectionView)
             messageContentView.textColor = textColor
+            messageContentView.enabledDetectors = detectors
         }
 
         switch message.data {

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -57,6 +57,10 @@ open class MessagesCollectionView: UICollectionView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    public convenience init() {
+        self.init(frame: .zero, collectionViewLayout: MessagesCollectionViewFlowLayout())
+    }
+
     // MARK: - Methods
 
     public func scrollToBottom(animated: Bool = false) {


### PR DESCRIPTION
### TODO:
- [x] CHANGELOG entry

This adds `TextMessageDisplayDelegate` and moves `textColor(for:at:in)` to that namespace. It also adds `enabledDetectors(for:at:in)` to set detector types on messages dynamically.

Related to #197 

cc @hyouuu