### PR TITLE
Add customizable accessoryView besides messageContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 
+### Fixed
+
+- Fixed message bubble tail orientation invalidation in `iOS9`.
+[#469](https://github.com/MessageKit/MessageKit/pull/469) by [@zhongwuzw](https://github.com/zhongwuzw).
+
 ## [[Prerelease] 0.13.0](https://github.com/MessageKit/MessageKit/releases/tag/0.13.0)
 
 ### Fixed

--- a/Example/Sources/InboxViewController.swift
+++ b/Example/Sources/InboxViewController.swift
@@ -28,7 +28,7 @@ import SafariServices
 
 final class InboxViewController: UITableViewController {
 
-    let cells = ["Example", "Settings", "Source Code", "Contributers"]
+    let cells = ["Example", "Settings", "Source Code", "Contributors"]
     
     // MARK: - View Life Cycle
     
@@ -83,7 +83,7 @@ final class InboxViewController: UITableViewController {
             guard let url = URL(string: "https://github.com/MessageKit/MessageKit") else { return }
             let webViewController = SFSafariViewController(url: url)
             present(webViewController, animated: true, completion: nil)
-        case "Contributers":
+        case "Contributors":
             guard let url = URL(string: "https://github.com/orgs/MessageKit/teams/contributors/members") else { return }
             let webViewController = SFSafariViewController(url: url)
             present(webViewController, animated: true, completion: nil)

--- a/Sources/Controllers/MessagesViewController+DataSource.swift
+++ b/Sources/Controllers/MessagesViewController+DataSource.swift
@@ -58,14 +58,17 @@ extension MessagesViewController: UICollectionViewDataSource {
         switch message.data {
         case .text, .attributedText, .emoji:
             let cell = messagesCollectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
+            messagesDataSource.configCell(cell, for: message, at: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         case .photo, .video:
             let cell = messagesCollectionView.dequeueReusableCell(MediaMessageCell.self, for: indexPath)
+            messagesDataSource.configCell(cell, for: message, at: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         case .location:
             let cell = messagesCollectionView.dequeueReusableCell(LocationMessageCell.self, for: indexPath)
+            messagesDataSource.configCell(cell, for: message, at: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         }

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -226,17 +226,17 @@ extension MessagesViewController: UICollectionViewDataSource {
         switch message.data {
         case .text, .attributedText, .emoji:
             let cell = messagesCollectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
-            messagesDataSource.additionalConfig(for: cell, at: indexPath)
+            messagesDataSource.configCell(cell, for: message, at: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         case .photo, .video:
     	    let cell = messagesCollectionView.dequeueReusableCell(MediaMessageCell.self, for: indexPath)
-            messagesDataSource.additionalConfig(for: cell, at: indexPath)
+            messagesDataSource.configCell(cell, for: message, at: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         case .location:
     	    let cell = messagesCollectionView.dequeueReusableCell(LocationMessageCell.self, for: indexPath)
-            messagesDataSource.additionalConfig(for: cell, at: indexPath)
+            messagesDataSource.configCell(cell, for: message, at: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         }

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -226,14 +226,17 @@ extension MessagesViewController: UICollectionViewDataSource {
         switch message.data {
         case .text, .attributedText, .emoji:
             let cell = messagesCollectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
+            messagesDataSource.additionalConfig(for: cell, at: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         case .photo, .video:
     	    let cell = messagesCollectionView.dequeueReusableCell(MediaMessageCell.self, for: indexPath)
+            messagesDataSource.additionalConfig(for: cell, at: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         case .location:
     	    let cell = messagesCollectionView.dequeueReusableCell(LocationMessageCell.self, for: indexPath)
+            messagesDataSource.additionalConfig(for: cell, at: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
         }

--- a/Sources/Layout/MessageIntermediateLayoutAttributes.swift
+++ b/Sources/Layout/MessageIntermediateLayoutAttributes.swift
@@ -98,6 +98,31 @@ final class MessageIntermediateLayoutAttributes {
         
     }()
 
+    // AccessoryView
+    var accessoryViewSize: CGSize = .zero
+    var accessoryViewPadding: UIEdgeInsets = .zero
+
+    lazy var accessoryViewFrame: CGRect = {
+
+        guard accessoryViewSize != .zero else { return .zero }
+
+        var origin: CGPoint = .zero
+
+        origin.y = messageContainerFrame.origin.y + messageContainerSize.height / 2 - accessoryViewSize.height / 2
+
+        switch avatarPosition.horizontal {
+        case .cellLeading:
+            origin.x = messageContainerFrame.origin.x + messageContainerSize.width + accessoryViewPadding.left
+        case .cellTrailing:
+            origin.x = messageContainerFrame.origin.x - accessoryViewPadding.right - accessoryViewSize.width
+        case .natural:
+            fatalError("AvatarPosition Horizontal.natural needs to be resolved.")
+        }
+
+        return CGRect(origin: origin, size: accessoryViewSize)
+
+    }()
+
     // Cell Top Label
     var topLabelAlignment: LabelAlignment = .cellLeading(.zero)
     var topLabelSize: CGSize = .zero
@@ -158,31 +183,6 @@ final class MessageIntermediateLayoutAttributes {
 
     }()
 
-    // AccessoryView
-    var accessoryViewSize: CGSize = .zero
-    var accessoryViewPadding: UIEdgeInsets = .zero
-
-    lazy var accessoryViewFrame: CGRect = {
-
-        guard accessoryViewSize != .zero else { return .zero }
-
-        var origin: CGPoint = .zero
-
-        origin.y = messageContainerFrame.origin.y + messageContainerSize.height / 2 - accessoryViewSize.height / 2
-
-        switch avatarPosition.horizontal {
-        case .cellLeading:
-            origin.x = messageContainerFrame.origin.x + messageContainerSize.width + accessoryViewPadding.left
-        case .cellTrailing:
-            origin.x = messageContainerFrame.origin.x - accessoryViewPadding.right - accessoryViewSize.width
-        case .natural:
-            fatalError("AvatarPosition Horizontal.natural needs to be resolved.")
-        }
-
-        return CGRect(origin: origin, size: accessoryViewSize)
-
-    }()
-
     // MARK: - Initializer
     
     init(message: MessageType, indexPath: IndexPath) {
@@ -194,6 +194,17 @@ final class MessageIntermediateLayoutAttributes {
 
 // MARK: - Helpers
 
+extension UIEdgeInsets {
+    var horizontalTotal: CGFloat {
+        return left + right
+    }
+
+    var verticalTotal: CGFloat {
+        return top + bottom
+    }
+}
+
+// TODO: Replace attributes below with padding.verticalTotal etc because they're too specific
 extension MessageIntermediateLayoutAttributes {
     
     var bottomLabelPadding: UIEdgeInsets {
@@ -227,13 +238,4 @@ extension MessageIntermediateLayoutAttributes {
     var messageLabelHorizontalInsets: CGFloat {
         return messageLabelInsets.left + messageLabelInsets.right
     }
-    
-    var messageVerticalPadding: CGFloat {
-        return messageContainerPadding.top + messageContainerPadding.bottom
-    }
-    
-    var messageHorizontalPadding: CGFloat {
-        return messageContainerPadding.left + messageContainerPadding.right
-    }
-
 }

--- a/Sources/Layout/MessageIntermediateLayoutAttributes.swift
+++ b/Sources/Layout/MessageIntermediateLayoutAttributes.swift
@@ -97,7 +97,7 @@ final class MessageIntermediateLayoutAttributes {
         return CGRect(origin: origin, size: messageContainerSize)
         
     }()
-    
+
     // Cell Top Label
     var topLabelAlignment: LabelAlignment = .cellLeading(.zero)
     var topLabelSize: CGSize = .zero
@@ -157,7 +157,32 @@ final class MessageIntermediateLayoutAttributes {
         return CGRect(origin: origin, size: bottomLabelSize)
 
     }()
-    
+
+    // AccessoryView
+    var accessoryViewSize: CGSize = .zero
+    var accessoryViewPadding: UIEdgeInsets = .zero
+
+    lazy var accessoryViewFrame: CGRect = {
+
+        guard accessoryViewSize != .zero else { return .zero }
+
+        var origin: CGPoint = .zero
+
+        origin.y = messageContainerFrame.origin.y + messageContainerSize.height / 2 - accessoryViewSize.height / 2
+
+        switch avatarPosition.horizontal {
+        case .cellLeading:
+            origin.x = messageContainerFrame.origin.x + messageContainerSize.width + accessoryViewPadding.left
+        case .cellTrailing:
+            origin.x = messageContainerFrame.origin.x - accessoryViewPadding.right - accessoryViewSize.width
+        case .natural:
+            fatalError("AvatarPosition Horizontal.natural needs to be resolved.")
+        }
+
+        return CGRect(origin: origin, size: accessoryViewSize)
+
+    }()
+
     // MARK: - Initializer
     
     init(message: MessageType, indexPath: IndexPath) {

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -238,11 +238,11 @@ fileprivate extension MessagesCollectionViewFlowLayout {
         attributes.avatarSize = avatarSize(for: attributes)
         attributes.messageContainerPadding = messageContainerPadding(for: attributes)
         attributes.messageLabelInsets = messageLabelInsets(for: attributes)
-        
+
         // MessageContainerView
         attributes.messageContainerMaxWidth = messageContainerMaxWidth(for: attributes)
         attributes.messageContainerSize = messageContainerSize(for: attributes)
-        
+
         // Cell Bottom Label
         attributes.bottomLabelAlignment = cellBottomLabelAlignment(for: attributes)
         attributes.bottomLabelMaxWidth = cellBottomLabelMaxWidth(for: attributes)
@@ -255,7 +255,10 @@ fileprivate extension MessagesCollectionViewFlowLayout {
         
         // Cell Height
         attributes.itemHeight = cellHeight(for: attributes)
-        
+
+        // AccessoryView
+        attributes.accessoryViewSize = accessoryViewSize(for: attributes)
+
         return attributes
     }
     
@@ -274,8 +277,9 @@ fileprivate extension MessagesCollectionViewFlowLayout {
         attributes.topLabelFrame = intermediateAttributes.topLabelFrame
         attributes.bottomLabelFrame = intermediateAttributes.bottomLabelFrame
         attributes.avatarFrame = intermediateAttributes.avatarFrame
+        attributes.accessoryViewFrame = intermediateAttributes.accessoryViewFrame
         attributes.messageLabelInsets = intermediateAttributes.messageLabelInsets
-        
+
         switch intermediateAttributes.message.data {
         case .emoji:
             attributes.messageLabelFont = emojiLabelFont
@@ -325,6 +329,20 @@ fileprivate extension MessagesCollectionViewFlowLayout {
         return messagesLayoutDelegate.avatarSize(for: attributes.message, at: attributes.indexPath, in: messagesCollectionView)
     }
     
+}
+
+// MARK: - Accessory View
+
+fileprivate extension MessagesCollectionViewFlowLayout {
+
+    /// Returns the size of the `AccessoryView` for a given `MessageType`.
+    ///
+    /// - Parameters:
+    ///   - attributes: The `MessageIntermediateLayoutAttributes` containing the `MessageType` object.
+    func accessoryViewSize(for attributes: MessageIntermediateLayoutAttributes) -> CGSize {
+        return messagesLayoutDelegate.accessoryViewSize(for: attributes.message, at: attributes.indexPath, in: messagesCollectionView)
+    }
+
 }
 
 // MARK: - General Label Size Calculations

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -233,11 +233,19 @@ fileprivate extension MessagesCollectionViewFlowLayout {
         
         let attributes = MessageIntermediateLayoutAttributes(message: message, indexPath: indexPath)
         
-        // None of these are dependent on other attributes
+        // Attributes that have no dependencies on other attributes
+
+        // Avatar
         attributes.avatarPosition = avatarPosition(for: attributes)
         attributes.avatarSize = avatarSize(for: attributes)
+        // AccessoryView
+        attributes.accessoryViewSize = accessoryViewSize(for: attributes)
+        attributes.accessoryViewPadding = accessoryViewPadding(for: attributes)
+        // MessageContainer & Label
         attributes.messageContainerPadding = messageContainerPadding(for: attributes)
         attributes.messageLabelInsets = messageLabelInsets(for: attributes)
+
+        // Attributes that depends on the above attributes
 
         // MessageContainerView
         attributes.messageContainerMaxWidth = messageContainerMaxWidth(for: attributes)
@@ -255,9 +263,6 @@ fileprivate extension MessagesCollectionViewFlowLayout {
         
         // Cell Height
         attributes.itemHeight = cellHeight(for: attributes)
-
-        // AccessoryView
-        attributes.accessoryViewSize = accessoryViewSize(for: attributes)
 
         return attributes
     }
@@ -343,6 +348,13 @@ fileprivate extension MessagesCollectionViewFlowLayout {
         return messagesLayoutDelegate.accessoryViewSize(for: attributes.message, at: attributes.indexPath, in: messagesCollectionView)
     }
 
+    /// Returns the padding to be used around the `MessageContainerView` for a given `MessageType`.
+    ///
+    /// - Parameters:
+    ///   - attributes: The `MessageIntermediateLayoutAttributes` containing the `MessageType` object.
+    func accessoryViewPadding(for attributes: MessageIntermediateLayoutAttributes) -> UIEdgeInsets {
+        return messagesLayoutDelegate.accessoryViewPadding(for: attributes.message, at: attributes.indexPath, in: messagesCollectionView)
+    }
 }
 
 // MARK: - General Label Size Calculations
@@ -415,12 +427,17 @@ private extension MessagesCollectionViewFlowLayout {
     /// - Parameters:
     ///   - attributes: The `MessageIntermediateLayoutAttributes` to consider when calculating the max width.
     func messageContainerMaxWidth(for attributes: MessageIntermediateLayoutAttributes) -> CGFloat {
-        
+
+        let base: CGFloat = itemWidth
+            - attributes.avatarSize.width
+            - attributes.accessoryViewSize.width - attributes.accessoryViewPadding.horizontalTotal
+            - attributes.messageContainerPadding.horizontalTotal
+
         switch attributes.message.data {
         case .text, .attributedText:
-            return itemWidth - attributes.avatarSize.width - attributes.messageHorizontalPadding - attributes.messageLabelHorizontalInsets
+            return base - attributes.messageLabelHorizontalInsets
         default:
-            return itemWidth - attributes.avatarSize.width - attributes.messageHorizontalPadding
+            return base
         }
         
     }
@@ -635,15 +652,15 @@ private extension MessagesCollectionViewFlowLayout {
             cellHeight += max(attributes.avatarSize.height, attributes.topLabelSize.height)
             cellHeight += attributes.bottomLabelSize.height
             cellHeight += attributes.messageContainerSize.height
-            cellHeight += attributes.messageVerticalPadding
+            cellHeight += attributes.messageContainerPadding.verticalTotal
         case .cellBottom:
             cellHeight += max(attributes.avatarSize.height, attributes.bottomLabelSize.height)
             cellHeight += attributes.topLabelSize.height
             cellHeight += attributes.messageContainerSize.height
-            cellHeight += attributes.messageVerticalPadding
+            cellHeight += attributes.messageContainerPadding.verticalTotal
         case .messageTop, .messageCenter, .messageBottom:
             cellHeight += max(attributes.avatarSize.height, attributes.messageContainerSize.height)
-            cellHeight += attributes.messageVerticalPadding
+            cellHeight += attributes.messageContainerPadding.verticalTotal
             cellHeight += attributes.topLabelSize.height
             cellHeight += attributes.bottomLabelSize.height
         }

--- a/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
+++ b/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
@@ -38,6 +38,8 @@ final class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttrib
     var topLabelFrame: CGRect = .zero
     var bottomLabelFrame: CGRect = .zero
 
+    var accessoryViewFrame: CGRect = .zero
+
     // MARK: - Methods
 
     override func copy(with zone: NSZone? = nil) -> Any {
@@ -49,6 +51,7 @@ final class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttrib
         copy.messageLabelInsets = messageLabelInsets
         copy.topLabelFrame = topLabelFrame
         copy.bottomLabelFrame = bottomLabelFrame
+        copy.accessoryViewFrame = accessoryViewFrame
         return copy
         // swiftlint:enable force_cast
     }

--- a/Sources/Models/MessageStyle.swift
+++ b/Sources/Models/MessageStyle.swift
@@ -89,7 +89,7 @@ public enum MessageStyle {
             image = UIImage(cgImage: cgImage, scale: image.scale, orientation: corner.imageOrientation)
         }
 
-        return stretch(image).withRenderingMode(.alwaysTemplate)
+        return stretch(image)
     }
 
     // MARK: - Private

--- a/Sources/Protocols/MessagesDataSource.swift
+++ b/Sources/Protocols/MessagesDataSource.swift
@@ -81,14 +81,15 @@ public protocol MessagesDataSource: AnyObject {
     /// The default value returned by this method is `nil`.
     func cellBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString?
 
-    /// Additional config for a cell, called in cellForItem method. e.g. customize accessoryView.   
+    /// A chance to config a cell before it's presented e.g. customize accessoryView.
     ///
     /// - Parameters:
     ///   - cell: The `MessageCollectionViewCell` that can be configured.
+    ///   - message: The `MessageType` that will be displayed by this cell.
     ///   - indexPath: The `IndexPath` of the cell.
     ///
     /// The default value returned by this method is `nil`.
-    func additionalConfig(for cell: MessageCollectionViewCell, at indexPath: IndexPath)
+    func configCell(_ cell: MessageCollectionViewCell, for message: MessageType, at indexPath: IndexPath)
 }
 
 public extension MessagesDataSource {
@@ -109,5 +110,5 @@ public extension MessagesDataSource {
         return nil
     }
 
-    func additionalConfig(for cell: MessageCollectionViewCell, at indexPath: IndexPath) {}
+    func configCell(_ cell: MessageCollectionViewCell, for message: MessageType, at indexPath: IndexPath) {}
 }

--- a/Sources/Protocols/MessagesDataSource.swift
+++ b/Sources/Protocols/MessagesDataSource.swift
@@ -81,6 +81,14 @@ public protocol MessagesDataSource: AnyObject {
     /// The default value returned by this method is `nil`.
     func cellBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString?
 
+    /// Additional config for a cell, called in cellForItem method. e.g. customize accessoryView.   
+    ///
+    /// - Parameters:
+    ///   - cell: The `MessageCollectionViewCell` that can be configured.
+    ///   - indexPath: The `IndexPath` of the cell.
+    ///
+    /// The default value returned by this method is `nil`.
+    func additionalConfig(for cell: MessageCollectionViewCell, at indexPath: IndexPath)
 }
 
 public extension MessagesDataSource {
@@ -101,4 +109,5 @@ public extension MessagesDataSource {
         return nil
     }
 
+    func additionalConfig(for cell: MessageCollectionViewCell, at indexPath: IndexPath) {}
 }

--- a/Sources/Protocols/MessagesLayoutDelegate.swift
+++ b/Sources/Protocols/MessagesLayoutDelegate.swift
@@ -242,6 +242,10 @@ public extension MessagesLayoutDelegate {
         return .zero
     }
 
+    func accessoryViewPadding(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIEdgeInsets
+        return .zero
+    }
+
     func headerViewSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize {
         guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else { return .zero }
         let shouldDisplay = displayDelegate.shouldDisplayHeader(for: message, at: indexPath, in: messagesCollectionView)

--- a/Sources/Protocols/MessagesLayoutDelegate.swift
+++ b/Sources/Protocols/MessagesLayoutDelegate.swift
@@ -104,6 +104,16 @@ public protocol MessagesLayoutDelegate: AnyObject {
     /// The default value returned by this method is a size of `30 x 30`.
     func accessoryViewSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize
 
+    /// Specifies the padding around the `AccessoryView` in a `MessageCollectionViewCell`.
+    ///
+    /// - Parameters:
+    ///   - message: The `MessageType` that will be displayed by this cell.
+    ///   - indexPath: The `IndexPath` of the cell.
+    ///   - messagesCollectionView: The `MessagesCollectionView` in which this cell will be displayed.
+    ///
+    /// The default value returned by this method is zero.
+    func accessoryViewPadding(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIEdgeInsets
+
     /// Specifies the size to use for a `MessageHeaderView`.
     ///
     /// - Parameters:

--- a/Sources/Protocols/MessagesLayoutDelegate.swift
+++ b/Sources/Protocols/MessagesLayoutDelegate.swift
@@ -242,7 +242,7 @@ public extension MessagesLayoutDelegate {
         return .zero
     }
 
-    func accessoryViewPadding(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIEdgeInsets
+    func accessoryViewPadding(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIEdgeInsets {
         return .zero
     }
 

--- a/Sources/Protocols/MessagesLayoutDelegate.swift
+++ b/Sources/Protocols/MessagesLayoutDelegate.swift
@@ -94,6 +94,16 @@ public protocol MessagesLayoutDelegate: AnyObject {
     /// The default value returned by this method is a size of `30 x 30`.
     func avatarSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize
 
+    /// Specifies the size of the `AccessoryView` in a `MessageCollectionViewCell`.
+    ///
+    /// - Parameters:
+    ///   - message: The `MessageType` that will be displayed by this cell.
+    ///   - indexPath: The `IndexPath` of the cell.
+    ///   - messagesCollectionView: The `MessagesCollectionView` in which this cell will be displayed.
+    ///
+    /// The default value returned by this method is a size of `30 x 30`.
+    func accessoryViewSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize
+
     /// Specifies the size to use for a `MessageHeaderView`.
     ///
     /// - Parameters:
@@ -216,6 +226,10 @@ public extension MessagesLayoutDelegate {
     
     func avatarPosition(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> AvatarPosition {
         return AvatarPosition(horizontal: .natural, vertical: .messageBottom)
+    }
+
+    func accessoryViewSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize {
+        return .zero
     }
 
     func headerViewSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize {

--- a/Sources/Views/Cells/MessageCollectionViewCell.swift
+++ b/Sources/Views/Cells/MessageCollectionViewCell.swift
@@ -51,6 +51,7 @@ open class MessageCollectionViewCell: UICollectionViewCell, CollectionViewReusab
         return label
     }()
 
+    // Should only add customized subviews, but not change accessoryView itself.
     open var accessoryView: UIView = .init()
 
     open weak var delegate: MessageCellDelegate?

--- a/Sources/Views/Cells/MessageCollectionViewCell.swift
+++ b/Sources/Views/Cells/MessageCollectionViewCell.swift
@@ -51,6 +51,8 @@ open class MessageCollectionViewCell: UICollectionViewCell, CollectionViewReusab
         return label
     }()
 
+    open var accessoryView: UIView = .init()
+
     open weak var delegate: MessageCellDelegate?
 
     override public init(frame: CGRect) {
@@ -69,6 +71,7 @@ open class MessageCollectionViewCell: UICollectionViewCell, CollectionViewReusab
         contentView.addSubview(avatarView)
         contentView.addSubview(cellTopLabel)
         contentView.addSubview(cellBottomLabel)
+        contentView.addSubview(accessoryView)
     }
 
     open override func prepareForReuse() {
@@ -76,6 +79,9 @@ open class MessageCollectionViewCell: UICollectionViewCell, CollectionViewReusab
         cellTopLabel.attributedText = nil
         cellBottomLabel.text = nil
         cellBottomLabel.attributedText = nil
+        for view in accessoryView.subviews {
+            view.removeFromSuperview()
+        }
     }
 
     // MARK: - Configuration
@@ -87,6 +93,7 @@ open class MessageCollectionViewCell: UICollectionViewCell, CollectionViewReusab
             cellTopLabel.frame = attributes.topLabelFrame
             cellBottomLabel.frame = attributes.bottomLabelFrame
             messageContainerView.frame = attributes.messageContainerFrame
+            accessoryView.frame = attributes.accessoryViewFrame
         }
     }
 

--- a/VISION.md
+++ b/VISION.md
@@ -18,7 +18,7 @@ Instead, MessageKit will provide you with hooks to easily handle your different 
 - **iOS version**: 
 We will strive to support the 3 latest versions of iOS.
 
-- **Objective-C Compatability**: 
+- **Objective-C Compatibility**: 
 We will not sacrifice functionality or an idiomatic Swift API to support Objective-C, but would love to improve Objective-C compatability where possible.
 
 - **Layouts**: 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Add an accessoryView and give client a chance to config it to whatever they like (e.g. a button, image etc)

Does this close any currently open issues?
------------------------------------------
And I found one ;) https://github.com/MessageKit/MessageKit/issues/190


Any relevant logs, error output, etc?
-------------------------------------
NA

Any other comments?
-------------------
Let me know how you want to approach it!

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 8+ simulator

**iOS Version:** 11

**Swift Version:** 4

**MessageKit Version:** 0.12

Example screenshot where in configCell added a UIView with green background:

<img width="393" alt="screen shot 2017-12-31 at 1 01 22 pm" src="https://user-images.githubusercontent.com/5061867/34464616-bca7ce96-ee3b-11e7-8feb-c809861d70a3.png">



