### PR TITLE
Revert to old cell configure API and fix #407

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ attributes to be set outside of the cell.
 - Fixed `scrollToBottom(animated:)` not work in some situations.
 [#395](https://github.com/MessageKit/MessageKit/issues/395) by [@zhongwuzw](https://github.com/zhongwuzw).
 
+- Fixed `.attributedText(NSAttributedString)` messages that were not using the `textColor` from the
+`MessagesDisplayDelegate` method.
+[#414](https://github.com/MessageKit/MessageKit/issues/414) by [@SD10](https://github.com/sd10).
+
 ### Changed
 
 - **Breaking Change** The `MessageLabel` properties `addressAttributes`, `dateAttributes`, `phoneNumberAttributes`,
@@ -35,11 +39,6 @@ and `urlAttributes` are now read only. Please use `setAttributes(_:detector:)` t
 [#397](https://github.com/MessageKit/MessageKit/pull/397) by [@SD10](https://github.com/sd10).
 
 - **Breaking Change** Removed the generic constraint `<ContentView: UIView>` from `MessageCollectionViewCell`.
-[#391](https://github.com/MessageKit/MessageKit/pull/391) by [@SD10](https://github.com/sd10).
-
-- **Breaking Change** The `configure(message:indexPath:messagesCollectionView)` method of `LocationMessageCell`,
-`MediaMessageCell`, `TextMessageCell`, and `MessageCollectionViewCell` has been replaced by methods that take the
-delegate return values as arguments.
 [#391](https://github.com/MessageKit/MessageKit/pull/391) by [@SD10](https://github.com/sd10).
 
 - **Breaking Change** The `contentView` property has been renamed to `imageView` for `LocationMessageCell` and `MediaMessageCell`

--- a/Example/Sources/IMessageViewController.swift
+++ b/Example/Sources/IMessageViewController.swift
@@ -1,0 +1,54 @@
+//
+//  IMessageViewController.swift
+//  ChatExample
+//
+//  Created by Steven Deutsch on 12/17/17.
+//  Copyright © 2017 MessageKit. All rights reserved.
+//
+
+import MessageKit
+
+class IMessageViewController: MessagesViewController {
+
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        iMessage()
+    }
+
+    func defaultStyle() {
+        let newMessageInputBar = MessageInputBar()
+        newMessageInputBar.sendButton.tintColor = UIColor(red: 69/255, green: 193/255, blue: 89/255, alpha: 1)
+        //newMessageInputBar.delegate = self
+        messageInputBar = newMessageInputBar
+        reloadInputViews()
+    }
+
+    func iMessage() {
+        defaultStyle()
+        messageInputBar.isTranslucent = false
+        messageInputBar.backgroundView.backgroundColor = .red
+        messageInputBar.separatorLine.isHidden = true
+        messageInputBar.inputTextView.backgroundColor = UIColor(red: 245/255, green: 245/255, blue: 245/255, alpha: 1)
+        messageInputBar.inputTextView.placeholderTextColor = UIColor(red: 0.6, green: 0.6, blue: 0.6, alpha: 1)
+        messageInputBar.inputTextView.textContainerInset = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 36)
+        messageInputBar.inputTextView.placeholderLabelInsets = UIEdgeInsets(top: 8, left: 20, bottom: 8, right: 36)
+        messageInputBar.inputTextView.layer.borderColor = UIColor(red: 200/255, green: 200/255, blue: 200/255, alpha: 1).cgColor
+        messageInputBar.inputTextView.layer.borderWidth = 1.0
+        messageInputBar.inputTextView.layer.cornerRadius = 16.0
+        messageInputBar.inputTextView.layer.masksToBounds = true
+        messageInputBar.inputTextView.scrollIndicatorInsets = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
+        messageInputBar.setRightStackViewWidthConstant(to: 36, animated: false)
+        messageInputBar.setStackViewItems([messageInputBar.sendButton], forStack: .right, animated: true)
+        messageInputBar.sendButton.imageView?.backgroundColor = UIColor(red: 69/255, green: 193/255, blue: 89/255, alpha: 1)
+        messageInputBar.sendButton.contentEdgeInsets = UIEdgeInsets(top: 2, left: 2, bottom: 2, right: 2)
+        messageInputBar.sendButton.setSize(CGSize(width: 36, height: 36), animated: true)
+        messageInputBar.sendButton.image = #imageLiteral(resourceName: "ic_up")
+        messageInputBar.sendButton.title = nil
+        messageInputBar.sendButton.imageView?.layer.cornerRadius = 16
+        messageInputBar.sendButton.backgroundColor = .clear
+        messageInputBar.textViewPadding.right = -38
+        messageInputBar.textViewPadding.top = 20
+    }
+
+}

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -221,51 +221,20 @@ extension MessagesViewController: UICollectionViewDataSource {
             fatalError("MessagesDataSource has not been set.")
         }
 
-        guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {
-            fatalError("MessagesDisplayDelegate has not been set.")
-        }
-
         let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
-        let avatar = messagesDataSource.avatar(for: message, at: indexPath, in: messagesCollectionView)
-        let bottomText = messagesDataSource.cellBottomLabelAttributedText(for: message, at: indexPath)
-        let topText = messagesDataSource.cellTopLabelAttributedText(for: message, at: indexPath)
-        let style = displayDelegate.messageStyle(for: message, at: indexPath, in: messagesCollectionView)
-        let backgroundColor = displayDelegate.backgroundColor(for: message, at: indexPath, in: messagesCollectionView)
-
-        let commonConfigure = { (cell: MessageCollectionViewCell) in
-            cell.messageContainerView.style = style
-            cell.messageContainerView.backgroundColor = backgroundColor
-            cell.configureAvatar(avatar)
-            cell.configureAccessoryLabels(topText, bottomText)
-            cell.delegate = messagesCollectionView.messageCellDelegate
-        }
 
         switch message.data {
         case .text, .attributedText, .emoji:
             let cell = messagesCollectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
-            let textColor = displayDelegate.textColor(for: message, at: indexPath, in: messagesCollectionView)
-            let detectors = displayDelegate.enabledDetectors(for: message, at: indexPath, in: messagesCollectionView)
-            cell.messageLabel.configure {
-                for detector in detectors {
-                    let attributes = displayDelegate.detectorAttributes(for: detector, and: message, at: indexPath)
-                    cell.messageLabel.setAttributes(attributes, detector: detector)
-                }
-            }
-            cell.configure(message, textColor, detectors)
-            commonConfigure(cell)
+            cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         case .photo, .video:
     	    let cell = messagesCollectionView.dequeueReusableCell(MediaMessageCell.self, for: indexPath)
-            cell.configure(message)
-            commonConfigure(cell)
+            cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
-        case .location(let location):
+        case .location:
     	    let cell = messagesCollectionView.dequeueReusableCell(LocationMessageCell.self, for: indexPath)
-            let options = displayDelegate.snapshotOptionsForLocation(message: message, at: indexPath, in: messagesCollectionView)
-            let annotationView = displayDelegate.annotationViewForLocation(message: message, at: indexPath, in: messagesCollectionView)
-            let animationBlock = displayDelegate.animationBlockForLocation(message: message, at: indexPath, in: messagesCollectionView)
-            cell.configure(location, options, annotationView, animationBlock)
-            commonConfigure(cell)
+            cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         }
     }

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -302,12 +302,12 @@ fileprivate extension MessagesViewController {
             let afterBottomInset = keyboardEndFrame.height > keyboardOffsetFrame.height ? (keyboardEndFrame.height - iPhoneXBottomInset) : keyboardOffsetFrame.height
             let differenceOfBottomInset = afterBottomInset - messageCollectionViewBottomInset
             let contentOffset = CGPoint(x: messagesCollectionView.contentOffset.x, y: messagesCollectionView.contentOffset.y + differenceOfBottomInset)
-            
-            messageCollectionViewBottomInset = afterBottomInset
-            
+
             if maintainPositionOnKeyboardFrameChanged {
                 messagesCollectionView.setContentOffset(contentOffset, animated: false)
             }
+
+            messageCollectionViewBottomInset = afterBottomInset
         }
     }
     

--- a/Sources/Views/Cells/LocationMessageCell.swift
+++ b/Sources/Views/Cells/LocationMessageCell.swift
@@ -35,13 +35,9 @@ open class LocationMessageCell: MessageCollectionViewCell {
 
     open var imageView = UIImageView()
 
-    open func configure(_ location: CLLocation, _ options: LocationMessageSnapshotOptions, _ annotationView: MKAnnotationView?, _ animationBlock: ((UIImageView) -> Void)?) {
-
-        setMapSnaphotImage(for: location, annotationView: annotationView, options: options, animation: animationBlock)
-    }
-
     open override func setupSubviews() {
         super.setupSubviews()
+        imageView.contentMode = .scaleAspectFill
         messageContainerView.addSubview(imageView)
         messageContainerView.addSubview(activityIndicator)
         setupConstraints()
@@ -52,7 +48,16 @@ open class LocationMessageCell: MessageCollectionViewCell {
         activityIndicator.centerInSuperview()
     }
 
-    open func setMapSnaphotImage(for location: CLLocation, annotationView: MKAnnotationView?, options: LocationMessageSnapshotOptions, animation: ((UIImageView) -> Void)?) {
+    open override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
+        super.configure(with: message, at: indexPath, and: messagesCollectionView)
+        guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {
+            fatalError("MessagesDisplayDelegate is not set.")
+        }
+        let options = displayDelegate.snapshotOptionsForLocation(message: message, at: indexPath, in: messagesCollectionView)
+        let annotationView = displayDelegate.annotationViewForLocation(message: message, at: indexPath, in: messagesCollectionView)
+        let animationBlock = displayDelegate.animationBlockForLocation(message: message, at: indexPath, in: messagesCollectionView)
+
+        guard case let .location(location) = message.data else { fatalError("") }
 
         activityIndicator.startAnimating()
 
@@ -92,7 +97,9 @@ open class LocationMessageCell: MessageCollectionViewCell {
 
             UIGraphicsEndImageContext()
             self.imageView.image = composedImage
-            animation?(self.imageView)
+            animationBlock?(self.imageView)
         }
+        
+        
     }
 }

--- a/Sources/Views/Cells/MediaMessageCell.swift
+++ b/Sources/Views/Cells/MediaMessageCell.swift
@@ -52,7 +52,8 @@ open class MediaMessageCell: MessageCollectionViewCell {
         setupConstraints()
     }
 
-    open func configure(_ message: MessageType) {
+    open override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
+        super.configure(with: message, at: indexPath, and: messagesCollectionView)
         switch message.data {
         case .photo(let image):
             imageView.image = image

--- a/Sources/Views/Cells/MessageCollectionViewCell.swift
+++ b/Sources/Views/Cells/MessageCollectionViewCell.swift
@@ -90,11 +90,27 @@ open class MessageCollectionViewCell: UICollectionViewCell, CollectionViewReusab
         }
     }
 
-    open func configureAvatar(_ avatar: Avatar) {
-        avatarView.set(avatar: avatar)
-    }
+    open func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
+        guard let dataSource = messagesCollectionView.messagesDataSource else {
+            fatalError("MessagesDataSource is not set.")
+        }
+        guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {
+            fatalError("MessagesDisplayDelegate is not set.")
+        }
 
-    open func configureAccessoryLabels(_ topText: NSAttributedString?, _ bottomText: NSAttributedString?) {
+        delegate = messagesCollectionView.messageCellDelegate
+
+        let messageColor = displayDelegate.backgroundColor(for: message, at: indexPath, in: messagesCollectionView)
+        let messageStyle = displayDelegate.messageStyle(for: message, at: indexPath, in: messagesCollectionView)
+
+        messageContainerView.backgroundColor = messageColor
+        messageContainerView.style = messageStyle
+
+        let avatar = dataSource.avatar(for: message, at: indexPath, in: messagesCollectionView)
+        let topText = dataSource.cellTopLabelAttributedText(for: message, at: indexPath)
+        let bottomText = dataSource.cellBottomLabelAttributedText(for: message, at: indexPath)
+
+        avatarView.set(avatar: avatar)
         cellTopLabel.attributedText = topText
         cellBottomLabel.attributedText = bottomText
     }


### PR DESCRIPTION
The old API (current `master`) was much better before I changed it during the removal of generic constraint from the `MessagesCollectionViewCell` class.

This also solves #407 where the color returned by `MessagesDisplayDelegate` does not take priority over the font color supplied in `.attributedText(NSAttributedString)`.