### PR TITLE
Fixes #243 by deprecating addiontalTopContentInset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 
+### Removed
+
+- **Breaking Change** Removed `additionalTopContentInset` property of `MessagesViewController` because this is no longer necessary
+when `extendedLayoutIncludesOpaqueBars` is `true`.
+[#250](https://github.com/MessageKit/MessageKit/pull/250) by [@SD10](https://github.com/SD10).
+
 ## [[Prerelease] 0.9.0](https://github.com/MessageKit/MessageKit/releases/tag/0.9.0)
 
 ### Added

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MessageKit (0.8.2)
+  - MessageKit (0.9.0)
 
 DEPENDENCIES:
   - MessageKit (from `../MessageKit.podspec`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../MessageKit.podspec
 
 SPEC CHECKSUMS:
-  MessageKit: 8b66f40a259d731a4570db967410c7966c2e7c8a
+  MessageKit: b9f9b15e7994a9a81515d364a0c03cf86c62de7e
 
 PODFILE CHECKSUM: 9ac65b8dedf0e1b63fea245b089b6645c4e66309
 

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -38,7 +38,11 @@ class ConversationViewController: MessagesViewController {
         super.viewDidLoad()
 
         DispatchQueue.global(qos: .userInitiated).async {
-            self.messageList = SampleData.shared.getMessages(count: 100)
+            SampleData.shared.getMessages(count: 100) { messages in
+                DispatchQueue.main.async {
+                    self.messageList = messages
+                }
+            }
         }
 
         messagesCollectionView.messagesDataSource = self

--- a/Example/Sources/SampleData.swift
+++ b/Example/Sources/SampleData.swift
@@ -174,12 +174,12 @@ final class SampleData {
         }
     }
 
-    func getMessages(count: Int) -> [MockMessage] {
+    func getMessages(count: Int, completion: ([MockMessage]) -> Void) {
         var messages: [MockMessage] = []
         for _ in 0...count {
             messages.append(randomMessage())
         }
-        return messages
+        completion(messages)
     }
 
     func getAvatarFor(sender: Sender) -> Avatar {

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -36,13 +36,6 @@ open class MessagesViewController: UIViewController {
 
     open var scrollsToBottomOnKeybordBeginsEditing: Bool = false
 
-    open var additionalTopContentInset: CGFloat = 0 {
-        didSet {
-            let inset = topLayoutGuide.length + additionalTopContentInset
-            messagesCollectionView.contentInset.top = inset
-        }
-    }
-
     private var isFirstLayout: Bool = true
 
     open override var canBecomeFirstResponder: Bool {
@@ -80,7 +73,6 @@ open class MessagesViewController: UIViewController {
             defer { isFirstLayout = false }
 
             addKeyboardObservers()
-            messagesCollectionView.contentInset.top = additionalTopContentInset + topLayoutGuide.length
             messagesCollectionView.contentInset.bottom = messageInputBar.frame.height
             messagesCollectionView.scrollIndicatorInsets.bottom = messageInputBar.frame.height
             

--- a/Sources/Supporting/MessageKit+Availability.swift
+++ b/Sources/Supporting/MessageKit+Availability.swift
@@ -24,6 +24,22 @@
 
 import Foundation
 
+// MARK: - MessagesViewController
+
+public extension MessagesViewController {
+
+    @available(*, deprecated: 0.10.0, message: "Removed in MessageKit 0.10.0. Please use the messagesCollectionView.contentInsets.top property.")
+    public var additionalTopContentInset: CGFloat {
+        get {
+            return messagesCollectionView.contentInset.top
+        }
+        set {
+            messagesCollectionView.contentInset.top = newValue
+        }
+    }
+
+}
+
 // MARK: - MessagesDisplayDataSource
 
 @available(*, deprecated: 0.7.0, message: "Removed in MessageKit 0.7.0. Please use MessagesDisplayDelegate.")


### PR DESCRIPTION
### TODO: 
- [x] CHANGELOG entry

This should fix #243 where the `contentInset.top` is set incorrectly for the `MessagesCollectionView`.
It looks like just setting `extendedTopLayoutIncludesOpaqueBars` is all that is necessary. By merging the two PRs in the wrong order I missed this.

cc @cwalo, hope I'm not going crazy 😅 
