### PR TITLE
Fixing input bar on iPhone X

### DIFF
--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -80,10 +80,16 @@ open class MessagesViewController: UIViewController {
             defer { isFirstLayout = false }
 
             addKeyboardObservers()
-            messagesCollectionView.contentInset.top = additionalTopContentInset + topLayoutGuide.length
-            messagesCollectionView.contentInset.bottom = messageInputBar.frame.height
-            messagesCollectionView.scrollIndicatorInsets.bottom = messageInputBar.frame.height
             
+            if #available(iOS 11.0, *) {
+                messagesCollectionView.contentInset.top = additionalTopContentInset
+            } else {
+                messagesCollectionView.contentInset.top = additionalTopContentInset + topLayoutGuide.length
+            }
+            let bottomInset = messageInputBar.frame.height - bottomLayoutGuide.length
+            messagesCollectionView.contentInset.bottom = bottomInset
+            messagesCollectionView.scrollIndicatorInsets.bottom = bottomInset
+
             //Scroll to bottom at first load
             if scrollsToBottomOnFirstLayout {
                 messagesCollectionView.scrollToBottom(animated: false)
@@ -273,7 +279,7 @@ extension MessagesViewController {
 
         } else {
             //Software keyboard is found
-            let bottomInset = keyboardEndFrame.height > messageInputBar.frame.height ? keyboardEndFrame.height : messageInputBar.frame.height
+            let bottomInset = keyboardEndFrame.height > messageInputBar.frame.height ? keyboardEndFrame.height - bottomLayoutGuide.length : messageInputBar.frame.height - bottomLayoutGuide.length
             messagesCollectionView.contentInset.bottom = bottomInset
             messagesCollectionView.scrollIndicatorInsets.bottom = bottomInset
         }

--- a/Sources/Views/MessageInputBar.swift
+++ b/Sources/Views/MessageInputBar.swift
@@ -277,7 +277,7 @@ open class MessageInputBar: UIView {
         
         bottomStackViewLayoutSet = NSLayoutConstraintSet(
             top:    bottomStackView.topAnchor.constraint(equalTo: inputTextView.bottomAnchor),
-            bottom: bottomStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -padding.bottom),
+            bottom: bottomStackView.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor, constant: -padding.bottom),
             left:   bottomStackView.leftAnchor.constraint(equalTo: leftAnchor, constant: padding.left),
             right:  bottomStackView.rightAnchor.constraint(equalTo: rightAnchor, constant: -padding.right)
             ).activate()

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -65,7 +65,7 @@ open class MessagesCollectionView: UICollectionView {
 
     public func scrollToBottom(animated: Bool = false) {
         guard let indexPath = indexPathForLastItem else { return }
-        scrollToItem(at: indexPath, at: .bottom, animated: animated)
+        scrollToItem(at: indexPath, at: .centeredVertically, animated: animated)
     }
 
 }


### PR DESCRIPTION
Making `bottomStackView.bottomAnchor.constraint` equal to `layoutMarginsGuide.bottomAnchor` on  `MessageInputBar.swift`makes the input bar to increase its height on iPhone X to cover the extra bottom space. This breaks the current messagesCollectionView's bottom inset management, so some extra calculations on the bottom inset were added to take into account this extra input bar height.

Also, I noticed that `messagesCollectionView.contentInset.top = additionalTopContentInset + topLayoutGuide.length` was creating an extra top inset on iOS 11, while It was necessary on iOS 10, so a OS version check was added to take into account this difference. I'm not sure If it is the best way to fix this issue.

I tested on iPhone 5S with iOS 10, iPhone 7 with iOS 11 and iPhone X from simulator.
All top and bottom insets where working properly with and without keyboard.

I had no chance to test with a hardware keyboard so it might no work properly with the iPhone X 