### PR TITLE
Resize imageMask instead of reapplying style

### DIFF
--- a/Sources/Views/MessageContainerView.swift
+++ b/Sources/Views/MessageContainerView.swift
@@ -30,38 +30,49 @@ open class MessageContainerView: UIImageView {
 
     private let imageMask = UIImageView()
 
-    open override var frame: CGRect {
-        didSet {
-            applyMessageStyle()
-        }
-    }
-
     open var style: MessageStyle = .none {
         didSet {
             applyMessageStyle()
         }
     }
 
+    open override var frame: CGRect {
+        didSet {
+            sizeMaskToView()
+        }
+    }
+
     // MARK: - Methods
+
+    private func sizeMaskToView() {
+        switch style {
+        case .none, .custom:
+            break
+        case .bubble, .bubbleTail:
+            imageMask.frame = bounds
+        case .bubbleOutline, .bubbleTailOutline:
+            imageMask.frame = bounds.insetBy(dx: 1.0, dy: 1.0)
+        }
+    }
 
     private func applyMessageStyle() {
         switch style {
         case .bubble, .bubbleTail:
             imageMask.image = style.image
-            imageMask.frame = bounds
+            sizeMaskToView()
             mask = imageMask
             image = nil
         case .bubbleOutline(let color):
             let bubbleStyle: MessageStyle = .bubble
             imageMask.image = bubbleStyle.image
-            imageMask.frame = bounds.insetBy(dx: 1.0, dy: 1.0)
+            sizeMaskToView()
             mask = imageMask
             image = style.image
             tintColor = color
         case .bubbleTailOutline(let color, let tail, let corner):
             let bubbleStyle: MessageStyle = .bubbleTailOutline(.white, tail, corner)
             imageMask.image = bubbleStyle.image
-            imageMask.frame = bounds.insetBy(dx: 1.0, dy: 1.0)
+            sizeMaskToView()
             mask = imageMask
             image = style.image
             tintColor = color
@@ -76,5 +87,4 @@ open class MessageContainerView: UIImageView {
             configurationClosure(self)
         }
     }
-
 }


### PR DESCRIPTION
I still want to refactor this to an approach that doesn't use masks, however, this reduces some of the redundant calls to retrieve the image from the bundle.