### PR TITLE
fix issue #232 to stop calculating origins for UI elements with a .zero frame

### DIFF
--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -695,7 +695,7 @@ fileprivate extension MessagesCollectionViewFlowLayout {
     ///   - attributes: The `MessageIntermediateLayoutAttributes` to consider when calculating origin.
     private func avatarOrigin(for attributes: MessageIntermediateLayoutAttributes, and contentFrame: CGRect) -> CGPoint {
         
-        guard attributes.avatarSize != .zero else { return .zero }
+        guard attributes.avatarSize != .zero, contentFrame.size != .zero else { return .zero }
         
         var origin = CGPoint.zero
         
@@ -732,7 +732,7 @@ fileprivate extension MessagesCollectionViewFlowLayout {
     ///   - attributes: The `MessageIntermediateLayoutAttributes` to consider when calculating origin.
     private func messageContainerOrigin(for attributes: MessageIntermediateLayoutAttributes, and contentFrame: CGRect) -> CGPoint {
         
-        guard attributes.messageContainerSize != .zero else { return .zero }
+        guard attributes.messageContainerSize != .zero, contentFrame.size != .zero else { return .zero }
         
         var origin = CGPoint.zero
         
@@ -757,7 +757,7 @@ fileprivate extension MessagesCollectionViewFlowLayout {
     ///   - attributes: The `MessageIntermediateLayoutAttributes` to consider when calculating origin.
     private func cellBottomLabelOrigin(for attributes: MessageIntermediateLayoutAttributes, and contentFrame: CGRect) -> CGPoint {
         
-        guard attributes.cellBottomLabelSize != .zero else { return .zero }
+        guard attributes.cellBottomLabelSize != .zero, contentFrame.size != .zero else { return .zero }
         
         var origin = CGPoint(x: 0, y: contentFrame.height - attributes.cellBottomLabelSize.height)
         
@@ -790,7 +790,7 @@ fileprivate extension MessagesCollectionViewFlowLayout {
     ///   - attributes: The `MessageIntermediateLayoutAttributes` to consider when calculating origin.
     fileprivate func cellTopLabelOrigin(for attributes: MessageIntermediateLayoutAttributes, and contentFrame: CGRect) -> CGPoint {
         
-        guard attributes.cellTopLabelSize != .zero else { return .zero }
+        guard attributes.cellTopLabelSize != .zero, contentFrame.size != .zero else { return .zero }
         
         var origin = CGPoint.zero
         


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR stops calculating origins for UI elements (avatar, message container, cell bottom label, cell top label) with a .zero content frame by returning .zero origins if content size is .zero.

Does this close any currently open issues?
------------------------------------------
Yes, issue #232


Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
This is my first PR into MessageKit. Hopefully, I got the issue properly.

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 8 Plus SImulator

**iOS Version:** iOS 11.0

**Swift Version:** 4.0

**MessageKit Version:** 0.9.0


