### PR TITLE
Bugfix/location message snapshot options inaccessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 
+### Fixed
+
+- Fixed `LocationMessageCell` reuse bug, to avoid inconsistency when get capture image asynchronously. 
+[#428](https://github.com/MessageKit/MessageKit/pull/428) by [@zhongwuzw](https://github.com/zhongwuzw).
+
 ## [[Prerelease] 0.12.0](https://github.com/MessageKit/MessageKit/releases/tag/0.12.0)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 
+## [[Prerelease] 0.12.1](https://github.com/MessageKit/MessageKit/releases/tag/0.12.1)
+
 ### Fixed
 
 - Fixed `LocationMessageCell` reuse bug, to avoid inconsistency when get capture image asynchronously. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - Fixed `LocationMessageCell` reuse bug, to avoid inconsistency when get capture image asynchronously. 
 [#428](https://github.com/MessageKit/MessageKit/pull/428) by [@zhongwuzw](https://github.com/zhongwuzw).
 
+- Fixed `MessageLabel` detector attributes not being applied due to early exit.
+[#429](https://github.com/MessageKit/MessageKit/pull/429) by [@antoinelamy](https://github.com/antoinelamy).
+
 ## [[Prerelease] 0.12.0](https://github.com/MessageKit/MessageKit/releases/tag/0.12.0)
 
 ### Added

--- a/Example/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/ChatExample.xcodeproj/project.pbxproj
@@ -267,7 +267,7 @@
 				TargetAttributes = {
 					882B5E321CF7D4B900B6E160 = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 9EUCWD26TP;
+						DevelopmentTeam = T26M4385KK;
 						LastSwiftMigration = 0800;
 					};
 					882B5E481CF7D4B900B6E160 = {
@@ -646,7 +646,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 9EUCWD26TP;
+				DEVELOPMENT_TEAM = T26M4385KK;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.messagekit.ChatExample;
@@ -661,7 +661,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 9EUCWD26TP;
+				DEVELOPMENT_TEAM = T26M4385KK;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.messagekit.ChatExample;

--- a/Example/ChatExample.xcodeproj/xcshareddata/xcschemes/ChatExample.xcscheme
+++ b/Example/ChatExample.xcodeproj/xcshareddata/xcschemes/ChatExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/ChatExample.xcodeproj/xcshareddata/xcschemes/ChatExampleUITests.xcscheme
+++ b/Example/ChatExample.xcodeproj/xcshareddata/xcschemes/ChatExampleUITests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MessageKit (0.11.0)
+  - MessageKit (0.12.0)
 
 DEPENDENCIES:
   - MessageKit (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  MessageKit: 96caa3ba2c32f9393b406256c5caa29ae9189d71
+  MessageKit: 616b81ac09e7ec9627fa47f26f9b9c684b33eab6
 
 PODFILE CHECKSUM: cecdb7bc8129cf99f66de9f68eea3256fec30c3d
 

--- a/Example/Sources/AppDelegate.swift
+++ b/Example/Sources/AppDelegate.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -343,6 +343,11 @@ extension ConversationViewController: MessagesDisplayDelegate {
             }, completion: nil)
         }
     }
+    
+    func snapshotOptionsForLocation(message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LocationMessageSnapshotOptions {
+        
+        return LocationMessageSnapshotOptions()
+    }
 }
 
 // MARK: - MessagesLayoutDelegate

--- a/Example/Sources/InboxViewController.swift
+++ b/Example/Sources/InboxViewController.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Example/Sources/MockMessage.swift
+++ b/Example/Sources/MockMessage.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Example/Sources/Playgrounds/Avatar.playground/playground.xcworkspace/contents.xcworkspacedata
+++ b/Example/Sources/Playgrounds/Avatar.playground/playground.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Sources/SampleData.swift
+++ b/Example/Sources/SampleData.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Example/Sources/SettingsViewController.swift
+++ b/Example/Sources/SettingsViewController.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 MessageKit
+Copyright (c) 2017-2018 MessageKit
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MessageKit.podspec
+++ b/MessageKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
    s.name = 'MessageKit'
-   s.version = '0.12.0'
+   s.version = '0.12.1'
    s.license = { :type => "MIT", :file => "LICENSE.md" }
 
    s.summary = 'An elegant messages UI library for iOS.'

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -2,7 +2,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Extensions/Bundle+Extensions.swift
+++ b/Sources/Extensions/Bundle+Extensions.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Extensions/CGRect+Extensions.swift
+++ b/Sources/Extensions/CGRect+Extensions.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Extensions/NSAttributedString+Extensions.swift
+++ b/Sources/Extensions/NSAttributedString+Extensions.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Extensions/String+Extensions.swift
+++ b/Sources/Extensions/String+Extensions.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Extensions/UICollectionView+Extensions.swift
+++ b/Sources/Extensions/UICollectionView+Extensions.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Extensions/UIColor+Extensions.swift
+++ b/Sources/Extensions/UIColor+Extensions.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Extensions/UIView+Extensions.swift
+++ b/Sources/Extensions/UIView+Extensions.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Layout/MessageIntermediateLayoutAttributes.swift
+++ b/Sources/Layout/MessageIntermediateLayoutAttributes.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
+++ b/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Models/Avatar.swift
+++ b/Sources/Models/Avatar.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Models/AvatarPosition.swift
+++ b/Sources/Models/AvatarPosition.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Models/DetectorType.swift
+++ b/Sources/Models/DetectorType.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Models/LabelAlignment.swift
+++ b/Sources/Models/LabelAlignment.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Models/LocationMessageSnapshotOptions.swift
+++ b/Sources/Models/LocationMessageSnapshotOptions.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Models/LocationMessageSnapshotOptions.swift
+++ b/Sources/Models/LocationMessageSnapshotOptions.swift
@@ -27,24 +27,38 @@ import MapKit
 /// An object grouping the settings used by the `MKMapSnapshotter` through the `LocationMessageDisplayDelegate`.
 public struct LocationMessageSnapshotOptions {
 
+    /// Initialize LocationMessageSnapshotOptions with given parameters
+    ///
+    /// - Parameters:
+    ///   - showsBuildings: A Boolean value indicating whether the snapshot image should display buildings.
+    ///   - showsPointsOfInterest: A Boolean value indicating whether the snapshot image should display points of interest.
+    ///   - span: The span of the snapshot.
+    ///   - scale: The scale of the snapshot.
+    public init(showsBuildings: Bool = false, showsPointsOfInterest: Bool = false, span: MKCoordinateSpan = MKCoordinateSpan(latitudeDelta: 0, longitudeDelta: 0) , scale: CGFloat = UIScreen.main.scale) {
+        self.showsBuildings = showsBuildings
+        self.showsPointsOfInterest = showsPointsOfInterest
+        self.span = span
+        self.scale = scale
+    }
+    
     /// A Boolean value indicating whether the snapshot image should display buildings.
     ///
     /// The default value of this property is `false`.
-    var showsBuildings = false
-
+    public var showsBuildings = false
+    
     /// A Boolean value indicating whether the snapshot image should display points of interest.
     ///
     /// The default value of this property is `false`.
-    var showsPointsOfInterest = false
-
+    public var showsPointsOfInterest = false
+    
     /// The span of the snapshot.
     ///
     /// The default value of this property uses a width of `0` and height of `0`.
-    var span: MKCoordinateSpan = MKCoordinateSpan(latitudeDelta: 0, longitudeDelta: 0)
-
+    public var span: MKCoordinateSpan = MKCoordinateSpan(latitudeDelta: 0, longitudeDelta: 0)
+    
     /// The scale of the snapshot.
     ///
     /// The default value of this property uses the `UIScreen.main.scale`.
-    var scale: CGFloat = UIScreen.main.scale
+    public var scale: CGFloat = UIScreen.main.scale
     
 }

--- a/Sources/Models/MessageData.swift
+++ b/Sources/Models/MessageData.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Models/MessageKitDateFormatter.swift
+++ b/Sources/Models/MessageKitDateFormatter.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Models/MessageStyle.swift
+++ b/Sources/Models/MessageStyle.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Models/NSConstraintLayoutSet.swift
+++ b/Sources/Models/NSConstraintLayoutSet.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Models/Sender.swift
+++ b/Sources/Models/Sender.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Protocols/MessageCellDelegate.swift
+++ b/Sources/Protocols/MessageCellDelegate.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Protocols/MessageInputBarDelegate.swift
+++ b/Sources/Protocols/MessageInputBarDelegate.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Protocols/MessageLabelDelegate.swift
+++ b/Sources/Protocols/MessageLabelDelegate.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Protocols/MessageType.swift
+++ b/Sources/Protocols/MessageType.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Protocols/MessagesDataSource.swift
+++ b/Sources/Protocols/MessagesDataSource.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Protocols/MessagesDisplayDelegate.swift
+++ b/Sources/Protocols/MessagesDisplayDelegate.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Protocols/MessagesLayoutDelegate.swift
+++ b/Sources/Protocols/MessagesLayoutDelegate.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Supporting/MessageKit+Availability.swift
+++ b/Sources/Supporting/MessageKit+Availability.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/AvatarView.swift
+++ b/Sources/Views/AvatarView.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/Cells/LocationMessageCell.swift
+++ b/Sources/Views/Cells/LocationMessageCell.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/Cells/LocationMessageCell.swift
+++ b/Sources/Views/Cells/LocationMessageCell.swift
@@ -34,6 +34,8 @@ open class LocationMessageCell: MessageCollectionViewCell {
     open var activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .gray)
 
     open var imageView = UIImageView()
+    
+    private weak var snapShotter: MKMapSnapshotter?
 
     open override func setupSubviews() {
         super.setupSubviews()
@@ -46,6 +48,11 @@ open class LocationMessageCell: MessageCollectionViewCell {
     open func setupConstraints() {
         imageView.fillSuperview()
         activityIndicator.centerInSuperview()
+    }
+    
+    open override func prepareForReuse() {
+        super.prepareForReuse()
+        snapShotter?.cancel()
     }
 
     open override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
@@ -67,6 +74,7 @@ open class LocationMessageCell: MessageCollectionViewCell {
         snapshotOptions.showsPointsOfInterest = options.showsPointsOfInterest
 
         let snapShotter = MKMapSnapshotter(options: snapshotOptions)
+        self.snapShotter = snapShotter
         snapShotter.start { (snapshot, error) in
             defer {
                 self.activityIndicator.stopAnimating()

--- a/Sources/Views/Cells/MediaMessageCell.swift
+++ b/Sources/Views/Cells/MediaMessageCell.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/Cells/MessageCollectionViewCell.swift
+++ b/Sources/Views/Cells/MessageCollectionViewCell.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/Cells/MessageCollectionViewCell.swift
+++ b/Sources/Views/Cells/MessageCollectionViewCell.swift
@@ -72,6 +72,7 @@ open class MessageCollectionViewCell: UICollectionViewCell, CollectionViewReusab
     }
 
     open override func prepareForReuse() {
+        super.prepareForReuse()
         cellTopLabel.text = nil
         cellTopLabel.attributedText = nil
         cellBottomLabel.text = nil

--- a/Sources/Views/Cells/TextMessageCell.swift
+++ b/Sources/Views/Cells/TextMessageCell.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/Headers & Footers/MessageDateHeaderView.swift
+++ b/Sources/Views/Headers & Footers/MessageDateHeaderView.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/Headers & Footers/MessageFooterView.swift
+++ b/Sources/Views/Headers & Footers/MessageFooterView.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/Headers & Footers/MessageHeaderView.swift
+++ b/Sources/Views/Headers & Footers/MessageHeaderView.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/InputBarItem.swift
+++ b/Sources/Views/InputBarItem.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/InputStackView.swift
+++ b/Sources/Views/InputStackView.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/InputTextView.swift
+++ b/Sources/Views/InputTextView.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/MessageContainerView.swift
+++ b/Sources/Views/MessageContainerView.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/MessageInputBar.swift
+++ b/Sources/Views/MessageInputBar.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -245,7 +245,7 @@ open class MessageLabel: UILabel {
         let mutableAttributedString = NSMutableAttributedString(attributedString: attributedText)
 
         for detector in detectors {
-            guard let rangeTuples = rangesForDetectors[detector] else { return }
+            guard let rangeTuples = rangesForDetectors[detector] else { continue }
 
             for (range, _)  in rangeTuples {
                 let attributes = detectorAttributes(for: detector)

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/PlayButtonView.swift
+++ b/Sources/Views/PlayButtonView.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Views/SeparatorLine.swift
+++ b/Sources/Views/SeparatorLine.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/AvatarSpec.swift
+++ b/Tests/AvatarSpec.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ControllersTest/MessageLabelSpec.swift
+++ b/Tests/ControllersTest/MessageLabelSpec.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ControllersTest/MessagesViewControllerSpec.swift
+++ b/Tests/ControllersTest/MessagesViewControllerSpec.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ControllersTest/MessagesViewControllerTests.swift
+++ b/Tests/ControllersTest/MessagesViewControllerTests.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ControllersTest/MessagesViewControllerTests.swift
+++ b/Tests/ControllersTest/MessagesViewControllerTests.swift
@@ -205,4 +205,8 @@ private class MockLayoutDelegate: MessagesLayoutDelegate, MessagesDisplayDelegat
     func heightForMedia(message: MessageType, at indexPath: IndexPath, with maxWidth: CGFloat, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
         return 10.0
     }
+    
+    func snapshotOptionsForLocation(message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LocationMessageSnapshotOptions {
+        return LocationMessageSnapshotOptions()
+    }
 }

--- a/Tests/DetectorTypeSpec.swift
+++ b/Tests/DetectorTypeSpec.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Mocks/MockMessage.swift
+++ b/Tests/Mocks/MockMessage.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Mocks/MockMessagesDataSource.swift
+++ b/Tests/Mocks/MockMessagesDataSource.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ModelTests/MessageKitDateFormatterTests.swift
+++ b/Tests/ModelTests/MessageKitDateFormatterTests.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ModelTests/MessageKitDateFormatterTests.swift
+++ b/Tests/ModelTests/MessageKitDateFormatterTests.swift
@@ -93,7 +93,13 @@ class MessageKitDateFormatterTests: XCTestCase {
 
         ///Day of last week
         startOfWeek = (Calendar.current as NSCalendar).date(byAdding: .day, value: -2, to: startOfWeek, options: [])!
-        formatter.dateFormat = "E, d MMM, h:mm a"
+        
+        if Calendar.current.isDate(startOfWeek, equalTo: Date(), toGranularity: .year) {
+            formatter.dateFormat = "E, d MMM, h:mm a"
+        } else {
+            formatter.dateFormat = "MMM d, yyyy, h:mm a"
+        }
+        
         XCTAssertEqual(MessageKitDateFormatter.shared.string(from: startOfWeek), formatter.string(from: startOfWeek))
     }
 

--- a/Tests/ModelTests/MessageStyleTests.swift
+++ b/Tests/ModelTests/MessageStyleTests.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ProtocolsTests/MessagesDisplayDelegateTests.swift
+++ b/Tests/ProtocolsTests/MessagesDisplayDelegateTests.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ProtocolsTests/MessagesDisplayDelegateTests.swift
+++ b/Tests/ProtocolsTests/MessagesDisplayDelegateTests.swift
@@ -267,4 +267,7 @@ private class MockMessagesViewController: MessagesViewController, MessagesDispla
         return dataSource
     }
 
+    func snapshotOptionsForLocation(message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LocationMessageSnapshotOptions {
+        return LocationMessageSnapshotOptions()
+    }
 }

--- a/Tests/SenderSpec.swift
+++ b/Tests/SenderSpec.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ViewsTests/AvatarViewTests.swift
+++ b/Tests/ViewsTests/AvatarViewTests.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ViewsTests/InputBarItemTests.swift
+++ b/Tests/ViewsTests/InputBarItemTests.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ViewsTests/InputTextViewTests.swift
+++ b/Tests/ViewsTests/InputTextViewTests.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ViewsTests/MessageCollectionViewCellTests.swift
+++ b/Tests/ViewsTests/MessageCollectionViewCellTests.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ViewsTests/MessageCollectionViewCellTests.swift
+++ b/Tests/ViewsTests/MessageCollectionViewCellTests.swift
@@ -76,6 +76,11 @@ class MessageCollectionViewCellTests: XCTestCase {
 
 extension MessageCollectionViewCellTests {
 
-    fileprivate class MockMessagesDisplayDelegate: MessagesDisplayDelegate { }
+    fileprivate class MockMessagesDisplayDelegate: MessagesDisplayDelegate {
+        
+        func snapshotOptionsForLocation(message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LocationMessageSnapshotOptions {
+            return LocationMessageSnapshotOptions()
+        }
+    }
 
 }

--- a/Tests/ViewsTests/MessageDateHeaderViewTests.swift
+++ b/Tests/ViewsTests/MessageDateHeaderViewTests.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ViewsTests/MessageInputBarTests.swift
+++ b/Tests/ViewsTests/MessageInputBarTests.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ViewsTests/MessagesCollectionViewTests.swift
+++ b/Tests/ViewsTests/MessagesCollectionViewTests.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
added public init and public to properties of
LocationMessageSnapshotOptions to prevent inaccessible compiler error  

Does this close any currently open issues?
------------------------------------------
#442


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->
Nothing

Any other comments?
-------------------
Nothing

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone SE

**iOS Version:** 11.2

**Swift Version:** 4

**MessageKit Version:** 0.12.1
