### PR TITLE
Adding test case for textColor when dataSource is nil

### DIFF
--- a/Tests/MessagesDisplayDataSourceTests.swift
+++ b/Tests/MessagesDisplayDataSourceTests.swift
@@ -56,6 +56,12 @@ class MessagesDisplayDelegateTests: XCTestCase {
         XCTAssertEqual(testClass.textColor(for: testClass.messageList[0], at: IndexPath(item: 0, section: 0), in: testClass.messagesCollectionView), UIColor.white)
         XCTAssertEqual(testClass.textColor(for: testClass.messageList[1], at: IndexPath(item: 1, section: 0), in: testClass.messagesCollectionView), UIColor.darkText)
     }
+  
+    func testMessageTextColorWhenDataSourceIsNil() {
+        testClass.messagesCollectionView.messagesDataSource = nil
+        XCTAssertEqual(testClass.textColor(for: testClass.messageList[0], at: IndexPath(item: 0, section: 0), in: testClass.messagesCollectionView), UIColor.darkText)
+        XCTAssertEqual(testClass.textColor(for: testClass.messageList[1], at: IndexPath(item: 1, section: 0), in: testClass.messagesCollectionView), UIColor.darkText)
+    }
     
     func testBackGroundColorDefaultState() {
         XCTAssertEqual(testClass.backgroundColor(for: testClass.messageList[0], at:  IndexPath(item: 0, section: 0), in: testClass.messagesCollectionView), UIColor.outgoingGreen)


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request contains new test case for message text color when messagesDataSource is set to nil. As per the code, text color remains dark regardless of the message from sender or recipient.

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
Nil

Where has this been tested?
---------------------------
**Devices/Simulators:** Simulators

**iOS Version:** iOS 11

**Swift Version:** 4

**MessageKit Version:** v0.9.0


