### PR TITLE
Changing MessagesViewController reference to MessageInputBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 -  Fixed a bug that prevented the `textAllignment` property of `InputTextView`'s `placeholderLabel` from having noticable differences when changed to `.center` or `.right`
 [#262](https://github.com/MessageKit/MessageKit/pull/262) by [@nathantannar4](https://github.com/nathantannar4).
 
+-  Initial `contentInset.bottom` reference changed from `messageInputBar` to `inputAccessoryView` to allow custom inp`inputAccessoryView`'s that don't break the initial layout
+[#267](https://github.com/MessageKit/MessageKit/pull/262) by [@nathantannar4](https://github.com/nathantannar4).
+
 ### Removed
 
 - **Breaking Change** Removed `additionalTopContentInset` property of `MessagesViewController` because this is no longer necessary

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -73,8 +73,8 @@ open class MessagesViewController: UIViewController {
             defer { isFirstLayout = false }
 
             addKeyboardObservers()
-            messagesCollectionView.contentInset.bottom = messageInputBar.frame.height
-            messagesCollectionView.scrollIndicatorInsets.bottom = messageInputBar.frame.height
+            messagesCollectionView.contentInset.bottom = inputAccessoryView?.frame.height ?? 0
+            messagesCollectionView.scrollIndicatorInsets.bottom = inputAccessoryView?.frame.height ?? 0
             
             //Scroll to bottom at first load
             if scrollsToBottomOnFirstLayout {
@@ -265,7 +265,7 @@ extension MessagesViewController {
 
         } else {
             //Software keyboard is found
-            let bottomInset = keyboardEndFrame.height > messageInputBar.frame.height ? keyboardEndFrame.height : messageInputBar.frame.height
+            let bottomInset = keyboardEndFrame.height > (inputAccessoryView?.frame.height ?? 0) ? keyboardEndFrame.height : (inputAccessoryView?.frame.height ?? 0)
             messagesCollectionView.contentInset.bottom = bottomInset
             messagesCollectionView.scrollIndicatorInsets.bottom = bottomInset
         }


### PR DESCRIPTION
In the `MessagesViewController` we set the initial contentInset.bottom of the MessagesCollectionView to a direct reference to `messageInputBar`. This can pose problems if someone ever overrides the `inputBarAccessoryView` with a custom input bar that is not a `MessageInputBar`. 

This PR changes a direct reference to `messageInputBar` to just `inputAccessoryView`