### PR TITLE
Fix test failure after TextMessageDisplayDelegate refactoring

### DIFF
--- a/Tests/Support Files/TestMessagesViewControllerModel.swift
+++ b/Tests/Support Files/TestMessagesViewControllerModel.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-class TestMessagesViewControllerModel: MessagesViewController, MessagesDisplayDelegate {
+class TestMessagesViewControllerModel: MessagesViewController, MessagesDisplayDelegate, TextMessageDisplayDelegate {
     
     var messageList: [TestMessage] = []
     


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request fixes the test case failure after TextMessageDisplayDelegate refactoring done in the code. After this change **textColor** property has been moved to this delegate method which is causing the test to fail. So while accessing this property from TestMessagesViewControllerModel, it is not able to find as it is moved to TextMessageDisplayDelegate.

Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
NIL

Any other comments?
-------------------
NIL

Where has this been tested?
---------------------------
**Devices/Simulators:** Simulators

**iOS Version:** 11

**Swift Version:** 4

**MessageKit Version:** 0.9.0


