### PR TITLE
Bugfix/separator line

### DIFF
--- a/Sources/Views/MessageInputBar.swift
+++ b/Sources/Views/MessageInputBar.swift
@@ -307,13 +307,14 @@ open class MessageInputBar: UIView {
         addSubview(leftStackView)
         addSubview(rightStackView)
         addSubview(bottomStackView)
-        topStackView.addArrangedSubview(separatorLine)
+        addSubview(separatorLine)
         setStackViewItems([sendButton], forStack: .right, animated: false)
     }
     
     /// Sets up the initial constraints of each subview
     private func setupConstraints() {
         
+        separatorLine.addConstraints(topAnchor, left: leftAnchor, right: rightAnchor, heightConstant: 1)
         topStackViewLayoutSet = NSLayoutConstraintSet(
             top:    topStackView.topAnchor.constraint(equalTo: topAnchor, constant: topStackViewPadding.top),
             bottom: topStackView.bottomAnchor.constraint(equalTo: inputTextView.topAnchor, constant: -padding.top),


### PR DESCRIPTION
I don't think we can put the SeparatorLine in the topStackView as we use the safeAreaLayoutGuide for the topStackView. This results in this:
![simulator screen shot - iphone x - 2017-11-12 at 12 48 00](https://user-images.githubusercontent.com/15272998/32703395-034c49c0-c7aa-11e7-9048-0c301b5453a5.png)

Switching back to the way its currently done in the `master` branch