### PR TITLE
MessageLabel detectors off by default and configure method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,31 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 `AvatarView`'s vertical and horizontal position in a `MessageCollectionViewCell`.
 [#322](https://github.com/MessageKit/MessageKit/pull/322) by [@SD10](https://github.com/sd10).
 
+### Changed
+
+- All `DetectorType`s for `MessageLabel` are disabled by default.
+[#356](https://github.com/MessageKit/MessageKit/pull/356) by [@SD10](https://github.com/sd10). 
+
 ### Fixed
 
 - **Breaking Change** Fixed all instances of misspelled `inital` property. `Avatar.inital` has changed to `Avatar.initial` 
 and the initializer has changed from `public init(image: UIImage? = nil, initals: String = "?")` to `public init(image: UIImage? = nil, initials: String = "?")`. 
 [#298](https://github.com/MessageKit/MessageKit/issues/298) by [@sidmclaughlin](https://github.com/sidmclaughlin).
 
+- Fixed `MessageInputBar`'s `translucent` functionality.
+[#348](https://github.com/MessageKit/MessageKit/pull/348) by [@zhongwuzw](https://github.com/zhongwuzw).
+
 - Fixes infinite loop when dismissing keyboard on iPhone X.
 [#350](https://github.com/MessageKit/MessageKit/pull/350) by [@nathantannar4](https://github.com/nathantannar4).
+
+### Removed
+
+- **Breaking Change** Removed `AvatarAlignment` and `avatarAlignment(for:at:in)` delegate method
+in favor of new `AvatarPosition` representing both vertical and horizontal alignments.
+[#322](https://github.com/MessageKit/MessageKit/pull/322) by [@SD10](https://github.com/sd10).
+
+- **Breaking Change** Removed the `avatarAlwaysLeading` and `avatarAlwaysTrailing` properties of `MessagesCollectionViewFlow$
+[#322](https://github.com/MessageKit/MessageKit/pull/322) by [@SD10](https://github.com/sd10).
 
 ## [[Prerelease] 0.10.2](https://github.com/MessageKit/MessageKit/releases/tag/0.10.2)
 
@@ -35,19 +52,6 @@ and the initializer has changed from `public init(image: UIImage? = nil, initals
 origin Y so that the `cellBottomLabel` is always under the `MessageContainerView`.
 [#326](https://github.com/MessageKit/MessageKit/pull/326) by [@SD10](https://github.com/sd10). 
 
-- Fixed `MessageInputBar`'s `translucent` functionality.
-[#348](https://github.com/MessageKit/MessageKit/pull/348) by [@zhongwuzw](https://github.com/zhongwuzw). 
-
-### Removed
-
-- **Breaking Change** Removed `AvatarAlignment` and `avatarAlignment(for:at:in)` delegate method
-in favor of new `AvatarPosition` representing both vertical and horizontal alignments. 
-[#322](https://github.com/MessageKit/MessageKit/pull/322) by [@SD10](https://github.com/sd10).
-
-- **Breaking Change** Removed the `avatarAlwaysLeading` and `avatarAlwaysTrailing` properties of `MessagesCollectionViewFlowLayout`.
-[#322](https://github.com/MessageKit/MessageKit/pull/322) by [@SD10](https://github.com/sd10).
-
-=======
 - Fixed pixelation of `AvatarView`'s placeholder text initials.
 [#343](https://github.com/MessageKit/MessageKit/pull/343) by [@johnnyoin](https://github.com/johnnyoin).
 
@@ -56,7 +60,6 @@ in favor of new `AvatarPosition` representing both vertical and horizontal align
 
 - Fixed crash for escaping block in `InputBarItem`’s `setSize(newValue:animated)` method.
 [#342](https://github.com/MessageKit/MessageKit/pull/342) by [@zhongwuzw](https://github.com/zhongwuzw).
->>>>>>> master
 
 ## [[Prerelease] 0.10.1](https://github.com/MessageKit/MessageKit/releases/tag/0.10.1)
 

--- a/Sources/Protocols/MessagesDisplayDelegate.swift
+++ b/Sources/Protocols/MessagesDisplayDelegate.swift
@@ -61,7 +61,7 @@ public extension TextMessageDisplayDelegate {
     }
 
     func enabledDetectors(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> [DetectorType] {
-        return [.url, .address, .phoneNumber, .date]
+        return []
     }
 
 }

--- a/Sources/Views/Cells/TextMessageCell.swift
+++ b/Sources/Views/Cells/TextMessageCell.swift
@@ -47,8 +47,12 @@ open class TextMessageCell: MessageCollectionViewCell<MessageLabel> {
         super.apply(layoutAttributes)
 
         guard let attributes = layoutAttributes as? MessagesCollectionViewLayoutAttributes else { return }
-        messageContentView.textInsets = attributes.messageLabelInsets
-        messageContentView.font = attributes.messageLabelFont
+        
+        messageContentView.configure {
+            messageContentView.textInsets = attributes.messageLabelInsets
+            messageContentView.font = attributes.messageLabelFont
+        }
+
     }
 
     open override func prepareForReuse() {
@@ -63,8 +67,12 @@ open class TextMessageCell: MessageCollectionViewCell<MessageLabel> {
         if let displayDelegate = messagesCollectionView.messagesDisplayDelegate as? TextMessageDisplayDelegate {
             let textColor = displayDelegate.textColor(for: message, at: indexPath, in: messagesCollectionView)
             let detectors = displayDelegate.enabledDetectors(for: message, at: indexPath, in: messagesCollectionView)
-            messageContentView.textColor = textColor
-            messageContentView.enabledDetectors = detectors
+            
+            messageContentView.configure {
+                messageContentView.textColor = textColor
+                messageContentView.enabledDetectors = detectors
+            }
+
         }
 
         switch message.data {

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -408,7 +408,7 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
 
         let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleGesture(_:)))
         addGestureRecognizer(longPressGesture)
-        tapGesture.delegate = self
+        longPressGesture.delegate = self
 
         isUserInteractionEnabled = true
     }

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -59,39 +59,30 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
 
     open override var attributedText: NSAttributedString? {
         didSet {
-            guard attributedText != oldValue else { return }
-            setTextStorage()
+            setTextStorage(shouldParse: true)
         }
     }
 
     open override var text: String? {
         didSet {
-            guard text != oldValue else { return }
-            setTextStorage()
+            setTextStorage(shouldParse: true)
         }
     }
 
     open override var font: UIFont! {
         didSet {
-            guard font != oldValue else { return }
-            guard let attributedText = attributedText else { return }
-            textStorage.setAttributedString(attributedText)
-            setNeedsDisplay()
+            setTextStorage(shouldParse: false)
         }
     }
 
     open override var textColor: UIColor! {
         didSet {
-            guard textColor != oldValue else { return }
-            guard let attributedText = attributedText else { return }
-            textStorage.setAttributedString(attributedText)
-            setNeedsDisplay()
+            setTextStorage(shouldParse: false)
         }
     }
 
     open override var lineBreakMode: NSLineBreakMode {
         didSet {
-            guard lineBreakMode != oldValue else { return }
             textContainer.lineBreakMode = lineBreakMode
             setNeedsDisplay()
         }
@@ -99,7 +90,6 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
 
     open override var numberOfLines: Int {
         didSet {
-            guard numberOfLines != oldValue else { return }
             textContainer.maximumNumberOfLines = numberOfLines
             setNeedsDisplay()
         }
@@ -107,14 +97,12 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
 
     open override var textAlignment: NSTextAlignment {
         didSet {
-            guard textAlignment != oldValue else { return }
-            setTextStorage()
+            setTextStorage(shouldParse: false)
         }
     }
 
     open var textInsets: UIEdgeInsets = .zero {
         didSet {
-            guard textInsets != oldValue else { return }
             setNeedsDisplay()
         }
     }
@@ -232,60 +220,53 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
 
     // MARK: - Private Methods
 
-    private func setTextStorage() {
-
-        // Anytime we update the text storage we need to clear the previous ranges
-        rangesForDetectors.removeAll()
+    private func setTextStorage(shouldParse: Bool) {
 
         guard let attributedText = attributedText, attributedText.length > 0 else {
             textStorage.setAttributedString(NSAttributedString())
             setNeedsDisplay()
             return
         }
-
-        guard let checkingResults = parse(text: attributedText, for: enabledDetectors), checkingResults.isEmpty == false else {
-            let textWithParagraphAttributes = addParagraphStyleAttribute(to: attributedText)
-            textStorage.setAttributedString(textWithParagraphAttributes)
-            setNeedsDisplay()
-            return
+        
+        let style = paragraphStyle(for: attributedText)
+        let range = NSRange(location: 0, length: attributedText.length)
+        
+        let mutableText = NSMutableAttributedString(attributedString: attributedText)
+        mutableText.addAttribute(.paragraphStyle, value: style, range: range)
+        
+        if shouldParse {
+            rangesForDetectors.removeAll()
+            let results = parse(text: mutableText)
+            setRangesForDetectors(in: results)
+        }
+        
+        for (detector, rangeTuples) in rangesForDetectors {
+            if enabledDetectors.contains(detector) {
+                let attributes = detectorAttributes(for: detector)
+                rangeTuples.forEach { (range, _) in
+                    mutableText.addAttributes(attributes, range: range)
+                }
+            }
         }
 
-        setRangesForDetectors(in: checkingResults)
-
-        let textWithDetectorAttributes = addDetectorAttributes(to: attributedText, for: checkingResults)
-        let textWithParagraphAttributes = addParagraphStyleAttribute(to: textWithDetectorAttributes)
-
-        textStorage.setAttributedString(textWithParagraphAttributes)
+        let modifiedText = NSAttributedString(attributedString: mutableText)
+        textStorage.setAttributedString(modifiedText)
 
         setNeedsDisplay()
 
     }
-
-    private func addParagraphStyleAttribute(to text: NSAttributedString) -> NSAttributedString {
-
-        let mutableAttributedString = NSMutableAttributedString(attributedString: text)
-        var textRange = NSRange(location: 0, length: 0)
-
-      let paragraphStyle = text.attribute(NSAttributedStringKey.paragraphStyle, at: 0, effectiveRange: &textRange) as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
-        paragraphStyle.lineBreakMode = lineBreakMode
-        paragraphStyle.alignment = textAlignment
-
-      mutableAttributedString.addAttribute(NSAttributedStringKey.paragraphStyle, value: paragraphStyle, range: textRange)
-
-        return mutableAttributedString
-
-    }
-
-    private func addDetectorAttributes(to text: NSAttributedString, for checkingResults: [NSTextCheckingResult]) -> NSAttributedString {
-
-        let mutableAttributedString = NSMutableAttributedString(attributedString: text)
-
-        checkingResults.forEach { result in
-            let attributes = detectorAttributes(for: result.resultType)
-            mutableAttributedString.addAttributes(attributes, range: result.range)
-        }
-
-        return mutableAttributedString
+    
+    private func paragraphStyle(for text: NSAttributedString) -> NSParagraphStyle {
+        guard text.length > 0 else { return NSParagraphStyle() }
+        
+        var range = NSRange(location: 0, length: text.length)
+        let existingStyle = text.attribute(.paragraphStyle, at: 0, effectiveRange: &range) as? NSMutableParagraphStyle
+        let style = existingStyle ?? NSMutableParagraphStyle()
+        
+        style.lineBreakMode = lineBreakMode
+        style.alignment = textAlignment
+        
+        return style
     }
 
     private func updateAttributes(for detectorType: DetectorType) {
@@ -336,16 +317,18 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
 
     // MARK: - Parsing Text
 
-    private func parse(text: NSAttributedString, for detectorTypes: [DetectorType]) -> [NSTextCheckingResult]? {
-        guard detectorTypes.isEmpty == false else { return nil }
-        let checkingTypes = detectorTypes.reduce(0) { $0 | $1.textCheckingType.rawValue }
+    private func parse(text: NSAttributedString) -> [NSTextCheckingResult] {
+        guard enabledDetectors.isEmpty == false else { return [] }
+        let checkingTypes = enabledDetectors.reduce(0) { $0 | $1.textCheckingType.rawValue }
         let detector = try? NSDataDetector(types: checkingTypes)
-
-        return detector?.matches(in: text.string, options: [], range: NSRange(location: 0, length: text.length))
+        let range = NSRange(location: 0, length: text.length)
+        return detector?.matches(in: text.string, options: [], range: range) ?? []
     }
 
     private func setRangesForDetectors(in checkingResults: [NSTextCheckingResult]) {
 
+        guard checkingResults.isEmpty == false else { return }
+        
         for result in checkingResults {
 
             switch result.resultType {
@@ -388,15 +371,17 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
         location.x -= textOffset.x
         location.y -= textOffset.y
 
-        let glyphIndex = layoutManager.glyphIndex(for: location, in: textContainer)
+        let index = layoutManager.glyphIndex(for: location, in: textContainer)
 
-        let lineRect = layoutManager.lineFragmentUsedRect(forGlyphAt: glyphIndex, effectiveRange: nil)
-
+        let lineRect = layoutManager.lineFragmentUsedRect(forGlyphAt: index, effectiveRange: nil)
+        
+        var characterIndex: Int?
+        
         if lineRect.contains(location) {
-            return layoutManager.characterIndexForGlyph(at: glyphIndex)
-        } else {
-            return nil
+            characterIndex = layoutManager.characterIndexForGlyph(at: index)
         }
+        
+        return characterIndex
 
     }
 

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -57,7 +57,11 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
 
     open weak var delegate: MessageLabelDelegate?
 
-    open var enabledDetectors: [DetectorType] = [.phoneNumber, .address, .date, .url]
+    open var enabledDetectors: [DetectorType] = [] {
+        didSet {
+            setTextStorage(shouldParse: true)
+        }
+    }
 
     open override var attributedText: NSAttributedString? {
         didSet {

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -50,6 +50,8 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
     }()
 
     private lazy var rangesForDetectors: [DetectorType: [(NSRange, MessageTextCheckingType)]] = [:]
+    
+    private var isConfiguring: Bool = false
 
     // MARK: - Public Properties
 
@@ -84,14 +86,14 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
     open override var lineBreakMode: NSLineBreakMode {
         didSet {
             textContainer.lineBreakMode = lineBreakMode
-            setNeedsDisplay()
+            if !isConfiguring { setNeedsDisplay() }
         }
     }
 
     open override var numberOfLines: Int {
         didSet {
             textContainer.maximumNumberOfLines = numberOfLines
-            setNeedsDisplay()
+            if !isConfiguring { setNeedsDisplay() }
         }
     }
 
@@ -103,35 +105,35 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
 
     open var textInsets: UIEdgeInsets = .zero {
         didSet {
-            setNeedsDisplay()
+            if !isConfiguring { setNeedsDisplay() }
         }
     }
 
     open var addressAttributes: [NSAttributedStringKey: Any] = [:] {
         didSet {
             updateAttributes(for: .address)
-            setNeedsDisplay()
+            if !isConfiguring { setNeedsDisplay() }
         }
     }
 
     open var dateAttributes: [NSAttributedStringKey: Any] = [:] {
         didSet {
             updateAttributes(for: .date)
-            setNeedsDisplay()
+            if !isConfiguring { setNeedsDisplay() }
         }
     }
 
     open var phoneNumberAttributes: [NSAttributedStringKey: Any] = [:] {
         didSet {
             updateAttributes(for: .phoneNumber)
-            setNeedsDisplay()
+            if !isConfiguring { setNeedsDisplay() }
         }
     }
 
     open var urlAttributes: [NSAttributedStringKey: Any] = [:] {
         didSet {
             updateAttributes(for: .url)
-            setNeedsDisplay()
+            if !isConfiguring { setNeedsDisplay() }
         }
     }
 
@@ -178,6 +180,13 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
     }
 
     // MARK: - Public Methods
+    
+    public func configure(block: () -> Void) {
+        isConfiguring = true
+        block()
+        isConfiguring = false
+        setNeedsDisplay()
+    }
 
     // MARK: UIGestureRecognizer Delegate
 
@@ -252,7 +261,7 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
         let modifiedText = NSAttributedString(attributedString: mutableText)
         textStorage.setAttributedString(modifiedText)
 
-        setNeedsDisplay()
+        if !isConfiguring { setNeedsDisplay() }
 
     }
     

--- a/Tests/ProtocolsTests/MessagesDisplayDelegateTests.swift
+++ b/Tests/ProtocolsTests/MessagesDisplayDelegateTests.swift
@@ -226,11 +226,11 @@ class TextMessageDisplayDelegateTests: XCTestCase {
         XCTAssertEqual(textColor, .darkText)
     }
 
-    func testEnableDetectors_returnsUrlAddressPhoneNumberAndDateForDefault() {
+    func testEnableDetectors_returnsEmptyForDefault() {
         let detectors = sut.enabledDetectors(for: sut.dataProvider.messages[1],
                                              at: IndexPath(item: 0, section: 0),
                                              in: sut.messagesCollectionView)
-        let expectedDetectors: [DetectorType] = [.url, .address, .phoneNumber, .date]
+        let expectedDetectors: [DetectorType] = []
 
         XCTAssertEqual(detectors, expectedDetectors)
     }


### PR DESCRIPTION
#287 Didn't work out too well but these are some improvements to reduce redundant `setNeedsDisplay()` and `parse(text:)` calls

This also sets `MessageLabel` `enabledDetectors` to be off by default.


TODO:
- [ ] CHANGELOG entry 
- [ ] Update Unit Tests