### PR TITLE
Fix MessageInputBar bottomAnchor issue

### DIFF
--- a/Sources/Views/MessageInputBar.swift
+++ b/Sources/Views/MessageInputBar.swift
@@ -553,6 +553,7 @@ open class MessageInputBar: UIView {
                 guard superview != nil else { return }
                 topStackView.layoutIfNeeded()
             }
+            invalidateIntrinsicContentSize()
         }
         
         performLayout(animated) {


### PR DESCRIPTION
This #359 is correct, I forgot to add `invalidateIntrinsicContentSize` in #358 

It needs when changed keyboard style.