### PR TITLE
Default frames based on device orrientation

### DIFF
--- a/Sources/Protocols/LocationMessageLayoutDelegate.swift
+++ b/Sources/Protocols/LocationMessageLayoutDelegate.swift
@@ -53,7 +53,14 @@ public protocol LocationMessageLayoutDelegate: MessagesLayoutDelegate {
 public extension LocationMessageLayoutDelegate {
 
     func widthForLocation(message: MessageType, at indexPath: IndexPath, with maxWidth: CGFloat, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
-        return maxWidth
+        
+        if messagesCollectionView.frame.width > messagesCollectionView.frame.height {
+            // isLandscape
+            return maxWidth / 2
+        } else {
+            // isPortait
+            return maxWidth
+        }
     }
     
 }

--- a/Sources/Protocols/MediaMessageLayoutDelegate.swift
+++ b/Sources/Protocols/MediaMessageLayoutDelegate.swift
@@ -56,13 +56,21 @@ public protocol MediaMessageLayoutDelegate: MessagesLayoutDelegate {
 public extension MediaMessageLayoutDelegate {
 
     func widthForMedia(message: MessageType, at indexPath: IndexPath, with maxWidth: CGFloat, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
-        return maxWidth
+        
+        if messagesCollectionView.frame.width > messagesCollectionView.frame.height {
+            // isLandscape
+            return maxWidth / 2
+        } else {
+            // isPortait
+            return maxWidth
+        }
     }
 
     func heightForMedia(message: MessageType, at indexPath: IndexPath, with maxWidth: CGFloat, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
         switch message.data {
         case .photo(let image), .video(_, let image):
-            let boundingRect = CGRect(origin: .zero, size: CGSize(width: maxWidth, height: .greatestFiniteMagnitude))
+            let scaledMaxwidth = messagesCollectionView.frame.width > messagesCollectionView.frame.height ? maxWidth / 2 : maxWidth
+            let boundingRect = CGRect(origin: .zero, size: CGSize(width: scaledMaxwidth, height: .greatestFiniteMagnitude))
             return AVMakeRect(aspectRatio: image.size, insideRect: boundingRect).height
         default:
             return 0


### PR DESCRIPTION
Updates the default width/height protocols to return a value based on the devices orientation

Changes This
![simulator screen shot - iphone x - 2017-10-27 at 13 11 22](https://user-images.githubusercontent.com/15272998/32124175-b40a2700-bb1b-11e7-9097-f42a7b79407d.png)

To This
![simulator screen shot - iphone x - 2017-10-27 at 13 33 59](https://user-images.githubusercontent.com/15272998/32124179-bac0e854-bb1b-11e7-9f32-a10a2a1d28b0.png)

And
![simulator screen shot - iphone x - 2017-10-27 at 13 33 52](https://user-images.githubusercontent.com/15272998/32124187-bff72c34-bb1b-11e7-965b-4accfca66e3a.png)
