### PR TITLE
Remove useless guard and fix issue #403

### DIFF
--- a/Sources/Views/MessageInputBar.swift
+++ b/Sources/Views/MessageInputBar.swift
@@ -520,7 +520,6 @@ open class MessageInputBar: UIView {
                     $0.parentStackViewPosition = position
                     leftStackView.addArrangedSubview($0)
                 }
-                guard superview != nil else { return }
                 leftStackView.layoutIfNeeded()
             case .right:
                 rightStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
@@ -530,7 +529,6 @@ open class MessageInputBar: UIView {
                     $0.parentStackViewPosition = position
                     rightStackView.addArrangedSubview($0)
                 }
-                guard superview != nil else { return }
                 rightStackView.layoutIfNeeded()
             case .bottom:
                 bottomStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
@@ -540,7 +538,6 @@ open class MessageInputBar: UIView {
                     $0.parentStackViewPosition = position
                     bottomStackView.addArrangedSubview($0)
                 }
-                guard superview != nil else { return }
                 bottomStackView.layoutIfNeeded()
             case .top:
                 topStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
@@ -550,7 +547,6 @@ open class MessageInputBar: UIView {
                     $0.parentStackViewPosition = position
                     topStackView.addArrangedSubview($0)
                 }
-                guard superview != nil else { return }
                 topStackView.layoutIfNeeded()
             }
             invalidateIntrinsicContentSize()


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Ensure that bar height is calculated correctly even if the setup is made before view appearance.

Does this close any currently open issues?
------------------------------------------
#403 


Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 8 (Simulator)

**iOS Version:** 11.2

**Swift Version:** 4.0

**MessageKit Version:** 0.11

