### PR TITLE
Allow detector attributes to be set outside of cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 
+### Added
+
+- Added `detectorAttributes(for:and:at:)` method to `MessagesDisplayDelegate` allowing `DetectorType`
+attributes to be set outside of the cell.
+[#397](https://github.com/MessageKit/MessageKit/pull/397) by [@SD10](https://github.com/sd10).
+
 ### Changed
+
+- **Breaking Change** The `MessageLabel` properties `addressAttributes`, `dateAttributes`, `phoneNumberAttributes`,
+and `urlAttributes` are now read only. Please use `setAttributes(_:detector:)` to set these properties. 
+[#397](https://github.com/MessageKit/MessageKit/pull/397) by [@SD10](https://github.com/sd10).
 
 - **Breaking Change** Removed the generic constraint `<ContentView: UIView>` from `MessageCollectionViewCell`.
 [#391](https://github.com/MessageKit/MessageKit/pull/391) by [@SD10](https://github.com/sd10).

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -281,14 +281,24 @@ extension ConversationViewController: MessagesDataSource {
 
 extension ConversationViewController: MessagesDisplayDelegate {
 
+    // MARK: - Text Messages
+
+    func textColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
+        return isFromCurrentSender(message: message) ? .white : .darkText
+    }
+
+    func detectorAttributes(for detector: DetectorType, and message: MessageType, at indexPath: IndexPath) -> [NSAttributedStringKey : Any] {
+        return [.foregroundColor: UIColor.darkText, .underlineStyle: NSUnderlineStyle.styleSingle.rawValue]
+    }
+
+    func enabledDetectors(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> [DetectorType] {
+        return [.url, .address, .phoneNumber, .date]
+    }
+
     // MARK: - All Messages
     
     func backgroundColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
         return isFromCurrentSender(message: message) ? UIColor(red: 69/255, green: 193/255, blue: 89/255, alpha: 1) : UIColor(red: 230/255, green: 230/255, blue: 230/255, alpha: 1)
-    }
-
-    func textColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
-        return isFromCurrentSender(message: message) ? .white : .darkText
     }
 
     func messageStyle(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageStyle {
@@ -325,10 +335,6 @@ extension ConversationViewController: MessagesDisplayDelegate {
 // MARK: - MessagesLayoutDelegate
 
 extension ConversationViewController: MessagesLayoutDelegate {
-
-    func enabledDetectors(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> [DetectorType] {
-        return [.url, .address, .phoneNumber, .date]
-    }
 
     func avatarPosition(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> AvatarPosition {
         return AvatarPosition(horizontal: .natural, vertical: .messageBottom)

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -243,8 +243,14 @@ extension MessagesViewController: UICollectionViewDataSource {
         switch message.data {
         case .text, .attributedText, .emoji:
             let cell = messagesCollectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
-            let detectors = displayDelegate.enabledDetectors(for: message, at: indexPath, in: messagesCollectionView)
             let textColor = displayDelegate.textColor(for: message, at: indexPath, in: messagesCollectionView)
+            let detectors = displayDelegate.enabledDetectors(for: message, at: indexPath, in: messagesCollectionView)
+            cell.messageLabel.configure {
+                for detector in detectors {
+                    let attributes = displayDelegate.detectorAttributes(for: detector, and: message, at: indexPath)
+                    cell.messageLabel.setAttributes(attributes, detector: detector)
+                }
+            }
             cell.configure(message, textColor, detectors)
             commonConfigure(cell)
             return cell

--- a/Sources/Protocols/MessagesDisplayDelegate.swift
+++ b/Sources/Protocols/MessagesDisplayDelegate.swift
@@ -110,6 +110,15 @@ public protocol MessagesDisplayDelegate: AnyObject {
     /// The default value returned by this method is all available detector types.
     func enabledDetectors(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> [DetectorType]
 
+    /// Specifies the attributes for a given `DetectorType`
+    ///
+    /// - Parameters:
+    ///   - detector: The `DetectorType` for the applied attributes.
+    ///   - message: A `MessageType` with a `MessageData` case of `.text` or `.attributedText`
+    ///   to which the detectors will apply.
+    ///   - indexPath: The `IndexPath` of the cell.
+    func detectorAttributes(for detector: DetectorType, and message: MessageType, at indexPath: IndexPath) -> [NSAttributedStringKey: Any]
+
     // MARK: - Location Messages
 
     /// Ask the delegate for a LocationMessageSnapshotOptions instance to customize the MapView on the given message
@@ -194,6 +203,10 @@ public extension MessagesDisplayDelegate {
 
     func enabledDetectors(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> [DetectorType] {
         return []
+    }
+
+    func detectorAttributes(for detector: DetectorType, and message: MessageType, at indexPath: IndexPath) -> [NSAttributedStringKey: Any] {
+        return [:]
     }
 
     // MARK: - Location Messages Defaults

--- a/Sources/Views/Cells/TextMessageCell.swift
+++ b/Sources/Views/Cells/TextMessageCell.swift
@@ -67,7 +67,9 @@ open class TextMessageCell: MessageCollectionViewCell {
         messageLabel.fillSuperview()
     }
 
-    open func configure(_ message: MessageType, _ textColor: UIColor, _ detectors: [DetectorType]) {
+    open func configure(_ message: MessageType,
+                        _ textColor: UIColor,
+                        _ detectors: [DetectorType]) {
 
         messageLabel.configure {
             messageLabel.textColor = textColor


### PR DESCRIPTION
This would resolve #237. It's still in progress because I haven't decided on the API.

I also need to think of a better way to configure the cells because I'm not happy with the function signatures on all the `configure(_:...)` methods of `MessageCollectionViewCell` subclasses.

### TODO
- [x] CHANGELOG
- [x] Finalize API