### PR TITLE
[WIP] Fixing scroll to bottom

### DIFF
--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -382,8 +382,7 @@ extension ConversationViewController: MessageInputBarDelegate {
     func messageInputBar(_ inputBar: MessageInputBar, didPressSendButtonWith text: String) {
         messageList.append(MockMessage(text: text, sender: currentSender(), messageId: UUID().uuidString, date: Date()))
         inputBar.inputTextView.text = String()
-        messagesCollectionView.reloadData()
-        messagesCollectionView.scrollToBottom()
+        messagesCollectionView.scrollToBottom(animated: true)
     }
 
 }

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -64,8 +64,19 @@ open class MessagesCollectionView: UICollectionView {
     // MARK: - Methods
 
     public func scrollToBottom(animated: Bool = false) {
-        guard let indexPath = indexPathForLastItem else { return }
-        scrollToItem(at: indexPath, at: .bottom, animated: animated)
+//        guard let indexPath = indexPathForLastItem else { return }
+//        scrollToItem(at: indexPath, at: .bottom, animated: animated)
+
+        // Work in progress here :)
+
+        guard indexPathForLastItem != nil else { return }
+
+        // This works fairly reliably, but using `DispatchQueue.main.async` might not let you invoke this method from an animation block :(
+        DispatchQueue.main.async {
+            self.layoutIfNeeded()
+            let scrollRect = CGRect(x: 0, y: self.contentSize.height - 1, width: 1, height: 1)
+            self.scrollRectToVisible(scrollRect, animated: animated)
+        }
     }
 
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Hey, I want to try to this issue #268 with scrolling to bottom.

I did some experiments, my current version of scrolling works fairly reliably.
Unfortunately, it uses `DispatchQueue.main.async`, which is kinda hacky.

JSQMessagesViewController had a similar issue: https://github.com/jessesquires/JSQMessagesViewController/issues/256
I think we should study it. Maybe we can just copy and document it properly.

Does this close any currently open issues?
------------------------------------------
#268 


Where has this been tested?
---------------------------
**Devices/Simulators:** 
iPhone and iPad sims

**iOS Version:** 
iOS 9, 11

**Swift Version:** 
Swift 4

**MessageKit Version:** 
v0.11.0


