### PR TITLE
LocationMessageSnapshotOptions public

### DIFF
--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -343,6 +343,11 @@ extension ConversationViewController: MessagesDisplayDelegate {
                 view.alpha = 1.0
             }, completion: nil)
         }
+    }
+    
+    func snapshotOptionsForLocation(message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LocationMessageSnapshotOptions {
+        
+        return LocationMessageSnapshotOptions()
     }
 }
 

--- a/Sources/Models/LocationMessageSnapshotOptions.swift
+++ b/Sources/Models/LocationMessageSnapshotOptions.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -27,24 +27,38 @@ import MapKit
 /// An object grouping the settings used by the `MKMapSnapshotter` through the `LocationMessageDisplayDelegate`.
 public struct LocationMessageSnapshotOptions {
 
+    /// Initialize LocationMessageSnapshotOptions with given parameters
+    ///
+    /// - Parameters:
+    ///   - showsBuildings: A Boolean value indicating whether the snapshot image should display buildings.
+    ///   - showsPointsOfInterest: A Boolean value indicating whether the snapshot image should display points of interest.
+    ///   - span: The span of the snapshot.
+    ///   - scale: The scale of the snapshot.
+    public init(showsBuildings: Bool = false, showsPointsOfInterest: Bool = false, span: MKCoordinateSpan = MKCoordinateSpan(latitudeDelta: 0, longitudeDelta: 0) , scale: CGFloat = UIScreen.main.scale) {
+        self.showsBuildings = showsBuildings
+        self.showsPointsOfInterest = showsPointsOfInterest
+        self.span = span
+        self.scale = scale
+    }
+    
     /// A Boolean value indicating whether the snapshot image should display buildings.
     ///
     /// The default value of this property is `false`.
-    var showsBuildings = false
-
+    public var showsBuildings = false
+    
     /// A Boolean value indicating whether the snapshot image should display points of interest.
     ///
     /// The default value of this property is `false`.
-    var showsPointsOfInterest = false
-
+    public var showsPointsOfInterest = false
+    
     /// The span of the snapshot.
     ///
     /// The default value of this property uses a width of `0` and height of `0`.
-    var span: MKCoordinateSpan = MKCoordinateSpan(latitudeDelta: 0, longitudeDelta: 0)
-
+    public var span: MKCoordinateSpan = MKCoordinateSpan(latitudeDelta: 0, longitudeDelta: 0)
+    
     /// The scale of the snapshot.
     ///
     /// The default value of this property uses the `UIScreen.main.scale`.
-    var scale: CGFloat = UIScreen.main.scale
+    public var scale: CGFloat = UIScreen.main.scale
     
 }

--- a/Sources/Models/LocationMessageSnapshotOptions.swift
+++ b/Sources/Models/LocationMessageSnapshotOptions.swift
@@ -44,21 +44,21 @@ public struct LocationMessageSnapshotOptions {
     /// A Boolean value indicating whether the snapshot image should display buildings.
     ///
     /// The default value of this property is `false`.
-    public var showsBuildings = false
+    public var showsBuildings: Bool
     
     /// A Boolean value indicating whether the snapshot image should display points of interest.
     ///
     /// The default value of this property is `false`.
-    public var showsPointsOfInterest = false
+    public var showsPointsOfInterest: Bool
     
     /// The span of the snapshot.
     ///
     /// The default value of this property uses a width of `0` and height of `0`.
-    public var span: MKCoordinateSpan = MKCoordinateSpan(latitudeDelta: 0, longitudeDelta: 0)
+    public var span: MKCoordinateSpan
     
     /// The scale of the snapshot.
     ///
     /// The default value of this property uses the `UIScreen.main.scale`.
-    public var scale: CGFloat = UIScreen.main.scale
+    public var scale: CGFloat
     
 }

--- a/Tests/ControllersTest/MessagesViewControllerTests.swift
+++ b/Tests/ControllersTest/MessagesViewControllerTests.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -204,5 +204,9 @@ private class MockLayoutDelegate: MessagesLayoutDelegate, MessagesDisplayDelegat
 
     func heightForMedia(message: MessageType, at indexPath: IndexPath, with maxWidth: CGFloat, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
         return 10.0
+    }
+    
+    func snapshotOptionsForLocation(message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LocationMessageSnapshotOptions {
+        return LocationMessageSnapshotOptions()
     }
 }

--- a/Tests/ProtocolsTests/MessagesDisplayDelegateTests.swift
+++ b/Tests/ProtocolsTests/MessagesDisplayDelegateTests.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -261,4 +261,7 @@ private class MockMessagesViewController: MessagesViewController, MessagesDispla
         return dataSource
     }
 
+    func snapshotOptionsForLocation(message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LocationMessageSnapshotOptions {
+        return LocationMessageSnapshotOptions()
+    }
 }

--- a/Tests/ViewsTests/MessageCollectionViewCellTests.swift
+++ b/Tests/ViewsTests/MessageCollectionViewCellTests.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -76,6 +76,11 @@ class MessageCollectionViewCellTests: XCTestCase {
 
 extension MessageCollectionViewCellTests {
 
-    fileprivate class MockMessagesDisplayDelegate: MessagesDisplayDelegate { }
+    fileprivate class MockMessagesDisplayDelegate: MessagesDisplayDelegate {
+        
+        func snapshotOptionsForLocation(message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LocationMessageSnapshotOptions {
+            return LocationMessageSnapshotOptions()
+        }
+    }
 
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
added public init and public to properties of
LocationMessageSnapshotOptions to prevent inaccessible compiler error  

Does this close any currently open issues?
------------------------------------------
#442


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->
Nothing

Any other comments?
-------------------
Nothing

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone SE

**iOS Version:** 11.2

**Swift Version:** 4

**MessageKit Version:** 0.12.1

  