### PR TITLE
Fix attributedText messageLabelFont bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ attributes to be set outside of the cell.
 - Fixed `scrollToBottom(animated:)` not work in some situations.
 [#395](https://github.com/MessageKit/MessageKit/issues/395) by [@zhongwuzw](https://github.com/zhongwuzw).
 
+- Fixed a bug where new messages using `.attributedText(NSAttributedString)` have the incorrect font.
+[#412](https://github.com/MessageKit/MessageKit/issues/412) by [@SD10](https://github.com/sd10).
+
 ### Changed
 
 - **Breaking Change** The `MessageLabel` properties `addressAttributes`, `dateAttributes`, `phoneNumberAttributes`,

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -343,8 +343,6 @@ extension ConversationViewController: MessagesDisplayDelegate {
             }, completion: nil)
         }
     }
-
-
 }
 
 // MARK: - MessagesLayoutDelegate
@@ -441,7 +439,10 @@ extension ConversationViewController: MessageLabelDelegate {
 extension ConversationViewController: MessageInputBarDelegate {
 
     func messageInputBar(_ inputBar: MessageInputBar, didPressSendButtonWith text: String) {
-        messageList.append(MockMessage(text: text, sender: currentSender(), messageId: UUID().uuidString, date: Date()))
+        let attributedText = NSAttributedString(string: text, attributes: [.font: UIFont.systemFont(ofSize: 8), .foregroundColor: UIColor.blue])
+        let id = UUID().uuidString
+        let message = MockMessage(attributedText: attributedText, sender: currentSender(), messageId: id, date: Date())
+        messageList.append(message)
         inputBar.inputTextView.text = String()
         messagesCollectionView.insertSections([messageList.count - 1])
         messagesCollectionView.scrollToBottom()

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -279,8 +279,13 @@ fileprivate extension MessagesCollectionViewFlowLayout {
         switch intermediateAttributes.message.data {
         case .emoji:
             attributes.messageLabelFont = emojiLabelFont
-        default:
+        case .text:
             attributes.messageLabelFont = messageLabelFont
+        case .attributedText(let text):
+            guard let font = text.attribute(.font, at: 0, effectiveRange: nil) as? UIFont else { return }
+            attributes.messageLabelFont = font
+        default:
+            break
         }
 
     }


### PR DESCRIPTION
This resolves a bug when sending a new message using `.attributedText(NSAttributedString)`.

This is caused by `MessagesCollectionView` calling the `TextMessageCell`'s method `configure(with:at:and)` which sets the `attributedText` for `MessageLabel`.

However, afterwards `apply(_ layoutAttributes: UICollectionViewLayoutAttributes)` is called which then results in overwriting the `.font` in the `attributedText` by settings `messageLabel.font` to `MessageCollectionViewLayoutAttributes.messageLabelFont`. 

Therefore, my solution is to extract the `font` inside of the `MessagesCollectionViewFlowLayout` object. 