### PR TITLE
Feature/mock messages count settings

### DIFF
--- a/Example/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/ChatExample.xcodeproj/project.pbxproj
@@ -273,7 +273,7 @@
 				TargetAttributes = {
 					882B5E321CF7D4B900B6E160 = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 28VWFVMBDR;
+						DevelopmentTeam = 9EUCWD26TP;
 						LastSwiftMigration = 0800;
 					};
 					882B5E481CF7D4B900B6E160 = {
@@ -654,10 +654,10 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 28VWFVMBDR;
+				DEVELOPMENT_TEAM = 9EUCWD26TP;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.messagekit.ChatExample.123;
+				PRODUCT_BUNDLE_IDENTIFIER = com.messagekit.ChatExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 			};
@@ -669,10 +669,10 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 28VWFVMBDR;
+				DEVELOPMENT_TEAM = 9EUCWD26TP;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.messagekit.ChatExample.123;
+				PRODUCT_BUNDLE_IDENTIFIER = com.messagekit.ChatExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.0;

--- a/Example/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/ChatExample.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		B096438B1F288D47004D0129 /* MockMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B096438A1F288D47004D0129 /* MockMessage.swift */; };
 		C1DF6DF39F66906000EC76CF /* Pods_ChatExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 56F0AC85B38034EC92CCBC7D /* Pods_ChatExampleTests.framework */; };
 		C7CA53A1B85256A5097E7DC7 /* Pods_ChatExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B316705C4717C3B4C916D62 /* Pods_ChatExample.framework */; };
+		CAB36EA12007A573009995ED /* TableViewCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB36EA02007A573009995ED /* TableViewCells.swift */; };
+		CAB36EA32007B1B7009995ED /* Settings+UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB36EA22007B1B7009995ED /* Settings+UserDefaults.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +81,8 @@
 		B0DD3C951C9D064B5E6D6644 /* Pods-ChatExampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ChatExampleUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ChatExampleUITests/Pods-ChatExampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		B2F1C412A96DE613A0AC31F8 /* Pods-ChatExampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ChatExampleUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ChatExampleUITests/Pods-ChatExampleUITests.release.xcconfig"; sourceTree = "<group>"; };
 		BFE5859D088A740A7D43E1B1 /* Pods-ChatExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ChatExampleTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ChatExampleTests/Pods-ChatExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		CAB36EA02007A573009995ED /* TableViewCells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewCells.swift; sourceTree = "<group>"; };
+		CAB36EA22007B1B7009995ED /* Settings+UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Settings+UserDefaults.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -157,6 +161,8 @@
 				882B5E791CF7D53600B6E160 /* Assets.xcassets */,
 				882B5E7F1CF7D53600B6E160 /* Info.plist */,
 				882B5E7A1CF7D53600B6E160 /* LaunchScreen.storyboard */,
+				CAB36EA02007A573009995ED /* TableViewCells.swift */,
+				CAB36EA22007B1B7009995ED /* Settings+UserDefaults.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -267,7 +273,7 @@
 				TargetAttributes = {
 					882B5E321CF7D4B900B6E160 = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 9EUCWD26TP;
+						DevelopmentTeam = 28VWFVMBDR;
 						LastSwiftMigration = 0800;
 					};
 					882B5E481CF7D4B900B6E160 = {
@@ -485,6 +491,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CAB36EA12007A573009995ED /* TableViewCells.swift in Sources */,
+				CAB36EA32007B1B7009995ED /* Settings+UserDefaults.swift in Sources */,
 				882B5E871CF7D53600B6E160 /* SettingsViewController.swift in Sources */,
 				37D3EAC41F390E5F00DD6A55 /* SampleData.swift in Sources */,
 				B096438B1F288D47004D0129 /* MockMessage.swift in Sources */,
@@ -646,10 +654,10 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 9EUCWD26TP;
+				DEVELOPMENT_TEAM = 28VWFVMBDR;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.messagekit.ChatExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.messagekit.ChatExample.123;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 			};
@@ -661,10 +669,10 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 9EUCWD26TP;
+				DEVELOPMENT_TEAM = 28VWFVMBDR;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.messagekit.ChatExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.messagekit.ChatExample.123;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.0;

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -37,8 +37,10 @@ class ConversationViewController: MessagesViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
     
+        let messagesToFetch = UserDefaults.standard.mockMessagesCount()
+        
         DispatchQueue.global(qos: .userInitiated).async {
-            SampleData.shared.getMessages(count: 10) { messages in
+            SampleData.shared.getMessages(count: messagesToFetch) { messages in
                 DispatchQueue.main.async {
                     self.messageList = messages
                     self.messagesCollectionView.reloadData()

--- a/Example/Sources/Settings+UserDefaults.swift
+++ b/Example/Sources/Settings+UserDefaults.swift
@@ -1,10 +1,26 @@
-//
-//  Settings+UserDefaults.swift
-//  ChatExample
-//
-//  Created by Alessio Arsuffi on 11/01/2018.
-//  Copyright © 2018 MessageKit. All rights reserved.
-//
+/*
+ MIT License
+ 
+ Copyright (c) 2017 MessageKit
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
 
 import Foundation
 

--- a/Example/Sources/Settings+UserDefaults.swift
+++ b/Example/Sources/Settings+UserDefaults.swift
@@ -1,0 +1,28 @@
+//
+//  Settings+UserDefaults.swift
+//  ChatExample
+//
+//  Created by Alessio Arsuffi on 11/01/2018.
+//  Copyright © 2018 MessageKit. All rights reserved.
+//
+
+import Foundation
+
+extension UserDefaults {
+    
+    static let messagesKey = "mockMessages"
+    
+    // MARK: - Mock Messages
+    
+    func setMockMessages(count: Int) {
+        set(count, forKey: "mockMessages")
+        synchronize()
+    }
+    
+    func mockMessagesCount() -> Int {
+        if let value = object(forKey: "mockMessages") as? Int {
+            return value
+        }
+        return 20
+    }
+}

--- a/Example/Sources/SettingsViewController.swift
+++ b/Example/Sources/SettingsViewController.swift
@@ -27,8 +27,113 @@ import MessageKit
 
 final class SettingsViewController: UITableViewController {
 
+    // MARK: - Properties
+    
+    var selectedMockMessagesCount: Int = 20
+    
+    // MARK: - Picker
+    
+    var messagesPicker = UIPickerView()
+    
+    @objc func onDoneWithPickerView() {
+        let selectedMessagesCount = messagesPicker.selectedRow(inComponent: 0)
+        print("selected \(selectedMessagesCount) messages count")
+        UserDefaults.standard.setMockMessages(count: selectedMessagesCount)
+        view.endEditing(false)
+        tableView.reloadData()
+    }
+    
+    @objc func dismissPickerView() {
+        view.endEditing(false)
+    }
+    
+    private func configurePickerView() {
+        messagesPicker.dataSource = self
+        messagesPicker.delegate = self
+        messagesPicker.backgroundColor = .white
+    }
+    
+    // MARK: - Toolbar
+    
+    var messagesToolbar = UIToolbar()
+    
+    private func configureToolbar() {
+        let doneButton = UIBarButtonItem(title: "Done", style: .plain, target: self, action: #selector(onDoneWithPickerView))
+        let spaceButton = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        let cancelButton = UIBarButtonItem(title: "Cancel", style: .plain, target: self, action: #selector(dismissPickerView))
+        messagesToolbar.items = [cancelButton, spaceButton, doneButton]
+        messagesToolbar.sizeToFit()
+    }
+    
+    // MARK: - View lifecycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        tableView.register(TextFieldTableViewCell.self, forCellReuseIdentifier: TextFieldTableViewCell.identifier)
+        
+        configurePickerView()
+        configureToolbar()
     }
+    
+    // MARK: - TableViewDelegate & TableViewDataSource
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        if indexPath.row == 0 {
+            return configureTextFieldTableViewCell(at: indexPath)
+        } else {
+            return UITableViewCell()
+        }
+    }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        
+        let cell = tableView.cellForRow(at: indexPath)
+        
+        cell?.contentView.subviews.forEach {
+            if $0 is UITextField {
+                $0.becomeFirstResponder()
+            }
+        }
+    }
+    
+    // MARK: - Helper
+    
+    private func configureTextFieldTableViewCell(at indexPath: IndexPath) -> TextFieldTableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: TextFieldTableViewCell.identifier, for: indexPath) as! TextFieldTableViewCell
+        cell.mainLabel.text = "Mock messages count:"
+        
+        let messagesCount = UserDefaults.standard.mockMessagesCount()
+        cell.textField.text = "\(messagesCount)"
+        
+        cell.textField.inputView = messagesPicker
+        cell.textField.inputAccessoryView = messagesToolbar
+        
+        return cell
+    }
+}
 
+// MARK: - UIPickerViewDelegate, UIPickerViewDataSource
+extension SettingsViewController: UIPickerViewDelegate, UIPickerViewDataSource {
+    
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return 100
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        return "\(row)"
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        selectedMockMessagesCount = row
+    }
 }

--- a/Example/Sources/SettingsViewController.swift
+++ b/Example/Sources/SettingsViewController.swift
@@ -37,7 +37,6 @@ final class SettingsViewController: UITableViewController {
     
     @objc func onDoneWithPickerView() {
         let selectedMessagesCount = messagesPicker.selectedRow(inComponent: 0)
-        print("selected \(selectedMessagesCount) messages count")
         UserDefaults.standard.setMockMessages(count: selectedMessagesCount)
         view.endEditing(false)
         tableView.reloadData()
@@ -83,11 +82,7 @@ final class SettingsViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
-        if indexPath.row == 0 {
-            return configureTextFieldTableViewCell(at: indexPath)
-        } else {
-            return UITableViewCell()
-        }
+        return indexPath.row == 0 ? configureTextFieldTableViewCell(at: indexPath) : UITableViewCell()
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Example/Sources/TableViewCells.swift
+++ b/Example/Sources/TableViewCells.swift
@@ -1,10 +1,26 @@
-//
-//  TableViewCells.swift
-//  ChatExample
-//
-//  Created by Alessio Arsuffi on 11/01/2018.
-//  Copyright © 2018 MessageKit. All rights reserved.
-//
+/*
+ MIT License
+ 
+ Copyright (c) 2017 MessageKit
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
 
 import UIKit
 

--- a/Example/Sources/TableViewCells.swift
+++ b/Example/Sources/TableViewCells.swift
@@ -27,7 +27,6 @@ import UIKit
 class TextFieldTableViewCell: UITableViewCell {
 
     static let identifier = "TextFieldTableViewCellIdentifier"
-    static let height: CGFloat = 40.0
     
     var mainLabel = UILabel()
     var textField = UITextField()

--- a/Example/Sources/TableViewCells.swift
+++ b/Example/Sources/TableViewCells.swift
@@ -58,10 +58,6 @@ class TextFieldTableViewCell: UITableViewCell {
     }
     
     required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
+        fatalError("init(coder:) has not been implemented")
     }
-    
-    // MARK: -
-    
-    
 }

--- a/Example/Sources/TableViewCells.swift
+++ b/Example/Sources/TableViewCells.swift
@@ -1,0 +1,51 @@
+//
+//  TableViewCells.swift
+//  ChatExample
+//
+//  Created by Alessio Arsuffi on 11/01/2018.
+//  Copyright © 2018 MessageKit. All rights reserved.
+//
+
+import UIKit
+
+class TextFieldTableViewCell: UITableViewCell {
+
+    static let identifier = "TextFieldTableViewCellIdentifier"
+    static let height: CGFloat = 40.0
+    
+    var mainLabel = UILabel()
+    var textField = UITextField()
+    
+    // MARK: - View lifecycle
+    
+    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        mainLabel.translatesAutoresizingMaskIntoConstraints = false
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        
+        contentView.addSubview(mainLabel)
+        contentView.addSubview(textField)
+        
+        NSLayoutConstraint.activate([
+            mainLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            mainLabel.widthAnchor.constraint(equalToConstant: 200),
+            mainLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            
+            textField.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            
+            textField.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            textField.widthAnchor.constraint(equalToConstant: 50)
+        ])
+        
+        textField.textAlignment = .right
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    // MARK: -
+    
+    
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Added new file to interact easily with UserDefaults;
ConversationViewController will fetch messages count set in Settings.
In SettingsViewController I've added a tableViewCell with a pickerView to select desired messages count to fetch. Starting from 0 to 99.

Does this close any currently open issues?
------------------------------------------
it is related to first point of #362 


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->
Nothing

Any other comments?
-------------------
Let me know if everything is ok for you :)

attached screen:

![simulator screen shot - iphone x - 2018-01-11 at 17 41 22](https://user-images.githubusercontent.com/3455711/34835950-b21d0626-f6f6-11e7-9071-a07d316b89a9.png)


Where has this been tested?
---------------------------
**Devices/Simulators:** 
iPhone 4s (iOS 9.0)
iPhone SE, 7, 7 plus, X (iOS 11)

**iOS Version:** 11.2

**Swift Version:** 4

**MessageKit Version:** 0.12.1
