### PR TITLE
Bug Fix for issue #260

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 
+### Changed
+
+-  Fixed a bug that prevented the `textAllignment` property of `InputTextView`'s `placeholderLabel` from having noticable differences when changed to `.center` or `.right`
+[#262](https://github.com/MessageKit/MessageKit/pull/262) by [@nathantannar4](https://github.com/nathantannar4).
+
 ### Removed
 
 - **Breaking Change** Removed `additionalTopContentInset` property of `MessagesViewController` because this is no longer necessary

--- a/Sources/Views/InputTextView.swift
+++ b/Sources/Views/InputTextView.swift
@@ -24,7 +24,7 @@
 
 import UIKit
 
-open class InputTextView: UITextView, UITextViewDelegate {
+open class InputTextView: UITextView {
 
     // MARK: - Properties
 
@@ -70,7 +70,7 @@ open class InputTextView: UITextView, UITextViewDelegate {
         }
     }
 
-    open var placeholderLabelInsets: UIEdgeInsets = UIEdgeInsets(top: 4, left: 7, bottom: 4, right: 4) {
+    open var placeholderLabelInsets: UIEdgeInsets = UIEdgeInsets(top: 4, left: 7, bottom: 4, right: 7) {
         didSet {
             updateConstraintsForPlaceholderLabel()
         }
@@ -118,7 +118,6 @@ open class InputTextView: UITextView, UITextViewDelegate {
         layer.cornerRadius = 5.0
         layer.borderWidth = 1.25
         layer.borderColor = UIColor.lightGray.cgColor
-        delegate = self
 
         addSubviews()
         addConstraints()
@@ -135,7 +134,7 @@ open class InputTextView: UITextView, UITextViewDelegate {
             top:    placeholderLabel.topAnchor.constraint(equalTo: topAnchor, constant: placeholderLabelInsets.top),
             bottom: placeholderLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -placeholderLabelInsets.bottom),
             left:   placeholderLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: placeholderLabelInsets.left),
-            right:  placeholderLabel.rightAnchor.constraint(equalTo: rightAnchor, constant: -placeholderLabelInsets.right)
+            width:  placeholderLabel.widthAnchor.constraint(equalTo: widthAnchor, constant: -(placeholderLabelInsets.left + placeholderLabelInsets.right))
             ).activate()
     }
 
@@ -144,22 +143,6 @@ open class InputTextView: UITextView, UITextViewDelegate {
         placeholderLabelConstraintSet?.top?.constant = placeholderLabelInsets.top
         placeholderLabelConstraintSet?.bottom?.constant = -placeholderLabelInsets.bottom
         placeholderLabelConstraintSet?.left?.constant = placeholderLabelInsets.left
-        placeholderLabelConstraintSet?.right?.constant = -placeholderLabelInsets.bottom
-    }
-    
-    // MARK: - UITextViewDelegate
-    
-    public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        
-        // When isScrollEnabled gets changed in MessageInputBar when it becomes more than the maxHeight there is a bug the incorrectly sets the contentSize. This fixes it by inserting the text via `replacingCharacters`
-        if text == UIPasteboard.general.string {
-            if let messageInputBar = messageInputBar {
-                if !messageInputBar.isOverMaxHeight {
-                    textView.text = (textView.text as NSString).replacingCharacters(in: range, with: text)
-                    return false
-                }
-            }
-        }
-        return true
+        placeholderLabelConstraintSet?.width?.constant = -(placeholderLabelInsets.left + placeholderLabelInsets.right)
     }
 }


### PR DESCRIPTION
It appears that inside a UITextVIew anchoring a label to the left and right anchors don't extend the labels width all the way, thus adjusting the textAllignment doesn't have visible changes. (Thanks @hemangshah)

This fix changes the constraints of the label to use a width anchor instead of a right anchor. Also removed the UITextViewDelegate as I saw it was causing other MessageInputBar height issues and was previously only included as a temp solution to another bug that was corrected.