### PR TITLE
FIx example launch screen icon layout

### DIFF
--- a/Example/Sources/Assets.xcassets/mklogo.imageset/Contents.json
+++ b/Example/Sources/Assets.xcassets/mklogo.imageset/Contents.json
@@ -2,11 +2,11 @@
   "images" : [
     {
       "idiom" : "universal",
-      "filename" : "mklogo.png",
       "scale" : "1x"
     },
     {
       "idiom" : "universal",
+      "filename" : "mklogo.png",
       "scale" : "2x"
     },
     {

--- a/Example/Sources/Base.lproj/LaunchScreen.storyboard
+++ b/Example/Sources/Base.lproj/LaunchScreen.storyboard
@@ -6,7 +6,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -23,15 +22,17 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="mklogo" translatesAutoresizingMaskIntoConstraints="NO" id="NHX-yN-7Jk">
-                                <rect key="frame" x="32" y="98" width="310" height="171"/>
+                                <rect key="frame" x="76" y="99" width="222" height="127"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="222" id="O7O-V2-Dmt"/>
+                                </constraints>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" red="0.24325716495513916" green="0.76319533586502075" blue="0.32751965522766113" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="NHX-yN-7Jk" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leadingMargin" constant="16" id="ak3-MI-1bZ"/>
+                            <constraint firstItem="xb3-aO-Qok" firstAttribute="top" relation="greaterThanOrEqual" secondItem="NHX-yN-7Jk" secondAttribute="bottom" id="1Ce-5w-nEL"/>
+                            <constraint firstItem="NHX-yN-7Jk" firstAttribute="top" secondItem="Llm-lL-Icb" secondAttribute="bottom" priority="750" constant="79" id="ReL-Hv-5uq"/>
                             <constraint firstItem="NHX-yN-7Jk" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="ebx-nK-jHq"/>
-                            <constraint firstItem="NHX-yN-7Jk" firstAttribute="top" secondItem="Llm-lL-Icb" secondAttribute="bottom" constant="78" id="mKL-l2-81o"/>
-                            <constraint firstItem="xb3-aO-Qok" firstAttribute="top" secondItem="NHX-yN-7Jk" secondAttribute="bottom" constant="398" id="mjQ-GM-veo"/>
                         </constraints>
                     </view>
                 </viewController>
@@ -41,6 +42,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="mklogo" width="888" height="255"/>
+        <image name="mklogo" width="444" height="127"/>
     </resources>
 </document>


### PR DESCRIPTION
**Before:**

portait:
<img width="381" alt="portrait-before" src="https://user-images.githubusercontent.com/5061845/33759382-0ab73254-dc3d-11e7-972e-70ed59973006.png">

landscape:
<img width="675" alt="landscape-before" src="https://user-images.githubusercontent.com/5061845/33759389-11b1ab48-dc3d-11e7-8019-3d23f920a267.png">

**After:**

portrait:
<img width="381" alt="portrait-after" src="https://user-images.githubusercontent.com/5061845/33759415-2a763c0c-dc3d-11e7-8a41-acc1018ce86f.png">

landscape:
<img width="678" alt="landscape-after" src="https://user-images.githubusercontent.com/5061845/33759421-31bec3f8-dc3d-11e7-83ec-087902be0d71.png">

