### PR TITLE
Add a contentView to make managing constraints easier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - **Breaking Change** Changed the name of  `MessageInputBar`'s property `maxHeight` to `maxTextViewHeight` as the property is the max height the `InputTextView` can have, not the `MessageInputBar` itself.
 [#380](https://github.com/MessageKit/MessageKit/pull/380) by [@nathantannar4](https://github.com/nathantannar4).
 
+- **Breaking Change**  Adds a new view `contentView` of type `UIView` to the MessageInputBar to hold the main subviews of the `MessageInputBar`. Reduces complexity of constraints for easier testing/debugging.
+[#384](https://github.com/MessageKit/MessageKit/pull/384) by [@nathantannar4](https://github.com/nathantannar4).
+
 ## [[Prerelease] 0.11.0](https://github.com/MessageKit/MessageKit/releases/tag/0.11.0)
 
 ### Added

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - MessageKit (0.10.2)
+  - MessageKit (0.11.0)
 
 DEPENDENCIES:
-  - MessageKit (from `../MessageKit.podspec`)
+  - MessageKit (from `../`)
 
 EXTERNAL SOURCES:
   MessageKit:
-    :path: ../MessageKit.podspec
+    :path: ../
 
 SPEC CHECKSUMS:
-  MessageKit: a1e8d0f1d7785891e4b37f6252898f23cd8f8b6a
+  MessageKit: 96caa3ba2c32f9393b406256c5caa29ae9189d71
 
-PODFILE CHECKSUM: 9ac65b8dedf0e1b63fea245b089b6645c4e66309
+PODFILE CHECKSUM: cecdb7bc8129cf99f66de9f68eea3256fec30c3d
 
 COCOAPODS: 1.3.1

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -74,12 +74,12 @@ class ConversationViewController: MessagesViewController {
         
         defer {
             isTyping = !isTyping
-            messageInputBar.layoutStackViews([.top])
         }
         
         if isTyping {
             
             messageInputBar.topStackView.arrangedSubviews.first?.removeFromSuperview()
+            messageInputBar.topStackViewPadding = .zero
             
         } else {
             
@@ -89,9 +89,10 @@ class ConversationViewController: MessagesViewController {
             messageInputBar.topStackView.addArrangedSubview(label)
             
             
-//            messageInputBar.topStackViewPadding.top = 6
-//            messageInputBar.topStackViewPadding.left = 12
-            // The backgroundView doesn't include the topStackView. This is so things in the topStackView can have transparent backgrounds if you need it that way
+            messageInputBar.topStackViewPadding.top = 6
+            messageInputBar.topStackViewPadding.left = 12
+            
+            // The backgroundView doesn't include the topStackView. This is so things in the topStackView can have transparent backgrounds if you need it that way or another color all together
             messageInputBar.backgroundColor = messageInputBar.backgroundView.backgroundColor
             
         }

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -74,14 +74,12 @@ class ConversationViewController: MessagesViewController {
         
         defer {
             isTyping = !isTyping
+            messageInputBar.layoutStackViews([.top])
         }
         
         if isTyping {
             
-            messageInputBar.topStackView.arrangedSubviews.forEach {
-                messageInputBar.topStackView.removeArrangedSubview($0)
-                $0.removeFromSuperview()
-            }
+            messageInputBar.topStackView.arrangedSubviews.first?.removeFromSuperview()
             
         } else {
             
@@ -91,8 +89,8 @@ class ConversationViewController: MessagesViewController {
             messageInputBar.topStackView.addArrangedSubview(label)
             
             
-            messageInputBar.topStackViewPadding.top = 6
-            messageInputBar.topStackViewPadding.left = 12
+//            messageInputBar.topStackViewPadding.top = 6
+//            messageInputBar.topStackViewPadding.left = 12
             // The backgroundView doesn't include the topStackView. This is so things in the topStackView can have transparent backgrounds if you need it that way
             messageInputBar.backgroundColor = messageInputBar.backgroundView.backgroundColor
             

--- a/Sources/Views/InputStackView.swift
+++ b/Sources/Views/InputStackView.swift
@@ -69,12 +69,4 @@ open class InputStackView: UIStackView {
         distribution = .fill
         alignment = .bottom
     }
-    
-    open override func layoutIfNeeded() {
-        super.layoutIfNeeded()
-        
-        // We need to invalidate the size of the superview (MessageInputBar) in case the subview heights have changed
-        // and thus the superview size needs to change
-        superview?.invalidateIntrinsicContentSize()
-    }
 }

--- a/Sources/Views/MessageInputBar.swift
+++ b/Sources/Views/MessageInputBar.swift
@@ -339,10 +339,10 @@ open class MessageInputBar: UIView {
         backgroundView.addConstraints(topStackView.bottomAnchor, left: leftAnchor, bottom: bottomAnchor, right: rightAnchor)
         
         topStackViewLayoutSet = NSLayoutConstraintSet(
-            top:    topStackView.topAnchor.constraint(equalTo: topAnchor, constant: textViewPadding.top),
+            top:    topStackView.topAnchor.constraint(equalTo: topAnchor, constant: topStackViewPadding.top),
             bottom: topStackView.bottomAnchor.constraint(equalTo: contentView.topAnchor, constant: -padding.top),
-            left:   topStackView.leftAnchor.constraint(equalTo: leftAnchor, constant: textViewPadding.left),
-            right:  topStackView.rightAnchor.constraint(equalTo: rightAnchor, constant: -textViewPadding.right)
+            left:   topStackView.leftAnchor.constraint(equalTo: leftAnchor, constant: topStackViewPadding.left),
+            right:  topStackView.rightAnchor.constraint(equalTo: rightAnchor, constant: -topStackViewPadding.right)
         )
         
         contentViewLayoutSet = NSLayoutConstraintSet(
@@ -358,8 +358,8 @@ open class MessageInputBar: UIView {
             contentViewLayoutSet?.left = contentView.leftAnchor.constraint(equalTo: safeAreaLayoutGuide.leftAnchor, constant: padding.left)
             contentViewLayoutSet?.right = contentView.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor, constant: -padding.right)
             
-            topStackViewLayoutSet?.left = topStackView.leftAnchor.constraint(equalTo: safeAreaLayoutGuide.leftAnchor, constant: textViewPadding.left)
-            topStackViewLayoutSet?.right = topStackView.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor, constant: -textViewPadding.right)
+            topStackViewLayoutSet?.left = topStackView.leftAnchor.constraint(equalTo: safeAreaLayoutGuide.leftAnchor, constant: topStackViewPadding.left)
+            topStackViewLayoutSet?.right = topStackView.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor, constant: -topStackViewPadding.right)
         }
         
         // Constraints Within the contentView

--- a/Sources/Views/MessageInputBar.swift
+++ b/Sources/Views/MessageInputBar.swift
@@ -415,6 +415,7 @@ open class MessageInputBar: UIView {
     
     /// Updates the constraint constants that correspond to the padding UIEdgeInsets
     private func updatePadding() {
+        topStackViewLayoutSet?.bottom?.constant = -padding.top
         contentViewLayoutSet?.top?.constant = padding.top
         contentViewLayoutSet?.left?.constant = padding.left
         contentViewLayoutSet?.right?.constant = -padding.right

--- a/Sources/Views/MessageInputBar.swift
+++ b/Sources/Views/MessageInputBar.swift
@@ -308,13 +308,13 @@ open class MessageInputBar: UIView {
                                                name: .UIDeviceOrientationDidChange, object: nil)
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(MessageInputBar.textViewDidChange),
-                                               name: .UITextViewTextDidChange, object: nil)
+                                               name: .UITextViewTextDidChange, object: inputTextView)
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(MessageInputBar.textViewDidBeginEditing),
-                                               name: .UITextViewTextDidBeginEditing, object: nil)
+                                               name: .UITextViewTextDidBeginEditing, object: inputTextView)
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(MessageInputBar.textViewDidEndEditing),
-                                               name: .UITextViewTextDidEndEditing, object: nil)
+                                               name: .UITextViewTextDidEndEditing, object: inputTextView)
     }
     
     /// Adds all of the subviews


### PR DESCRIPTION
This doesn't change the functionality or how any of the padding works. This just adds a new `contentView` of type UIView to the `MessageInputBar` to hold the main subviews of the `MessageInputBar`. I did this to clean up the way constraints were assigned as they got more complex with the addition of the top `InputStackView`

I also cleaned up some of the documentation.

In short this reduces lines of code and adds more clarity