### PR TITLE
[Example] Fix warning from thread access on reload

### DIFF
--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -30,7 +30,9 @@ class ConversationViewController: MessagesViewController {
 
     var messageList: [MockMessage] = [] {
         didSet {
-            messagesCollectionView.reloadData()
+            DispatchQueue.main.async {
+                self.messagesCollectionView.reloadData()
+            }
         }
     }
 


### PR DESCRIPTION
Xcode 9 likes to spam console when the UI elements aren’t accessed on the main thread. This fixes one of those warnings.