### PR TITLE
Adding method to remove cached attributes by message id.

### DIFF
--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -146,7 +146,15 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
     /// - Parameters:
     ///   - message: The `MessageType` whose cached layout information is to be removed.
     public func removeCachedAttributes(for message: MessageType) {
-        intermediateAttributesCache.removeValue(forKey: message.messageId)
+        removeCachedAttributes(for: message.messageId)
+    }
+    
+    /// Removes the cached layout information for a `MessageType` given its `messageId`.
+    ///
+    /// - Parameters:
+    ///   - messageId: The `messageId` for the `MessageType` whose cached layout information is to be removed.
+    public func removeCachedAttributes(for messageId: String) {
+        intermediateAttributesCache.removeValue(forKey: messageId)
     }
     
     /// Removes the cached layout information for all `MessageType`s.


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds a method `removeCachedAttributes` per #285 to remove cached attributes by id.

Does this close any currently open issues?
------------------------------------------
#285 

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
Nope. There's no tests covering the existing methods in this area and I've added some method docs. Ready to merge.

Where has this been tested?
---------------------------
**Devices/Simulators:**
iPhone 8 Simulator

**iOS Version:**
iOS 11

**Swift Version:**
Swift 4

**MessageKit Version:**
v0.10.0

