### PR TITLE
update Example podfile :path value

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -2,14 +2,14 @@ platform :ios, '9.0'
 
 target 'ChatExample' do
   use_frameworks!
-  pod 'MessageKit', :path => '../MessageKit.podspec'
+  pod 'MessageKit', :path => '../'
 
-  target 'ChatExampleTests' do
-    inherit! :search_paths
-  end
+target 'ChatExampleTests' do
+  inherit! :search_paths
+end
 
-  target 'ChatExampleUITests' do
-    inherit! :search_paths
-  end
+target 'ChatExampleUITests' do
+  inherit! :search_paths
+end
 
 end


### PR DESCRIPTION
[`:path`](https://guides.cocoapods.org/using/the-podfile.html#using-the-files-from-a-folder-local-to-the-machine) should set a `folder` name in my opinion. Using the file name `../MessageKit.podspec` may be leads to download from `cocoapods`.