### PR TITLE
Fix MessageInputBar translucent property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and the initializer has changed from `public init(image: UIImage? = nil, initals
 origin Y so that the `cellBottomLabel` is always under the `MessageContainerView`.
 [#326](https://github.com/MessageKit/MessageKit/pull/326) by [@SD10](https://github.com/sd10). 
 
+- Fixed `MessageInputBar`'s `translucent` functionality.
+[#348](https://github.com/MessageKit/MessageKit/pull/348) by [@zhongwuzw](https://github.com/zhongwuzw). 
+
 ### Removed
 
 - **Breaking Change** Removed `AvatarAlignment` and `avatarAlignment(for:at:in)` delegate method

--- a/Sources/Views/MessageInputBar.swift
+++ b/Sources/Views/MessageInputBar.swift
@@ -41,16 +41,9 @@ open class MessageInputBar: UIView {
     open var backgroundView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .white
+        view.backgroundColor = .inputBarGray
         return view
     }()
-    
-    /// Also sets the backgroundView's backgroundColor to the newValue
-    open override var backgroundColor: UIColor? {
-        didSet {
-            backgroundView.backgroundColor = backgroundColor
-        }
-    }
     
     /**
      A UIVisualEffectView that adds a blur effect to make the view appear transparent.
@@ -73,11 +66,8 @@ open class MessageInputBar: UIView {
                 blurView.fillSuperview()
             }
             blurView.isHidden = !isTranslucent
-            let color: UIColor = backgroundView.backgroundColor ?? .white
+            let color: UIColor = backgroundView.backgroundColor ?? .inputBarGray
             backgroundView.backgroundColor = isTranslucent ? color.withAlphaComponent(0.75) : color.withAlphaComponent(1.0)
-            
-            let bgColor: UIColor = backgroundColor ?? .inputBarGray
-            backgroundColor = isTranslucent ? bgColor.withAlphaComponent(0.75) : bgColor.withAlphaComponent(1.0)
         }
     }
     
@@ -294,7 +284,6 @@ open class MessageInputBar: UIView {
     /// Sets up the default properties
     open func setup() {
         
-        backgroundColor = .inputBarGray
         autoresizingMask = [.flexibleHeight]
         setupSubviews()
         setupConstraints()

--- a/Sources/Views/MessageInputBar.swift
+++ b/Sources/Views/MessageInputBar.swift
@@ -74,7 +74,10 @@ open class MessageInputBar: UIView {
             }
             blurView.isHidden = !isTranslucent
             let color: UIColor = backgroundView.backgroundColor ?? .white
-            backgroundView.backgroundColor = isTranslucent ? color.withAlphaComponent(0.75) : .white
+            backgroundView.backgroundColor = isTranslucent ? color.withAlphaComponent(0.75) : color.withAlphaComponent(1.0)
+            
+            let bgColor: UIColor = backgroundColor ?? .inputBarGray
+            backgroundColor = isTranslucent ? bgColor.withAlphaComponent(0.75) : bgColor.withAlphaComponent(1.0)
         }
     }
     


### PR DESCRIPTION
1. Change `backgroundView.backgroundColor` from `.white` to `color.withAlphaComponent(1.0)` because user can change `backgroundColor`.
2. Add `MessageInputBar` `backgroundColor` to support `translucent` feature .