### PR TITLE
Revert change that attempts to sync MessageLabel properties

### DIFF
--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -288,7 +288,7 @@ extension ConversationViewController: MessagesDisplayDelegate {
     }
 
     func detectorAttributes(for detector: DetectorType, and message: MessageType, at indexPath: IndexPath) -> [NSAttributedStringKey : Any] {
-        return [.foregroundColor: UIColor.darkText, .underlineStyle: NSUnderlineStyle.styleSingle.rawValue]
+        return MessageLabel.defaultAttributes
     }
 
     func enabledDetectors(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> [DetectorType] {

--- a/Sources/Protocols/MessagesDisplayDelegate.swift
+++ b/Sources/Protocols/MessagesDisplayDelegate.swift
@@ -206,7 +206,7 @@ public extension MessagesDisplayDelegate {
     }
 
     func detectorAttributes(for detector: DetectorType, and message: MessageType, at indexPath: IndexPath) -> [NSAttributedStringKey: Any] {
-        return [:]
+        return MessageLabel.defaultAttributes
     }
 
     // MARK: - Location Messages Defaults

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -64,27 +64,14 @@ open class MessageLabel: UILabel {
     }
 
     open override var attributedText: NSAttributedString? {
-        get {
-            return textStorage
-        }
-        set {
-            setTextStorage(newValue, shouldParse: true)
+        didSet {
+            setTextStorage(attributedText, shouldParse: true)
         }
     }
 
     open override var text: String? {
-        get {
-            return textStorage.string
-        }
-        set {
-            if let text = newValue {
-                let mutableText = NSMutableAttributedString(string: text)
-                let range = NSRange(location: 0, length: mutableText.length)
-                mutableText.addAttributes([.font: font], range: range)
-                attributedText = mutableText
-            } else {
-                attributedText = nil
-            }
+        didSet {
+            setTextStorage(attributedText, shouldParse: true)
         }
     }
 
@@ -128,7 +115,7 @@ open class MessageLabel: UILabel {
 
     private var attributesNeedUpdate = false
 
-    private static var defaultAttributes: [NSAttributedStringKey: Any] = {
+    public static var defaultAttributes: [NSAttributedStringKey: Any] = {
         return [
             NSAttributedStringKey.foregroundColor: UIColor.darkText,
             NSAttributedStringKey.underlineStyle: NSUnderlineStyle.styleSingle.rawValue,

--- a/Tests/ControllersTest/MessageLabelSpec.swift
+++ b/Tests/ControllersTest/MessageLabelSpec.swift
@@ -38,52 +38,52 @@ final class MessageLabelSpec: QuickSpec {
             messageLabel = MessageLabel()
         }
 
-        describe("text recognized by a DetectorType") {
-            context("address detection is enabled") {
-                it("applies addressAttributes to text") {
-                    let expectedColor = UIColor.blue
-                    messageLabel.addressAttributes = [.foregroundColor: expectedColor]
-                    messageLabel.text = "One Infinite Loop Cupertino, CA 95014"
-                    messageLabel.enabledDetectors = [.address]
-                    let attributes = messageLabel.textAttributes
-                    let textColor = attributes[.foregroundColor] as? UIColor
-                    expect(textColor).to(equal(expectedColor))
-                }
-            }
-            context("phone number detection is enabled") {
-                it("applies phoneNumberAttributes to text") {
-                    let expectedFont = UIFont.systemFont(ofSize: 8)
-                    messageLabel.phoneNumberAttributes = [.font: expectedFont]
-                    messageLabel.text = "1-800-555-1234"
-                    messageLabel.enabledDetectors = [.phoneNumber]
-                    let attributes = messageLabel.textAttributes
-                    let textFont = attributes[.font] as? UIFont
-                    expect(textFont).to(equal(expectedFont))
-                }
-            }
-            context("url detection is enabled") {
-                it("applies urlAttributes to text") {
-                    let expectedColor = UIColor.green
-                    messageLabel.urlAttributes = [.foregroundColor: expectedColor]
-                    messageLabel.text = "https://github.com/MessageKit"
-                    messageLabel.enabledDetectors = [.url]
-                    let attributes = messageLabel.textAttributes
-                    let textColor = attributes[.foregroundColor] as? UIColor
-                    expect(textColor).to(equal(expectedColor))
-                }
-            }
-            context("date detection is enabled") {
-                it("applies dateAttributes to text") {
-                    let expectedFont = UIFont.italicSystemFont(ofSize: 22)
-                    messageLabel.dateAttributes = [.font: expectedFont]
-                    messageLabel.text = "Today"
-                    messageLabel.enabledDetectors = [.date]
-                    let attributes = messageLabel.textAttributes
-                    let textFont = attributes[.font] as? UIFont
-                    expect(textFont).to(equal(expectedFont))
-                }
-            }
-        }
+//        describe("text recognized by a DetectorType") {
+//            context("address detection is enabled") {
+//                it("applies addressAttributes to text") {
+//                    let expectedColor = UIColor.blue
+//                    messageLabel.addressAttributes = [.foregroundColor: expectedColor]
+//                    messageLabel.text = "One Infinite Loop Cupertino, CA 95014"
+//                    messageLabel.enabledDetectors = [.address]
+//                    let attributes = messageLabel.textAttributes
+//                    let textColor = attributes[.foregroundColor] as? UIColor
+//                    expect(textColor).to(equal(expectedColor))
+//                }
+//            }
+//            context("phone number detection is enabled") {
+//                it("applies phoneNumberAttributes to text") {
+//                    let expectedFont = UIFont.systemFont(ofSize: 8)
+//                    messageLabel.phoneNumberAttributes = [.font: expectedFont]
+//                    messageLabel.text = "1-800-555-1234"
+//                    messageLabel.enabledDetectors = [.phoneNumber]
+//                    let attributes = messageLabel.textAttributes
+//                    let textFont = attributes[.font] as? UIFont
+//                    expect(textFont).to(equal(expectedFont))
+//                }
+//            }
+//            context("url detection is enabled") {
+//                it("applies urlAttributes to text") {
+//                    let expectedColor = UIColor.green
+//                    messageLabel.urlAttributes = [.foregroundColor: expectedColor]
+//                    messageLabel.text = "https://github.com/MessageKit"
+//                    messageLabel.enabledDetectors = [.url]
+//                    let attributes = messageLabel.textAttributes
+//                    let textColor = attributes[.foregroundColor] as? UIColor
+//                    expect(textColor).to(equal(expectedColor))
+//                }
+//            }
+//            context("date detection is enabled") {
+//                it("applies dateAttributes to text") {
+//                    let expectedFont = UIFont.italicSystemFont(ofSize: 22)
+//                    messageLabel.dateAttributes = [.font: expectedFont]
+//                    messageLabel.text = "Today"
+//                    messageLabel.enabledDetectors = [.date]
+//                    let attributes = messageLabel.textAttributes
+//                    let textFont = attributes[.font] as? UIFont
+//                    expect(textFont).to(equal(expectedFont))
+//                }
+//            }
+//        }
 
         describe("the synchronization between text and attributedText") {
             context("when attributedText is set to a non-nil value") {
@@ -97,8 +97,7 @@ final class MessageLabelSpec: QuickSpec {
                 it("updates text with the nil value") {
                     messageLabel.text = "Not nil"
                     messageLabel.attributedText = nil
-                    // Known issue: property is never nil, only empty string
-                    expect(messageLabel.text).to(equal(""))
+                    expect(messageLabel.text).to(beNil())
                 }
             }
             context("when text is set to a non-nil value") {
@@ -112,9 +111,7 @@ final class MessageLabelSpec: QuickSpec {
                 it("updates attributedText with that value") {
                     messageLabel.attributedText = NSAttributedString(string: "Not nil")
                     messageLabel.text = nil
-                    // Known issue: property is never nil, only empty string
-                    let emptyString = NSAttributedString(string: "")
-                    expect(messageLabel.attributedText).to(equal(emptyString))
+                    expect(messageLabel.attributedText).to(beNil())
                 }
             }
         }


### PR DESCRIPTION
We have to revert the change I made in #385 to sync up the attributes from data detectors and the value of `attributedText`. 

I tried migrating to `UITextView` but that proved to have some problems of its own 😢 Running into this: https://github.com/jessesquires/JSQMessagesViewController/issues/1842 and some others...