### PR TITLE
Update the README.md for using swift 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pod 'MessageKit'
 
 If your project is still using Swift 3. Add the following code in your Podfile.
 
-````ruby
+````
 target 'TARGET_NAME' do
     pod 'MessageKit'
     ...

--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ See [VISION.md](https://github.com/MessageKit/MessageKit/blob/master/VISION.md) 
 pod 'MessageKit'
 ````
 
+If your project is still using Swift 3. Add the following code in your Podfile.
+
+````ruby
+target 'TARGET_NAME' do
+    pod 'MessageKit'
+    ...
+    post_install do |installer|
+        installer.pods_project.targets.each do |target|
+            if target.name == 'MessageKit'
+                target.build_configurations.each do |config|
+                    config.build_settings['SWIFT_VERSION'] = '4.0'
+                end
+            end
+        end
+    end
+end
+````
+
 ### [Carthage](https://github.com/Carthage/Carthage)
 
 To integrate MessageKit using Carthage, add the following to your `Cartfile`:


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
If the project still use swift 3. The config in `MessageKit.podspec` will not work.

```
s.pod_target_xcconfig = {
      "SWIFT_VERSION" => "4.0",
}
```

Add the extra `post_install` in Podfile will fix this issue.

```
post_install do |installer|
        installer.pods_project.targets.each do |target|
            if target.name == 'MessageKit'
                target.build_configurations.each do |config|
                    config.build_settings['SWIFT_VERSION'] = '4.0'
                end
            end
        end
    end
```

Does this close any currently open issues?
------------------------------------------
#151 
#124 

Where has this been tested?
---------------------------
**Swift Version:** Swift 3.2
**MessageKit Version:** 0.9.0


