### PR TITLE
Fix #221 scroll to bottom is not working in sample app

### DIFF
--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -367,6 +367,7 @@ extension ConversationViewController: MessageInputBarDelegate {
         messageList.append(MockMessage(text: text, sender: currentSender(), messageId: UUID().uuidString, date: Date()))
         inputBar.inputTextView.text = String()
         messagesCollectionView.reloadData()
+        messagesCollectionView.scrollToBottom()
     }
 
 }


### PR DESCRIPTION
The pull request contains a fix for the issue mentioned in #221. The sample app did not call **scrollToBottom**() method after calling sending action. So by default, it is not going to latest message. 