### PR TITLE
Adding transactional message cell

### DIFF
--- a/Tests/MessagesDisplayDataSourceTests.swift
+++ b/Tests/MessagesDisplayDataSourceTests.swift
@@ -56,6 +56,12 @@ class MessagesDisplayDelegateTests: XCTestCase {
         XCTAssertEqual(testClass.textColor(for: testClass.messageList[0], at: IndexPath(item: 0, section: 0), in: testClass.messagesCollectionView), UIColor.white)
         XCTAssertEqual(testClass.textColor(for: testClass.messageList[1], at: IndexPath(item: 1, section: 0), in: testClass.messagesCollectionView), UIColor.darkText)
     }
+  
+    func testMessageTextColorWhenDataSourceIsNil() {
+        testClass.messagesCollectionView.messagesDataSource = nil
+        XCTAssertEqual(testClass.textColor(for: testClass.messageList[0], at: IndexPath(item: 0, section: 0), in: testClass.messagesCollectionView), UIColor.darkText)
+        XCTAssertEqual(testClass.textColor(for: testClass.messageList[1], at: IndexPath(item: 1, section: 0), in: testClass.messagesCollectionView), UIColor.darkText)
+    }
     
     func testBackGroundColorDefaultState() {
         XCTAssertEqual(testClass.backgroundColor(for: testClass.messageList[0], at:  IndexPath(item: 0, section: 0), in: testClass.messagesCollectionView), UIColor.outgoingGreen)

--- a/Tests/Support Files/TestMessagesViewControllerModel.swift
+++ b/Tests/Support Files/TestMessagesViewControllerModel.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-class TestMessagesViewControllerModel: MessagesViewController, MessagesDisplayDelegate {
+class TestMessagesViewControllerModel: MessagesViewController, MessagesDisplayDelegate, TextMessageDisplayDelegate {
     
     var messageList: [TestMessage] = []
     


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

I believe that a transactional message cell would be useful to support scenarios like bot integrations or commercial conversations: sellers/bots propose a multi-options menu to chose from either to drive end user or to finalize a sell.
It could be a cell containing just an image and a button (selling an item), a carousel of images with associated buttons or just buttons for predetermined actions.

Does this close any currently open issues?
------------------------------------------
no

Any relevant logs, error output, etc?
-------------------------------------

/
Any other comments?
-------------------
no
Where has this been tested?
---------------------------
 /


