### PR TITLE
Refactor `initals` to `initials`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 -  Fixed a bug that the `leftStackView`、`rightStackView` `subview` of `MessageInputBar` leads to ambiguous `Auto Layout` issue because of typo.
 [#311](https://github.com/MessageKit/MessageKit/pull/311) by [@zhongwuzw](https://github.com/zhongwuzw).
 
+- Fixed all instances of misspelled `inital` property. [#298](https://github.com/MessageKit/MessageKit/issues/298) by [@sidmclaughlin](https://github.com/sidmclaughlin)
+
 ### Changed
 
 -  Changed `InputStackView` default `alignment` from `.fill` to `.bottom`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,20 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ### Fixed
 
++- **Breaking Change** Fixed all instances of misspelled `inital` property.  `Avatar.inital` has changed to `Avatar.initial` and the initializer has changed from `public init(image: UIImage? = nil, initals: String = "?")` to `public init(image: UIImage? = nil, initials: String = "?")`. [#298](https://github.com/MessageKit/MessageKit/issues/298) by [@sidmclaughlin](https://github.com/sidmclaughlin).
+
+## [[Prerelease] 0.10.1](https://github.com/MessageKit/MessageKit/releases/tag/0.10.1)
+
+### Fixed
+
+-  Fixed a bug that caused a race condition to be met when invalidating the `intrinsicContentSize` of the `MessageInputBar` which froze the app during a "Select" or "Select All" long press
+[#313](https://github.com/MessageKit/MessageKit/pull/313) by [@zhongwuzw](https://github.com/nathantannar4).
+
 -  Fixed a bug that the `placeholderLabel` `subview` of `InputTextView` leads to ambiguous content size because of uncorrect `Auto Layout`.
 [#310](https://github.com/MessageKit/MessageKit/pull/310) by [@zhongwuzw](https://github.com/zhongwuzw).
 
 -  Fixed a bug that the `leftStackView`、`rightStackView` `subview` of `MessageInputBar` leads to ambiguous `Auto Layout` issue because of typo.
 [#311](https://github.com/MessageKit/MessageKit/pull/311) by [@zhongwuzw](https://github.com/zhongwuzw).
-
-- Fixed all instances of misspelled `inital` property.  `Avatar.inital` has changed to `Avatar.initial` and the initializer has changed from `public init(image: UIImage? = nil, initals: String = "?")` to `public init(image: UIImage? = nil, initials: String = "?")` [#298](https://github.com/MessageKit/MessageKit/issues/298) by [@sidmclaughlin](https://github.com/sidmclaughlin)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 -  Fixed a bug that the `leftStackView`、`rightStackView` `subview` of `MessageInputBar` leads to ambiguous `Auto Layout` issue because of typo.
 [#311](https://github.com/MessageKit/MessageKit/pull/311) by [@zhongwuzw](https://github.com/zhongwuzw).
 
-- Fixed all instances of misspelled `inital` property. [#298](https://github.com/MessageKit/MessageKit/issues/298) by [@sidmclaughlin](https://github.com/sidmclaughlin)
+- Fixed all instances of misspelled `inital` property.  `Avatar.inital` has changed to `Avatar.initial` and the initializer has changed from `public init(image: UIImage? = nil, initals: String = "?")` to `public init(image: UIImage? = nil, initials: String = "?")` [#298](https://github.com/MessageKit/MessageKit/issues/298) by [@sidmclaughlin](https://github.com/sidmclaughlin)
 
 ### Changed
 

--- a/Sources/Models/Avatar.swift
+++ b/Sources/Models/Avatar.swift
@@ -35,13 +35,13 @@ public struct Avatar {
     /// The placeholder initials to be used in the case where no image is provided.
     ///
     /// The default value of this property is "?".
-    public var initals: String = "?"
+    public var initials: String = "?"
     
     // MARK: - Initializer
     
-    public init(image: UIImage? = nil, initals: String = "?") {
+    public init(image: UIImage? = nil, initials: String = "?") {
         self.image = image
-        self.initals = initals
+        self.initials = initials
     }
     
 }

--- a/Sources/Views/AvatarView.swift
+++ b/Sources/Views/AvatarView.swift
@@ -83,7 +83,7 @@ open class AvatarView: UIView {
         self.init(frame: .zero)
     }
 
-    private func getImageFrom(initals: String) -> UIImage {
+    private func getImageFrom(initials: String) -> UIImage {
         let width = frame.width
         let height = frame.height
         if width == 0 || height == 0 {return UIImage()}
@@ -95,8 +95,8 @@ open class AvatarView: UIView {
         //// Text Drawing
         let textRect = calculateTextRect(outerViewWidth: width, outerViewHeight: height)
         if adjustsFontSizeToFitWidth,
-            initals.width(considering: textRect.height, and: font) > textRect.width {
-            let newFontSize = calculateFontSize(text: initals, font: font, width: textRect.width, height: textRect.height)
+            initials.width(considering: textRect.height, and: font) > textRect.width {
+            let newFontSize = calculateFontSize(text: initials, font: font, width: textRect.width, height: textRect.height)
             font = placeholderFont.withSize(newFontSize)
         }
 
@@ -104,10 +104,10 @@ open class AvatarView: UIView {
         textStyle.alignment = .center
       let textFontAttributes: [NSAttributedStringKey: Any] = [NSAttributedStringKey.font: font, NSAttributedStringKey.foregroundColor: placeholderTextColor, NSAttributedStringKey.paragraphStyle: textStyle]
 
-        let textTextHeight: CGFloat = initals.boundingRect(with: CGSize(width: textRect.width, height: CGFloat.infinity), options: .usesLineFragmentOrigin, attributes: textFontAttributes, context: nil).height
+        let textTextHeight: CGFloat = initials.boundingRect(with: CGSize(width: textRect.width, height: CGFloat.infinity), options: .usesLineFragmentOrigin, attributes: textFontAttributes, context: nil).height
         context.saveGState()
         context.clip(to: textRect)
-        initals.draw(in: CGRect(x: textRect.minX, y: textRect.minY + (textRect.height - textTextHeight) / 2, width: textRect.width, height: textTextHeight), withAttributes: textFontAttributes)
+        initials.draw(in: CGRect(x: textRect.minX, y: textRect.minY + (textRect.height - textTextHeight) / 2, width: textRect.width, height: textTextHeight), withAttributes: textFontAttributes)
         context.restoreGState()
         guard let renderedImage = UIGraphicsGetImageFromCurrentImageContext() else { assertionFailure("Could not create image from context"); return UIImage()}
         return renderedImage
@@ -162,14 +162,14 @@ open class AvatarView: UIView {
         imageView.contentMode = .scaleAspectFill
         imageView.frame = frame
         addSubview(imageView)
-        imageView.image = avatar.image ?? getImageFrom(initals: avatar.initals)
+        imageView.image = avatar.image ?? getImageFrom(initials: avatar.initials)
         setCorner(radius: nil)
     }
 
     // MARK: - Open setters
 
     open func set(avatar: Avatar) {
-        imageView.image = avatar.image ?? getImageFrom(initals: avatar.initals)
+        imageView.image = avatar.image ?? getImageFrom(initials: avatar.initials)
     }
 
     open func setCorner(radius: CGFloat?) {

--- a/Tests/ModelTests/AvatarTests.swift
+++ b/Tests/ModelTests/AvatarTests.swift
@@ -30,7 +30,7 @@ class AvatarTests: XCTestCase {
     func testDefaultInit() {
         let avatar = Avatar()
         XCTAssertNil(avatar.image)
-        XCTAssertEqual(avatar.initals, "?")
+        XCTAssertEqual(avatar.initials, "?")
     }
 
 }

--- a/Tests/ProtocolsTests/MessagesDisplayDelegateTests.swift
+++ b/Tests/ProtocolsTests/MessagesDisplayDelegateTests.swift
@@ -88,7 +88,7 @@ class MessagesDisplayDelegateTests: XCTestCase {
     func testAvatarDefaultState() {
         XCTAssertNotNil(sut.dataProvider.avatar(for: sut.dataProvider.messages[0],
                                                 at: IndexPath(item: 0, section: 0),
-                                                in: sut.messagesCollectionView).initals)
+                                                in: sut.messagesCollectionView).initials)
     }
 
     func testCellTopLabelDefaultState() {

--- a/Tests/ViewsTests/AvatarViewTests.swift
+++ b/Tests/ViewsTests/AvatarViewTests.swift
@@ -41,7 +41,7 @@ class AvatarViewTests: XCTestCase {
     }
 
     func testNoParams() {
-        XCTAssertEqual(avatarView.avatar.initals, "?")
+        XCTAssertEqual(avatarView.avatar.initials, "?")
         XCTAssertEqual(avatarView.layer.cornerRadius, 15.0)
         XCTAssertEqual(avatarView.backgroundColor, UIColor.gray)
     }
@@ -49,15 +49,15 @@ class AvatarViewTests: XCTestCase {
     func testWithImage() {
         let avatar = Avatar(image: UIImage())
         avatarView.set(avatar: avatar)
-        XCTAssertEqual(avatar.initals, "?")
+        XCTAssertEqual(avatar.initials, "?")
         XCTAssertEqual(avatarView.layer.cornerRadius, 15.0)
         XCTAssertEqual(avatarView.backgroundColor, UIColor.gray)
     }
 
-    func testInitalsOnly() {
-        let avatar = Avatar(initals: "DL")
+    func testInitialsOnly() {
+        let avatar = Avatar(initials: "DL")
         avatarView.set(avatar: avatar)
-        XCTAssertEqual(avatar.initals, "DL")
+        XCTAssertEqual(avatar.initials, "DL")
         XCTAssertEqual(avatarView.layer.cornerRadius, 15.0)
         XCTAssertEqual(avatarView.backgroundColor, UIColor.gray)
     }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR refactors the misspelled `initals` to `initials`.

Does this close any currently open issues?
------------------------------------------
https://github.com/MessageKit/MessageKit/issues/298

Any other comments?
-------------------
The test has been renamed also, from `testInitalsOnly()` to `testInitialsOnly()`

Where has this been tested?
---------------------------
**iOS Version:** 11.0
**Swift Version:** 4.0

**MessageKit Version:** v0.11.0 branch

