### PR TITLE
Update swiftlint conf to exclude unneeded sorces

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,13 +1,16 @@
 
 disabled_rules:
-- identifier_name
-- trailing_whitespace
-- line_length
-- type_body_length
-- file_length
+  - identifier_name
+  - trailing_whitespace
+  - line_length
+  - type_body_length
+  - file_length
 custom_rules:
   override_func: # rule identifier
     name: "override in func" # rule name. optional.
     regex: "override (open|public|private|internal|fileprivate)" # matching pattern
     message: "Use like open override or public override instead" # violation message. optional.
     severity: warning # violation severity. optional.
+included:
+  - Sources
+  - Tests


### PR DESCRIPTION
Only included needed Paths, exclude any other like `Carthage`..... to avoid issues because of third parties.
#368 