### PR TITLE
Fix bottom label origin bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 
+### Fixed
+
+- Fixed `cellbottomLabel` origin X for the `.messageLeading` alignment and
+origin Y so that the `cellBottomLabel` is always under the `MessageContainerView`.
+[#326](https://github.com/MessageKit/MessageKit/pull/326) by [@SD10](https://github.com/sd10). 
+
 ## [[Prerelease] 0.10.1](https://github.com/MessageKit/MessageKit/releases/tag/0.10.1)
 
 ### Fixed

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MessageKit (0.10.0)
+  - MessageKit (0.10.1)
 
 DEPENDENCIES:
   - MessageKit (from `../MessageKit.podspec`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../MessageKit.podspec
 
 SPEC CHECKSUMS:
-  MessageKit: dc900db857e89ac994f1afeb1080539de7fabde4
+  MessageKit: b0cd905fa1872952f25ff5ea8e67d7135fe7e176
 
 PODFILE CHECKSUM: 9ac65b8dedf0e1b63fea245b089b6645c4e66309
 

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -780,7 +780,7 @@ fileprivate extension MessagesCollectionViewFlowLayout {
         
         guard attributes.cellBottomLabelSize != .zero else { return .zero }
         
-        var origin = CGPoint(x: 0, y: contentFrame.height - attributes.cellBottomLabelSize.height)
+        var origin = CGPoint(x: 0, y: attributes.cellTopLabelSize.height + attributes.messageContainerSize.height + attributes.messageVerticalPadding)
         
         switch (attributes.cellBottomLabelAlignment, attributes.avatarHorizontal) {
         case (.cellLeading, _):
@@ -792,7 +792,7 @@ fileprivate extension MessagesCollectionViewFlowLayout {
         case (.messageLeading, .cellLeading):
             origin.x = attributes.avatarSize.width + attributes.messageContainerPadding.left
         case (.messageLeading, .cellTrailing):
-            origin.x = contentFrame.width - attributes.avatarSize.width - attributes.messageContainerPadding.right - attributes.cellBottomLabelSize.width
+            origin.x = contentFrame.width - attributes.avatarSize.width - attributes.messageContainerPadding.right - attributes.messageContainerSize.width
         case (.messageTrailing, .cellTrailing):
             origin.x = contentFrame.width - attributes.avatarSize.width - attributes.messageContainerPadding.right - attributes.cellBottomLabelSize.width
         case (.messageTrailing, .cellLeading):


### PR DESCRIPTION
I think this could resolve #231. 

The problem was simpler than when I was trying to diagnose it from the UI. Nonetheless, this is an improvement if I've over-simplified it and missed something.

I also caught a problem with the bottom label origin for the `.messageLeading` case and resolved that as well. Not sure how that regressed. Please let me know if it was a problem for anyone.

TODO:
- [x] CHANGELOG entry  
