### PR TITLE
Fix MediaMessageCell’s off center play button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - `scrollIndicatorInsets` to match the insets of the `MessagesCollectionView`.
 [#174](https://github.com/MessageKit/MessageKit/pull/174) by [@etoledom](https://github.com/etoledom).
 
+- `MediaMessageCell` had an offset `PlayButtonView` that was being constrained to the cell and not the message container.
+[#239](https://github.com/MessageKit/MessageKit/pull/239) by [@SirArkimedes](https://github.com/SirArkimedes).
+
 ### Changed
 
 - **Breaking Change** `snapshotOptionsForLocation` method is now part of `LocationMessageDisplayDelegate`. 

--- a/Sources/Views/Cells/MediaMessageCell.swift
+++ b/Sources/Views/Cells/MediaMessageCell.swift
@@ -40,8 +40,8 @@ open class MediaMessageCell: MessageCollectionViewCell<UIImageView> {
     private func setupConstraints() {
         playButtonView.translatesAutoresizingMaskIntoConstraints = false
 
-        let centerX = playButtonView.centerXAnchor.constraint(equalTo: centerXAnchor)
-        let centerY = playButtonView.centerYAnchor.constraint(equalTo: centerYAnchor)
+        let centerX = playButtonView.centerXAnchor.constraint(equalTo: messageContainerView.centerXAnchor)
+        let centerY = playButtonView.centerYAnchor.constraint(equalTo: messageContainerView.centerYAnchor)
         let width = playButtonView.widthAnchor.constraint(equalToConstant: playButtonView.bounds.width)
         let height = playButtonView.heightAnchor.constraint(equalToConstant: playButtonView.bounds.height)
 


### PR DESCRIPTION
Move the MediaMessageCell’s play button back to where it belongs.

Issue: #238