### PR TITLE
Add shouldCacheLayoutAttributes method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 `AvatarView`'s vertical and horizontal position in a `MessageCollectionViewCell`.
 [#322](https://github.com/MessageKit/MessageKit/pull/322) by [@SD10](https://github.com/sd10).
 
+- Added `shouldCacheLayoutAttributes(for:MessageType)-> Bool` method to `MessagesLayoutDelegate`
+to manage whether a `MessageType`'s layout information is cached or not.
+[#364](https://github.com/MessageKit/MessageKit/pull/322) by [@SD10](https://github.com/sd10).
+
 ### Changed
 
 - **Breaking Change** The `cellTopLabel` and `cellBottomLabel` properties of `MessageCollectionViewCell` are no longer

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -213,8 +213,10 @@ fileprivate extension MessagesCollectionViewFlowLayout {
             return intermediateAttributes
         } else {
             let newAttributes = createMessageIntermediateLayoutAttributes(for: message, at: indexPath)
+
+            let shouldCache = messagesLayoutDelegate.shouldCacheLayoutAttributes(for: message) && intermediateAttributesCache.count < attributesCacheMaxSize
             
-            if intermediateAttributesCache.count < attributesCacheMaxSize {
+            if shouldCache {
                 intermediateAttributesCache[message.messageId] = newAttributes
             }
             return newAttributes

--- a/Sources/Protocols/MessagesLayoutDelegate.swift
+++ b/Sources/Protocols/MessagesLayoutDelegate.swift
@@ -178,6 +178,14 @@ public protocol MessagesLayoutDelegate: AnyObject {
     ///   - messagesCollectionView: The `MessagesCollectionView` in which this cell will be displayed.
     func heightForLocation(message: MessageType, at indexPath: IndexPath, with maxWidth: CGFloat, in messagesCollectionView: MessagesCollectionView) -> CGFloat
 
+    /// Specifies whether the layout attributes for a given `MessageType`
+    /// should be cached by the `MessagesCollectionViewFlowLayout`.
+    /// - Parameters:
+    ///   - message: The `MessageType` whose attributes to cache.
+    ///
+    /// The default value returned by this method is `false`.
+    func shouldCacheLayoutAttributes(for message: MessageType) -> Bool
+
 }
 
 public extension MessagesLayoutDelegate {
@@ -219,6 +227,10 @@ public extension MessagesLayoutDelegate {
 
     func footerViewSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize {
         return .zero
+    }
+
+    func shouldCacheLayoutAttributes(for message: MessageType) -> Bool {
+        return false
     }
 
     // MARK: - Text Messages Defaults


### PR DESCRIPTION
Resolves #306. We no longer do any caching by default. This will resolve a lot of issues people are experiencing and eliminate the need to use the `(messagesCollectionView.collectionViewLayout as! MessagesCollectionViewFlowLayout).attributesCacheMaxSize = 0` workaround.

TODO:
- [x] CHANGELOG entry