### PR TITLE
Adjust messageInputBar's height when traitCollection changed

### DIFF
--- a/Sources/Views/MessageInputBar.swift
+++ b/Sources/Views/MessageInputBar.swift
@@ -460,7 +460,6 @@ open class MessageInputBar: UIView {
         var inputTextViewHeight = requiredInputTextViewHeight
         if inputTextViewHeight >= maxTextViewHeight {
             if !isOverMaxTextViewHeight {
-                textViewHeightAnchor?.constant = maxTextViewHeight
                 textViewHeightAnchor?.isActive = true
                 inputTextView.isScrollEnabled = true
                 isOverMaxTextViewHeight = true


### PR DESCRIPTION
1. Change orientation observe  to traitCollection.
2. Adjust messageInputBar's height automatically when traitCollection changed.
3. Don't adjust messageInputBar's height automatically when user set `maxTextViewHeight`, wether or not to adjust up to user.

#386 