### PR TITLE
Fix scroll to bottom instead of scroll to bottom bubble

### DIFF
--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -64,20 +64,10 @@ open class MessagesCollectionView: UICollectionView {
     // MARK: - Methods
 
     public func scrollToBottom(animated: Bool = false) {
-        guard let indexPath = indexPathForLastItem else { return }
-        
         let collectionViewContentHeight = collectionViewLayout.collectionViewContentSize.height
-        let isContentTooSmall = (collectionViewContentHeight < bounds.height * 2)
-        
-        if isContentTooSmall {
-            performBatchUpdates(nil) { _ in
-                self.scrollRectToVisible(CGRect(0.0, collectionViewContentHeight - 1.0, 1.0, 1.0), animated: animated)
-            }
-            return
-        }
-        
+
         performBatchUpdates(nil) { _ in
-            self.scrollToItem(at: indexPath, at: .bottom, animated: animated)
+            self.scrollRectToVisible(CGRect(0.0, collectionViewContentHeight - 1.0, 1.0, 1.0), animated: animated)
         }
     }
 


### PR DESCRIPTION
#404 

Maybe we can always `scrollRectToVisible` instead of `scrollToItem`.