### PR TITLE
Bug fix to the access level of MessageKitDateFormatter singleton 'sha…

### DIFF
--- a/Sources/Models/MessageKitDateFormatter.swift
+++ b/Sources/Models/MessageKitDateFormatter.swift
@@ -28,7 +28,7 @@ open class MessageKitDateFormatter {
 
     // MARK: - Properties
 
-    static let shared = MessageKitDateFormatter()
+    public static let shared = MessageKitDateFormatter()
 
     private let formatter = DateFormatter()
 


### PR DESCRIPTION
…red'

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This implementation fixes a bug in the API, and allows third-party Developers to access the singleton easily

Does this close any currently open issues?
------------------------------------------
I don't think so


Any relevant logs, error output, etc?
-------------------------------------
<!--
'shared' is inaccessible due to 'internal' protection level'
-->


Where has this been tested?
---------------------------
Tested on: iPhone-x Simulator

IOS 11 11

Swift 4

**MessageKit Version:**  0.11
