### PR TITLE
Split MessagesViewController functionality & add MessageKitError

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MessageKit (0.11.0)
+  - MessageKit (0.12.0)
 
 DEPENDENCIES:
   - MessageKit (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  MessageKit: 96caa3ba2c32f9393b406256c5caa29ae9189d71
+  MessageKit: 616b81ac09e7ec9627fa47f26f9b9c684b33eab6
 
 PODFILE CHECKSUM: cecdb7bc8129cf99f66de9f68eea3256fec30c3d
 

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -58,17 +58,17 @@ class ConversationViewController: MessagesViewController {
         maintainPositionOnKeyboardFrameChanged = true // default false
         
         messagesCollectionView.addSubview(refreshControl)
-        refreshControl.addTarget(self, action: #selector(loadMoreMessages), for: .valueChanged)
+        refreshControl.addTarget(self, action: #selector(ConversationViewController.loadMoreMessages), for: .valueChanged)
         
         navigationItem.rightBarButtonItems = [
             UIBarButtonItem(image: UIImage(named: "ic_keyboard"),
                             style: .plain,
                             target: self,
-                            action: #selector(handleKeyboardButton)),
+                            action: #selector(ConversationViewController.handleKeyboardButton)),
             UIBarButtonItem(image: UIImage(named: "ic_typing"),
                             style: .plain,
                             target: self,
-                            action: #selector(handleTyping))
+                            action: #selector(ConversationViewController.handleTyping))
         ]
     }
     

--- a/MessageKit.xcodeproj/project.pbxproj
+++ b/MessageKit.xcodeproj/project.pbxproj
@@ -18,6 +18,11 @@
 		1F7FC8C61FD26F33006CC979 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F7FC8C51FD26F33006CC979 /* Quick.framework */; };
 		1F7FC8C81FD26F49006CC979 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F7FC8C71FD26F49006CC979 /* Nimble.framework */; };
 		1F82D1431FB1B75B00B81A88 /* AvatarPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F82D1421FB1B75B00B81A88 /* AvatarPosition.swift */; };
+		1FF377A420087C82004FD648 /* MessageKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF377A320087C82004FD648 /* MessageKitError.swift */; };
+		1FF377A620087D20004FD648 /* MessagesViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF377A520087D20004FD648 /* MessagesViewController+DataSource.swift */; };
+		1FF377A820087D56004FD648 /* MessagesViewController+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF377A720087D56004FD648 /* MessagesViewController+Delegate.swift */; };
+		1FF377AA20087D78004FD648 /* MessagesViewController+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF377A920087D78004FD648 /* MessagesViewController+Menu.swift */; };
+		1FF377AC20087DA2004FD648 /* MessagesViewController+Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF377AB20087DA2004FD648 /* MessagesViewController+Keyboard.swift */; };
 		38C57C791F9AE3E50043CC03 /* SeparatorLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C57C781F9AE3E50043CC03 /* SeparatorLine.swift */; };
 		38C57C7C1F9AE4890043CC03 /* InputStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C57C7B1F9AE4870043CC03 /* InputStackView.swift */; };
 		88916B2D1CF0DF2F00469F91 /* MessageKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88916B221CF0DF2F00469F91 /* MessageKit.framework */; };
@@ -115,6 +120,11 @@
 		1F7FC8C71FD26F49006CC979 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		1F7FC8CB1FD2700B006CC979 /* MessagesViewControllerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesViewControllerSpec.swift; sourceTree = "<group>"; };
 		1F82D1421FB1B75B00B81A88 /* AvatarPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarPosition.swift; sourceTree = "<group>"; };
+		1FF377A320087C82004FD648 /* MessageKitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageKitError.swift; sourceTree = "<group>"; };
+		1FF377A520087D20004FD648 /* MessagesViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessagesViewController+DataSource.swift"; sourceTree = "<group>"; };
+		1FF377A720087D56004FD648 /* MessagesViewController+Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessagesViewController+Delegate.swift"; sourceTree = "<group>"; };
+		1FF377A920087D78004FD648 /* MessagesViewController+Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessagesViewController+Menu.swift"; sourceTree = "<group>"; };
+		1FF377AB20087DA2004FD648 /* MessagesViewController+Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessagesViewController+Keyboard.swift"; sourceTree = "<group>"; };
 		38C57C781F9AE3E50043CC03 /* SeparatorLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeparatorLine.swift; sourceTree = "<group>"; };
 		38C57C7B1F9AE4870043CC03 /* InputStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputStackView.swift; sourceTree = "<group>"; };
 		88916B221CF0DF2F00469F91 /* MessageKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MessageKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -373,6 +383,7 @@
 				B7A03F221F866895006AEF79 /* LabelAlignment.swift */,
 				B7A03F1D1F866895006AEF79 /* LocationMessageSnapshotOptions.swift */,
 				B7A03F231F866895006AEF79 /* MessageData.swift */,
+				1FF377A320087C82004FD648 /* MessageKitError.swift */,
 				B7A03F1B1F866895006AEF79 /* MessageKitDateFormatter.swift */,
 				B7A03F1F1F866895006AEF79 /* MessageStyle.swift */,
 				B7A03F1A1F866895006AEF79 /* NSConstraintLayoutSet.swift */,
@@ -418,6 +429,10 @@
 			isa = PBXGroup;
 			children = (
 				B7A03F4E1F86697C006AEF79 /* MessagesViewController.swift */,
+				1FF377A520087D20004FD648 /* MessagesViewController+DataSource.swift */,
+				1FF377A720087D56004FD648 /* MessagesViewController+Delegate.swift */,
+				1FF377A920087D78004FD648 /* MessagesViewController+Menu.swift */,
+				1FF377AB20087DA2004FD648 /* MessagesViewController+Keyboard.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -571,12 +586,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				B7A03F3C1F866946006AEF79 /* LocationMessageCell.swift in Sources */,
+				1FF377AA20087D78004FD648 /* MessagesViewController+Menu.swift in Sources */,
 				38C57C7C1F9AE4890043CC03 /* InputStackView.swift in Sources */,
 				B7A03F5B1F8669CA006AEF79 /* MessageType.swift in Sources */,
 				B7A03F6F1F8669EB006AEF79 /* String+Extensions.swift in Sources */,
 				B7A03F491F86694F006AEF79 /* InputBarItem.swift in Sources */,
 				B7A03F601F8669CA006AEF79 /* MessagesDisplayDelegate.swift in Sources */,
 				B7A03F5C1F8669CA006AEF79 /* MessageCellDelegate.swift in Sources */,
+				1FF377A420087C82004FD648 /* MessageKitError.swift in Sources */,
 				B7A03F4A1F86694F006AEF79 /* MessageInputBar.swift in Sources */,
 				B006FA021F99DE2100509C46 /* MessageIntermediateLayoutAttributes.swift in Sources */,
 				B7A03F4B1F86694F006AEF79 /* MessageContainerView.swift in Sources */,
@@ -610,14 +627,17 @@
 				0EE91E661FDEC888005420A2 /* CGRect+Extensions.swift in Sources */,
 				B7A03F181F86682C006AEF79 /* MessagesCollectionViewFlowLayout.swift in Sources */,
 				B7A03F2A1F866895006AEF79 /* MessageStyle.swift in Sources */,
+				1FF377A620087D20004FD648 /* MessagesViewController+DataSource.swift in Sources */,
 				B7A03F4D1F86694F006AEF79 /* MessagesCollectionView.swift in Sources */,
 				B7A03F351F866940006AEF79 /* MessageHeaderView.swift in Sources */,
 				B7A03F731F866A06006AEF79 /* MessageKit+Availability.swift in Sources */,
 				B7A03F2D1F866895006AEF79 /* LabelAlignment.swift in Sources */,
 				38C57C791F9AE3E50043CC03 /* SeparatorLine.swift in Sources */,
 				B7A03F2C1F866895006AEF79 /* DetectorType.swift in Sources */,
+				1FF377A820087D56004FD648 /* MessagesViewController+Delegate.swift in Sources */,
 				B7A03F271F866895006AEF79 /* Avatar.swift in Sources */,
 				1F82D1431FB1B75B00B81A88 /* AvatarPosition.swift in Sources */,
+				1FF377AC20087DA2004FD648 /* MessagesViewController+Keyboard.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -627,7 +647,6 @@
 			files = (
 				8962AC8C1F87AB7D0030B058 /* AvatarViewTests.swift in Sources */,
 				1F066E141FD90BB700E11013 /* MessageLabelSpec.swift in Sources */,
-				8962AC971F87AB860030B058 /* DetectorTypeTests.swift in Sources */,
 				8962AC941F87AB860030B058 /* MessageKitDateFormatterTests.swift in Sources */,
 				8962AC8E1F87AB7D0030B058 /* InputTextViewTests.swift in Sources */,
 				8962AC911F87AB860030B058 /* MessagesViewControllerTests.swift in Sources */,
@@ -637,7 +656,6 @@
 				8962AC8F1F87AB7D0030B058 /* MessageInputBarTests.swift in Sources */,
 				1F066E131FD90BB600E11013 /* MessagesViewControllerSpec.swift in Sources */,
 				1F066E1D1FDA3C1700E11013 /* SenderSpec.swift in Sources */,
-				1F7FC8CC1FD2700B006CC979 /* MessagesViewControllerSpec.swift in Sources */,
 				8962AC8A1F87AB7D0030B058 /* MessagesCollectionViewTests.swift in Sources */,
 				8962AC8D1F87AB7D0030B058 /* MessageCollectionViewCellTests.swift in Sources */,
 				8962AC991F87AB860030B058 /* MessagesDisplayDelegateTests.swift in Sources */,

--- a/Sources/Controllers/MessagesViewController+DataSource.swift
+++ b/Sources/Controllers/MessagesViewController+DataSource.swift
@@ -1,0 +1,98 @@
+/*
+ MIT License
+
+ Copyright (c) 2017 MessageKit
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+import UIKit
+
+extension MessagesViewController: UICollectionViewDataSource {
+
+    open func numberOfSections(in collectionView: UICollectionView) -> Int {
+        guard let collectionView = collectionView as? MessagesCollectionView else { return 0 }
+
+        // Each message is its own section
+        return collectionView.messagesDataSource?.numberOfMessages(in: collectionView) ?? 0
+    }
+
+    open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        guard let collectionView = collectionView as? MessagesCollectionView else { return 0 }
+
+        let messageCount = collectionView.messagesDataSource?.numberOfMessages(in: collectionView) ?? 0
+        // There will only ever be 1 message per section
+        return messageCount > 0 ? 1 : 0
+
+    }
+
+    open func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+
+        guard let messagesCollectionView = collectionView as? MessagesCollectionView else {
+            fatalError("Managed collectionView: \(collectionView.debugDescription) is not a MessagesCollectionView.")
+        }
+
+        guard let messagesDataSource = messagesCollectionView.messagesDataSource else {
+            fatalError("MessagesDataSource has not been set.")
+        }
+
+        let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
+
+        switch message.data {
+        case .text, .attributedText, .emoji:
+            let cell = messagesCollectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
+            cell.configure(with: message, at: indexPath, and: messagesCollectionView)
+            return cell
+        case .photo, .video:
+            let cell = messagesCollectionView.dequeueReusableCell(MediaMessageCell.self, for: indexPath)
+            cell.configure(with: message, at: indexPath, and: messagesCollectionView)
+            return cell
+        case .location:
+            let cell = messagesCollectionView.dequeueReusableCell(LocationMessageCell.self, for: indexPath)
+            cell.configure(with: message, at: indexPath, and: messagesCollectionView)
+            return cell
+        }
+    }
+
+    open func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+
+        guard let messagesCollectionView = collectionView as? MessagesCollectionView else {
+            fatalError("Managed collectionView: \(collectionView.debugDescription) is not a MessagesCollectionView.")
+        }
+
+        guard let dataSource = messagesCollectionView.messagesDataSource else {
+            fatalError("MessagesDataSource has not been set.")
+        }
+
+        guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {
+            fatalError("MessagesDisplayDelegate has not been set.")
+        }
+
+        let message = dataSource.messageForItem(at: indexPath, in: messagesCollectionView)
+
+        switch kind {
+        case UICollectionElementKindSectionHeader:
+            return displayDelegate.messageHeaderView(for: message, at: indexPath, in: messagesCollectionView)
+        case UICollectionElementKindSectionFooter:
+            return displayDelegate.messageFooterView(for: message, at: indexPath, in: messagesCollectionView)
+        default:
+            fatalError("Unrecognized element of kind: \(kind)")
+        }
+    }
+}

--- a/Sources/Controllers/MessagesViewController+DataSource.swift
+++ b/Sources/Controllers/MessagesViewController+DataSource.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -40,7 +40,7 @@ extension MessagesViewController: UICollectionViewDataSource {
         }
         let messageCount = collectionView.messagesDataSource?.numberOfMessages(in: collectionView) ?? 0
         // There will only ever be 1 message per section
-        return messageCount > 0 ? 1 : 0
+        return messageCount > 0 ? 2 : 0
     }
 
     open func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -53,21 +53,28 @@ extension MessagesViewController: UICollectionViewDataSource {
             fatalError(MessageKitError.nilMessagesDataSource)
         }
 
+        let isMessageCell = indexPath.row == 0
+
         let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
 
-        switch message.data {
-        case .text, .attributedText, .emoji:
-            let cell = messagesCollectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
-            cell.configure(with: message, at: indexPath, and: messagesCollectionView)
-            return cell
-        case .photo, .video:
-            let cell = messagesCollectionView.dequeueReusableCell(MediaMessageCell.self, for: indexPath)
-            cell.configure(with: message, at: indexPath, and: messagesCollectionView)
-            return cell
-        case .location:
-            let cell = messagesCollectionView.dequeueReusableCell(LocationMessageCell.self, for: indexPath)
-            cell.configure(with: message, at: indexPath, and: messagesCollectionView)
-            return cell
+        if isMessageCell {
+
+            switch message.data {
+            case .text, .attributedText, .emoji:
+                let cell = messagesCollectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
+                cell.configure(with: message, at: indexPath, and: messagesCollectionView)
+                return cell
+            case .photo, .video:
+                let cell = messagesCollectionView.dequeueReusableCell(MediaMessageCell.self, for: indexPath)
+                cell.configure(with: message, at: indexPath, and: messagesCollectionView)
+                return cell
+            case .location:
+                let cell = messagesCollectionView.dequeueReusableCell(LocationMessageCell.self, for: indexPath)
+                cell.configure(with: message, at: indexPath, and: messagesCollectionView)
+                return cell
+            }
+        } else {
+            return messagesCollectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
         }
     }
 

--- a/Sources/Controllers/MessagesViewController+DataSource.swift
+++ b/Sources/Controllers/MessagesViewController+DataSource.swift
@@ -27,29 +27,30 @@ import UIKit
 extension MessagesViewController: UICollectionViewDataSource {
 
     open func numberOfSections(in collectionView: UICollectionView) -> Int {
-        guard let collectionView = collectionView as? MessagesCollectionView else { return 0 }
-
+        guard let collectionView = collectionView as? MessagesCollectionView else {
+            fatalError(MessageKitError.notMessagesCollectionView)
+        }
         // Each message is its own section
         return collectionView.messagesDataSource?.numberOfMessages(in: collectionView) ?? 0
     }
 
     open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        guard let collectionView = collectionView as? MessagesCollectionView else { return 0 }
-
+        guard let collectionView = collectionView as? MessagesCollectionView else {
+            fatalError(MessageKitError.notMessagesCollectionView)
+        }
         let messageCount = collectionView.messagesDataSource?.numberOfMessages(in: collectionView) ?? 0
         // There will only ever be 1 message per section
         return messageCount > 0 ? 1 : 0
-
     }
 
     open func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
 
         guard let messagesCollectionView = collectionView as? MessagesCollectionView else {
-            fatalError("Managed collectionView: \(collectionView.debugDescription) is not a MessagesCollectionView.")
+            fatalError(MessageKitError.notMessagesCollectionView)
         }
 
         guard let messagesDataSource = messagesCollectionView.messagesDataSource else {
-            fatalError("MessagesDataSource has not been set.")
+            fatalError(MessageKitError.nilMessagesDataSource)
         }
 
         let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
@@ -73,15 +74,15 @@ extension MessagesViewController: UICollectionViewDataSource {
     open func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
 
         guard let messagesCollectionView = collectionView as? MessagesCollectionView else {
-            fatalError("Managed collectionView: \(collectionView.debugDescription) is not a MessagesCollectionView.")
+            fatalError(MessageKitError.notMessagesCollectionView)
         }
 
         guard let dataSource = messagesCollectionView.messagesDataSource else {
-            fatalError("MessagesDataSource has not been set.")
+            fatalError(MessageKitError.nilMessagesDataSource)
         }
 
         guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {
-            fatalError("MessagesDisplayDelegate has not been set.")
+            fatalError(MessageKitError.nilMessagesDisplayDelegate)
         }
 
         let message = dataSource.messageForItem(at: indexPath, in: messagesCollectionView)
@@ -92,7 +93,7 @@ extension MessagesViewController: UICollectionViewDataSource {
         case UICollectionElementKindSectionFooter:
             return displayDelegate.messageFooterView(for: message, at: indexPath, in: messagesCollectionView)
         default:
-            fatalError("Unrecognized element of kind: \(kind)")
+            fatalError(MessageKitError.unrecognizedSectionKind)
         }
     }
 }

--- a/Sources/Controllers/MessagesViewController+DataSource.swift
+++ b/Sources/Controllers/MessagesViewController+DataSource.swift
@@ -40,7 +40,7 @@ extension MessagesViewController: UICollectionViewDataSource {
         }
         let messageCount = collectionView.messagesDataSource?.numberOfMessages(in: collectionView) ?? 0
         // There will only ever be 1 message per section
-        return messageCount > 0 ? 2 : 0
+        return messageCount > 0 ? 1 : 0
     }
 
     open func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -53,28 +53,21 @@ extension MessagesViewController: UICollectionViewDataSource {
             fatalError(MessageKitError.nilMessagesDataSource)
         }
 
-        let isMessageCell = indexPath.row == 0
-
         let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
 
-        if isMessageCell {
-
-            switch message.data {
-            case .text, .attributedText, .emoji:
-                let cell = messagesCollectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
-                cell.configure(with: message, at: indexPath, and: messagesCollectionView)
-                return cell
-            case .photo, .video:
-                let cell = messagesCollectionView.dequeueReusableCell(MediaMessageCell.self, for: indexPath)
-                cell.configure(with: message, at: indexPath, and: messagesCollectionView)
-                return cell
-            case .location:
-                let cell = messagesCollectionView.dequeueReusableCell(LocationMessageCell.self, for: indexPath)
-                cell.configure(with: message, at: indexPath, and: messagesCollectionView)
-                return cell
-            }
-        } else {
-            return messagesCollectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
+        switch message.data {
+        case .text, .attributedText, .emoji:
+            let cell = messagesCollectionView.dequeueReusableCell(TextMessageCell.self, for: indexPath)
+            cell.configure(with: message, at: indexPath, and: messagesCollectionView)
+            return cell
+        case .photo, .video:
+            let cell = messagesCollectionView.dequeueReusableCell(MediaMessageCell.self, for: indexPath)
+            cell.configure(with: message, at: indexPath, and: messagesCollectionView)
+            return cell
+        case .location:
+            let cell = messagesCollectionView.dequeueReusableCell(LocationMessageCell.self, for: indexPath)
+            cell.configure(with: message, at: indexPath, and: messagesCollectionView)
+            return cell
         }
     }
 

--- a/Sources/Controllers/MessagesViewController+Delegate.swift
+++ b/Sources/Controllers/MessagesViewController+Delegate.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Controllers/MessagesViewController+Delegate.swift
+++ b/Sources/Controllers/MessagesViewController+Delegate.swift
@@ -1,0 +1,87 @@
+/*
+ MIT License
+
+ Copyright (c) 2017 MessageKit
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+import UIKit
+
+extension MessagesViewController: UICollectionViewDelegateFlowLayout {
+
+    open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        guard let messagesFlowLayout = collectionViewLayout as? MessagesCollectionViewFlowLayout else { return .zero }
+        return messagesFlowLayout.sizeForItem(at: indexPath)
+    }
+
+    open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+        guard let messagesCollectionView = collectionView as? MessagesCollectionView else { return .zero }
+        guard let messagesDataSource = messagesCollectionView.messagesDataSource else { return .zero }
+        guard let messagesLayoutDelegate = messagesCollectionView.messagesLayoutDelegate else { return .zero }
+        // Could pose a problem if subclass behaviors allows more than one item per section
+        let indexPath = IndexPath(item: 0, section: section)
+        let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
+        return messagesLayoutDelegate.headerViewSize(for: message, at: indexPath, in: messagesCollectionView)
+    }
+
+    open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
+        guard let messagesCollectionView = collectionView as? MessagesCollectionView else { return .zero }
+        guard let messagesDataSource = messagesCollectionView.messagesDataSource else { return .zero }
+        guard let messagesLayoutDelegate = messagesCollectionView.messagesLayoutDelegate else { return .zero }
+        // Could pose a problem if subclass behaviors allows more than one item per section
+        let indexPath = IndexPath(item: 0, section: section)
+        let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
+        return messagesLayoutDelegate.footerViewSize(for: message, at: indexPath, in: messagesCollectionView)
+    }
+
+    open func collectionView(_ collectionView: UICollectionView, shouldShowMenuForItemAt indexPath: IndexPath) -> Bool {
+        guard let messagesDataSource = messagesCollectionView.messagesDataSource else { return false }
+        let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
+
+        switch message.data {
+        case .text, .attributedText, .emoji, .photo:
+            selectedIndexPathForMenu = indexPath
+            return true
+        default:
+            return false
+        }
+    }
+
+    open func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
+        return (action == NSSelectorFromString("copy:"))
+    }
+
+    open func collectionView(_ collectionView: UICollectionView, performAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) {
+        guard let messagesDataSource = messagesCollectionView.messagesDataSource else { fatalError("Please set messagesDataSource") }
+        let pasteBoard = UIPasteboard.general
+        let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
+
+        switch message.data {
+        case .text(let text), .emoji(let text):
+            pasteBoard.string = text
+        case .attributedText(let attributedText):
+            pasteBoard.string = attributedText.string
+        case .photo(let image):
+            pasteBoard.image = image
+        default:
+            break
+        }
+    }
+}

--- a/Sources/Controllers/MessagesViewController+Delegate.swift
+++ b/Sources/Controllers/MessagesViewController+Delegate.swift
@@ -32,23 +32,36 @@ extension MessagesViewController: UICollectionViewDelegateFlowLayout {
     }
 
     open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        guard let messagesCollectionView = collectionView as? MessagesCollectionView else { return .zero }
-        guard let messagesDataSource = messagesCollectionView.messagesDataSource else { return .zero }
-        guard let messagesLayoutDelegate = messagesCollectionView.messagesLayoutDelegate else { return .zero }
+
+        guard let messagesCollectionView = collectionView as? MessagesCollectionView else {
+            fatalError(MessageKitError.notMessagesCollectionView)
+        }
+        guard let dataSource = messagesCollectionView.messagesDataSource else {
+            fatalError(MessageKitError.nilMessagesDataSource)
+        }
+        guard let layoutDelegate = messagesCollectionView.messagesLayoutDelegate else {
+            fatalError(MessageKitError.nilMessagesLayoutDeleagte)
+        }
         // Could pose a problem if subclass behaviors allows more than one item per section
         let indexPath = IndexPath(item: 0, section: section)
-        let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
-        return messagesLayoutDelegate.headerViewSize(for: message, at: indexPath, in: messagesCollectionView)
+        let message = dataSource.messageForItem(at: indexPath, in: messagesCollectionView)
+        return layoutDelegate.headerViewSize(for: message, at: indexPath, in: messagesCollectionView)
     }
 
     open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
-        guard let messagesCollectionView = collectionView as? MessagesCollectionView else { return .zero }
-        guard let messagesDataSource = messagesCollectionView.messagesDataSource else { return .zero }
-        guard let messagesLayoutDelegate = messagesCollectionView.messagesLayoutDelegate else { return .zero }
+        guard let messagesCollectionView = collectionView as? MessagesCollectionView else {
+            fatalError(MessageKitError.notMessagesCollectionView)
+        }
+        guard let dataSource = messagesCollectionView.messagesDataSource else {
+            fatalError(MessageKitError.nilMessagesDataSource)
+        }
+        guard let layoutDelegate = messagesCollectionView.messagesLayoutDelegate else {
+            fatalError(MessageKitError.nilMessagesLayoutDeleagte)
+        }
         // Could pose a problem if subclass behaviors allows more than one item per section
         let indexPath = IndexPath(item: 0, section: section)
-        let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
-        return messagesLayoutDelegate.footerViewSize(for: message, at: indexPath, in: messagesCollectionView)
+        let message = dataSource.messageForItem(at: indexPath, in: messagesCollectionView)
+        return layoutDelegate.footerViewSize(for: message, at: indexPath, in: messagesCollectionView)
     }
 
     open func collectionView(_ collectionView: UICollectionView, shouldShowMenuForItemAt indexPath: IndexPath) -> Bool {
@@ -69,7 +82,9 @@ extension MessagesViewController: UICollectionViewDelegateFlowLayout {
     }
 
     open func collectionView(_ collectionView: UICollectionView, performAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) {
-        guard let messagesDataSource = messagesCollectionView.messagesDataSource else { fatalError("Please set messagesDataSource") }
+        guard let messagesDataSource = messagesCollectionView.messagesDataSource else {
+            fatalError(MessageKitError.nilMessagesDataSource)
+        }
         let pasteBoard = UIPasteboard.general
         let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
 

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -1,0 +1,106 @@
+/*
+ MIT License
+
+ Copyright (c) 2017 MessageKit
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+import Foundation
+
+extension MessagesViewController {
+
+    // MARK: - Register / Unregister Observers
+
+    func addKeyboardObservers() {
+        NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardDidChangeState), name: .UIKeyboardWillChangeFrame, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleTextViewDidBeginEditing), name: .UITextViewTextDidBeginEditing, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(adjustScrollViewInset), name: .UIDeviceOrientationDidChange, object: nil)
+    }
+
+    func removeKeyboardObservers() {
+        NotificationCenter.default.removeObserver(self, name: .UIKeyboardWillChangeFrame, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .UITextViewTextDidBeginEditing, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .UIDeviceOrientationDidChange, object: nil)
+    }
+
+    // MARK: - Notification Handlers
+
+    @objc
+    fileprivate func handleTextViewDidBeginEditing(_ notification: Notification) {
+        if scrollsToBottomOnKeybordBeginsEditing {
+            guard let inputTextView = notification.object as? InputTextView, inputTextView === messageInputBar.inputTextView else { return }
+            messagesCollectionView.scrollToBottom(animated: true)
+        }
+    }
+
+    @objc
+    fileprivate func handleKeyboardDidChangeState(_ notification: Notification) {
+        guard let keyboardEndFrame = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? CGRect else { return }
+
+        if (keyboardEndFrame.origin.y + keyboardEndFrame.size.height) > UIScreen.main.bounds.height {
+            // Hardware keyboard is found
+            messageCollectionViewBottomInset = view.frame.size.height - keyboardEndFrame.origin.y - iPhoneXBottomInset
+        } else {
+            //Software keyboard is found
+            let afterBottomInset = keyboardEndFrame.height > keyboardOffsetFrame.height ? (keyboardEndFrame.height - iPhoneXBottomInset) : keyboardOffsetFrame.height
+            let differenceOfBottomInset = afterBottomInset - messageCollectionViewBottomInset
+            let contentOffset = CGPoint(x: messagesCollectionView.contentOffset.x, y: messagesCollectionView.contentOffset.y + differenceOfBottomInset)
+
+            if maintainPositionOnKeyboardFrameChanged {
+                messagesCollectionView.setContentOffset(contentOffset, animated: false)
+            }
+
+            messageCollectionViewBottomInset = afterBottomInset
+        }
+    }
+
+    @objc
+    func adjustScrollViewInset() {
+        if #available(iOS 11.0, *) {
+            // No need to add to the top contentInset
+        } else {
+            let navigationBarInset = navigationController?.navigationBar.frame.height ?? 0
+            let statusBarInset: CGFloat = UIApplication.shared.isStatusBarHidden ? 0 : 20
+            let topInset = navigationBarInset + statusBarInset
+            messagesCollectionView.contentInset.top = topInset
+            messagesCollectionView.scrollIndicatorInsets.top = topInset
+        }
+    }
+
+    // MARK: - Helpers
+
+    var keyboardOffsetFrame: CGRect {
+        guard let inputFrame = inputAccessoryView?.frame else { return .zero }
+        return CGRect(origin: inputFrame.origin, size: CGSize(width: inputFrame.width, height: inputFrame.height - iPhoneXBottomInset))
+    }
+
+    /// On the iPhone X the inputAccessoryView is anchored to the layoutMarginesGuide.bottom anchor
+    /// so the frame of the inputAccessoryView is larger than the required offset
+    /// for the MessagesCollectionView.
+    ///
+    /// - Returns: The safeAreaInsets.bottom if its an iPhoneX, else 0
+    fileprivate var iPhoneXBottomInset: CGFloat {
+        if #available(iOS 11.0, *) {
+            guard UIScreen.main.nativeBounds.height == 2436 else { return 0 }
+            return view.safeAreaInsets.bottom
+        }
+        return 0
+    }
+}

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -29,9 +29,9 @@ extension MessagesViewController {
     // MARK: - Register / Unregister Observers
 
     func addKeyboardObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardDidChangeState), name: .UIKeyboardWillChangeFrame, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(handleTextViewDidBeginEditing), name: .UITextViewTextDidBeginEditing, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(adjustScrollViewInset), name: .UIDeviceOrientationDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(MessagesViewController.handleKeyboardDidChangeState(_:)), name: .UIKeyboardWillChangeFrame, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(MessagesViewController.handleTextViewDidBeginEditing(_:)), name: .UITextViewTextDidBeginEditing, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(MessagesViewController.adjustScrollViewInset), name: .UIDeviceOrientationDidChange, object: nil)
     }
 
     func removeKeyboardObservers() {
@@ -43,7 +43,7 @@ extension MessagesViewController {
     // MARK: - Notification Handlers
 
     @objc
-    fileprivate func handleTextViewDidBeginEditing(_ notification: Notification) {
+    private func handleTextViewDidBeginEditing(_ notification: Notification) {
         if scrollsToBottomOnKeybordBeginsEditing {
             guard let inputTextView = notification.object as? InputTextView, inputTextView === messageInputBar.inputTextView else { return }
             messagesCollectionView.scrollToBottom(animated: true)
@@ -51,7 +51,7 @@ extension MessagesViewController {
     }
 
     @objc
-    fileprivate func handleKeyboardDidChangeState(_ notification: Notification) {
+    private func handleKeyboardDidChangeState(_ notification: Notification) {
         guard let keyboardEndFrame = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? CGRect else { return }
 
         if (keyboardEndFrame.origin.y + keyboardEndFrame.size.height) > UIScreen.main.bounds.height {
@@ -96,7 +96,7 @@ extension MessagesViewController {
     /// for the MessagesCollectionView.
     ///
     /// - Returns: The safeAreaInsets.bottom if its an iPhoneX, else 0
-    fileprivate var iPhoneXBottomInset: CGFloat {
+    private var iPhoneXBottomInset: CGFloat {
         if #available(iOS 11.0, *) {
             guard UIScreen.main.nativeBounds.height == 2436 else { return 0 }
             return view.safeAreaInsets.bottom

--- a/Sources/Controllers/MessagesViewController+Menu.swift
+++ b/Sources/Controllers/MessagesViewController+Menu.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Controllers/MessagesViewController+Menu.swift
+++ b/Sources/Controllers/MessagesViewController+Menu.swift
@@ -1,0 +1,101 @@
+/*
+ MIT License
+
+ Copyright (c) 2017 MessageKit
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+import Foundation
+
+extension MessagesViewController {
+
+    // MARK: - Register / Unregister Observers
+
+    /// Add observer for `UIMenuControllerWillShowMenu` notification
+    func addMenuControllerObservers() {
+        NotificationCenter.default.addObserver(self, selector: #selector(MessagesViewController.menuControllerWillShow(notification:)), name: .UIMenuControllerWillShowMenu, object: nil)
+    }
+
+    /// Remove observer for `UIMenuControllerWillShowMenu` notification
+    func removeMenuControllerObservers() {
+        NotificationCenter.default.removeObserver(self, name: .UIMenuControllerWillShowMenu, object: nil)
+    }
+
+    // MARK: - Notification Handlers
+
+    /// Show menuController and set target rect to selected bubble
+    @objc
+    fileprivate func menuControllerWillShow(notification: Notification) {
+
+        guard let currentMenuController = notification.object as? UIMenuController,
+            let selectedIndexPath = selectedIndexPathForMenu else { return }
+
+        NotificationCenter.default.removeObserver(self, name: .UIMenuControllerWillShowMenu, object: nil)
+        defer {
+            NotificationCenter.default.addObserver(self,
+                                                   selector: #selector(MessagesViewController.menuControllerWillShow(notification:)),
+                                                   name: .UIMenuControllerWillShowMenu, object: nil)
+            selectedIndexPathForMenu = nil
+        }
+
+        currentMenuController.setMenuVisible(false, animated: false)
+
+        guard let selectedCell = messagesCollectionView.cellForItem(at: selectedIndexPath) as? MessageCollectionViewCell else { return }
+        let selectedCellMessageBubbleFrame = selectedCell.convert(selectedCell.messageContainerView.frame, to: view)
+
+        var messageInputBarFrame: CGRect = .zero
+        if let messageInputBarSuperview = messageInputBar.superview {
+            messageInputBarFrame = view.convert(messageInputBar.frame, from: messageInputBarSuperview)
+        }
+
+        var topNavigationBarFrame: CGRect = navigationBarFrame
+        if navigationBarFrame != .zero, let navigationBarSuperview = navigationController?.navigationBar.superview {
+            topNavigationBarFrame = view.convert(navigationController!.navigationBar.frame, from: navigationBarSuperview)
+        }
+
+        let menuHeight = currentMenuController.menuFrame.height
+
+        let selectedCellMessageBubblePlusMenuFrame = CGRect(selectedCellMessageBubbleFrame.origin.x, selectedCellMessageBubbleFrame.origin.y - menuHeight, selectedCellMessageBubbleFrame.size.width, selectedCellMessageBubbleFrame.size.height + 2 * menuHeight)
+
+        var targetRect: CGRect = selectedCellMessageBubbleFrame
+        currentMenuController.arrowDirection = .default
+
+        /// Message bubble intersects with navigationBar and keyboard
+        if selectedCellMessageBubblePlusMenuFrame.intersects(topNavigationBarFrame) && selectedCellMessageBubblePlusMenuFrame.intersects(messageInputBarFrame) {
+            let centerY = (selectedCellMessageBubblePlusMenuFrame.intersection(messageInputBarFrame).minY + selectedCellMessageBubblePlusMenuFrame.intersection(topNavigationBarFrame).maxY) / 2
+            targetRect = CGRect(selectedCellMessageBubblePlusMenuFrame.midX, centerY, 1, 1)
+        } /// Message bubble only intersects with navigationBar
+        else if selectedCellMessageBubblePlusMenuFrame.intersects(topNavigationBarFrame) {
+            currentMenuController.arrowDirection = .up
+        }
+
+        currentMenuController.setTargetRect(targetRect, in: view)
+        currentMenuController.setMenuVisible(true, animated: true)
+    }
+
+    // MARK: - Helpers
+
+    fileprivate var navigationBarFrame: CGRect {
+        guard let navigationController = navigationController, !navigationController.navigationBar.isHidden else {
+            return .zero
+        }
+        return navigationController.navigationBar.frame
+    }
+}

--- a/Sources/Controllers/MessagesViewController+Menu.swift
+++ b/Sources/Controllers/MessagesViewController+Menu.swift
@@ -30,7 +30,7 @@ extension MessagesViewController {
 
     /// Add observer for `UIMenuControllerWillShowMenu` notification
     func addMenuControllerObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(MessagesViewController.menuControllerWillShow(notification:)), name: .UIMenuControllerWillShowMenu, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(MessagesViewController.menuControllerWillShow(_:)), name: .UIMenuControllerWillShowMenu, object: nil)
     }
 
     /// Remove observer for `UIMenuControllerWillShowMenu` notification
@@ -42,7 +42,7 @@ extension MessagesViewController {
 
     /// Show menuController and set target rect to selected bubble
     @objc
-    fileprivate func menuControllerWillShow(notification: Notification) {
+    private func menuControllerWillShow(_ notification: Notification) {
 
         guard let currentMenuController = notification.object as? UIMenuController,
             let selectedIndexPath = selectedIndexPathForMenu else { return }
@@ -50,7 +50,7 @@ extension MessagesViewController {
         NotificationCenter.default.removeObserver(self, name: .UIMenuControllerWillShowMenu, object: nil)
         defer {
             NotificationCenter.default.addObserver(self,
-                                                   selector: #selector(MessagesViewController.menuControllerWillShow(notification:)),
+                                                   selector: #selector(MessagesViewController.menuControllerWillShow(_:)),
                                                    name: .UIMenuControllerWillShowMenu, object: nil)
             selectedIndexPathForMenu = nil
         }
@@ -92,7 +92,7 @@ extension MessagesViewController {
 
     // MARK: - Helpers
 
-    fileprivate var navigationBarFrame: CGRect {
+    private var navigationBarFrame: CGRect {
         guard let navigationController = navigationController, !navigationController.navigationBar.isHidden else {
             return .zero
         }

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017 MessageKit
+ Copyright (c) 2017-2018 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Extensions/CGRect+Extensions.swift
+++ b/Sources/Extensions/CGRect+Extensions.swift
@@ -31,4 +31,3 @@ extension CGRect {
     }
 
 }
-

--- a/Sources/Layout/MessageIntermediateLayoutAttributes.swift
+++ b/Sources/Layout/MessageIntermediateLayoutAttributes.swift
@@ -52,7 +52,7 @@ final class MessageIntermediateLayoutAttributes {
         case .cellTrailing:
             origin.x = cellFrame.width - avatarSize.width
         case .natural:
-            fatalError("AvatarPosition Horizontal.natural needs to be resolved.")
+            fatalError(MessageKitError.avatarPositionUnresolved)
         }
         
         switch avatarPosition.vertical {
@@ -91,7 +91,7 @@ final class MessageIntermediateLayoutAttributes {
         case .cellTrailing:
             origin.x = cellFrame.width - avatarSize.width - messageContainerSize.width - messageContainerPadding.right
         case .natural:
-            fatalError("AvatarPosition Horizontal.natural needs to be resolved.")
+            fatalError(MessageKitError.avatarPositionUnresolved)
         }
         
         return CGRect(origin: origin, size: messageContainerSize)

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -104,7 +104,7 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
         sectionInset = UIEdgeInsets(top: 4, left: 8, bottom: 4, right: 8)
 
-        NotificationCenter.default.addObserver(self, selector: #selector(handleOrientationChange), name: .UIDeviceOrientationDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(MessagesCollectionViewFlowLayout.handleOrientationChange(_:)), name: .UIDeviceOrientationDidChange, object: nil)
     }
 
     required public init?(coder aDecoder: NSCoder) {

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -66,7 +66,7 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
     /// Convenience property for accessing the layout object's `MessagesCollectionView`.
     fileprivate var messagesCollectionView: MessagesCollectionView {
         guard let messagesCollectionView = collectionView as? MessagesCollectionView else {
-            fatalError("MessagesCollectionViewFlowLayout is being used on a foreign type.")
+            fatalError(MessageKitError.layoutUsedOnForeignType)
         }
         return messagesCollectionView
     }
@@ -74,7 +74,7 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
     /// Convenience property for unwrapping the `MessagesCollectionView`'s `MessagesDataSource`.
     fileprivate var messagesDataSource: MessagesDataSource {
         guard let messagesDataSource = messagesCollectionView.messagesDataSource else {
-            fatalError("MessagesDataSource has not been set.")
+            fatalError(MessageKitError.nilMessagesDataSource)
         }
         return messagesDataSource
     }
@@ -82,7 +82,7 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
     /// Convenience property for unwrapping the `MessagesCollectionView`'s `MessagesLayoutDelegate`.
     fileprivate var messagesLayoutDelegate: MessagesLayoutDelegate {
         guard let messagesLayoutDelegate = messagesCollectionView.messagesLayoutDelegate else {
-            fatalError("MessagesLayoutDeleagte has not been set.")
+            fatalError(MessageKitError.nilMessagesLayoutDeleagte)
         }
         return messagesLayoutDelegate
     }
@@ -502,7 +502,7 @@ private extension MessagesCollectionViewFlowLayout {
             return itemWidth - avatarWidth - attributes.messageContainerPadding.right - attributes.bottomLabelHorizontalPadding
 
         case (_, .natural):
-            fatalError("AvatarPosition Horizontal.natural needs to be resolved.")
+            fatalError(MessageKitError.avatarPositionUnresolved)
         }
         
     }
@@ -575,7 +575,7 @@ private extension MessagesCollectionViewFlowLayout {
             return itemWidth - avatarWidth - attributes.messageContainerPadding.right - attributes.topLabelHorizontalPadding
 
         case (_, .natural):
-            fatalError("AvatarPosition Horizontal.natural needs to be resolved.")
+            fatalError(MessageKitError.avatarPositionUnresolved)
         }
         
     }

--- a/Sources/Models/LocationMessageSnapshotOptions.swift
+++ b/Sources/Models/LocationMessageSnapshotOptions.swift
@@ -34,7 +34,7 @@ public struct LocationMessageSnapshotOptions {
     ///   - showsPointsOfInterest: A Boolean value indicating whether the snapshot image should display points of interest.
     ///   - span: The span of the snapshot.
     ///   - scale: The scale of the snapshot.
-    public init(showsBuildings: Bool = false, showsPointsOfInterest: Bool = false, span: MKCoordinateSpan = MKCoordinateSpan(latitudeDelta: 0, longitudeDelta: 0) , scale: CGFloat = UIScreen.main.scale) {
+    public init(showsBuildings: Bool = false, showsPointsOfInterest: Bool = false, span: MKCoordinateSpan = MKCoordinateSpan(latitudeDelta: 0, longitudeDelta: 0), scale: CGFloat = UIScreen.main.scale) {
         self.showsBuildings = showsBuildings
         self.showsPointsOfInterest = showsPointsOfInterest
         self.span = span

--- a/Sources/Models/MessageKitError.swift
+++ b/Sources/Models/MessageKitError.swift
@@ -22,22 +22,15 @@
  SOFTWARE.
  */
 
-import Foundation
-
-extension Bundle {
-
-    static func messageKitAssetBundle() -> Bundle {
-        let podBundle = Bundle(for: MessagesViewController.self)
-        
-        guard let resourceBundleUrl = podBundle.url(forResource: "MessageKitAssets", withExtension: "bundle") else {
-            fatalError(MessageKitError.couldNotCreateAssetsPath)
-        }
-        
-        guard let resourceBundle = Bundle(url: resourceBundleUrl) else {
-            fatalError(MessageKitError.couldNotLoadAssetsBundle)
-        }
-        
-        return resourceBundle
-    }
-
+enum MessageKitError {
+    static let avatarPositionUnresolved = "AvatarPosition Horizontal.natural needs to be resolved."
+    static let nilMessagesDataSource = "MessagesDataSource has not been set."
+    static let nilMessagesDisplayDelegate = "MessagesDisplayDelegate has not been set."
+    static let nilMessagesLayoutDeleagte = "MessagesLayoutDelegate has not been set."
+    static let notMessagesCollectionView = "The collectionView is not a MessagesCollectionView."
+    static let layoutUsedOnForeignType = "MessagesCollectionViewFlowLayout is being used on a foreign type."
+    static let unrecognizedSectionKind = "Received unrecognized element kind:"
+    static let unrecognizedCheckingResult = "Received an unrecognized NSTextCheckingResult.CheckingType"
+    static let couldNotLoadAssetsBundle = "MessageKit: Could not load the assets bundle"
+    static let couldNotCreateAssetsPath = "MessageKit: Could not create path to the assets bundle."
 }

--- a/Sources/Models/Sender.swift
+++ b/Sources/Models/Sender.swift
@@ -50,7 +50,7 @@ public struct Sender {
 extension Sender: Equatable {
 
     /// Two senders are considered equal if they have the same id.
-    static public func == (left: Sender, right: Sender) -> Bool {
+    public static func == (left: Sender, right: Sender) -> Bool {
         return left.id == right.id
     }
 

--- a/Sources/Protocols/MessagesDisplayDelegate.swift
+++ b/Sources/Protocols/MessagesDisplayDelegate.swift
@@ -212,7 +212,9 @@ public extension MessagesDisplayDelegate {
     // MARK: - Text Messages Defaults
 
     func textColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
-        guard let dataSource = messagesCollectionView.messagesDataSource else { return .darkText }
+        guard let dataSource = messagesCollectionView.messagesDataSource else {
+            fatalError(MessageKitError.nilMessagesDataSource)
+        }
         return dataSource.isFromCurrentSender(message: message) ? .white : .darkText
     }
 

--- a/Sources/Protocols/MessagesLayoutDelegate.swift
+++ b/Sources/Protocols/MessagesLayoutDelegate.swift
@@ -192,7 +192,9 @@ public extension MessagesLayoutDelegate {
     // MARK: - All Messages Defaults
 
     func messagePadding(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIEdgeInsets {
-        guard let dataSource = messagesCollectionView.messagesDataSource else { return .zero }
+        guard let dataSource = messagesCollectionView.messagesDataSource else {
+            fatalError(MessageKitError.nilMessagesDataSource)
+        }
         if dataSource.isFromCurrentSender(message: message) {
             return UIEdgeInsets(top: 0, left: 30, bottom: 0, right: 4)
         } else {
@@ -201,12 +203,16 @@ public extension MessagesLayoutDelegate {
     }
 
     func cellTopLabelAlignment(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LabelAlignment {
-        guard let dataSource = messagesCollectionView.messagesDataSource else { return .cellCenter(.zero) }
+        guard let dataSource = messagesCollectionView.messagesDataSource else {
+            fatalError(MessageKitError.nilMessagesDataSource)
+        }
         return dataSource.isFromCurrentSender(message: message) ? .messageTrailing(.zero) : .messageLeading(.zero)
     }
 
     func cellBottomLabelAlignment(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LabelAlignment {
-        guard let dataSource = messagesCollectionView.messagesDataSource else { return .cellCenter(.zero) }
+        guard let dataSource = messagesCollectionView.messagesDataSource else {
+            fatalError(MessageKitError.nilMessagesDataSource)
+        }
         return dataSource.isFromCurrentSender(message: message) ? .messageLeading(.zero) : .messageTrailing(.zero)
     }
 
@@ -219,7 +225,9 @@ public extension MessagesLayoutDelegate {
     }
 
     func headerViewSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize {
-        guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else { return .zero }
+        guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {
+            fatalError(MessageKitError.nilMessagesDisplayDelegate)
+        }
         let shouldDisplay = displayDelegate.shouldDisplayHeader(for: message, at: indexPath, in: messagesCollectionView)
         return shouldDisplay ? CGSize(width: messagesCollectionView.bounds.width, height: 12) : .zero
     }
@@ -235,7 +243,9 @@ public extension MessagesLayoutDelegate {
     // MARK: - Text Messages Defaults
 
     func messageLabelInset(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIEdgeInsets {
-        guard let dataSource = messagesCollectionView.messagesDataSource else { return .zero }
+        guard let dataSource = messagesCollectionView.messagesDataSource else {
+            fatalError(MessageKitError.nilMessagesDataSource)
+        }
         if dataSource.isFromCurrentSender(message: message) {
             return UIEdgeInsets(top: 7, left: 14, bottom: 7, right: 18)
         } else {
@@ -264,5 +274,4 @@ public extension MessagesLayoutDelegate {
     func widthForLocation(message: MessageType, at indexPath: IndexPath, with maxWidth: CGFloat, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
         return maxWidth
     }
-
 }

--- a/Sources/Views/AvatarView.swift
+++ b/Sources/Views/AvatarView.swift
@@ -169,8 +169,7 @@ open class AvatarView: UIImageView {
     open func set(avatar: Avatar) {
         if let image = avatar.image {
             self.image = image
-        }
-        else {
+        } else {
             initials = avatar.initials
         }
     }

--- a/Sources/Views/Cells/LocationMessageCell.swift
+++ b/Sources/Views/Cells/LocationMessageCell.swift
@@ -99,7 +99,5 @@ open class LocationMessageCell: MessageCollectionViewCell {
             self.imageView.image = composedImage
             animationBlock?(self.imageView)
         }
-        
-        
     }
 }

--- a/Sources/Views/Cells/LocationMessageCell.swift
+++ b/Sources/Views/Cells/LocationMessageCell.swift
@@ -51,7 +51,7 @@ open class LocationMessageCell: MessageCollectionViewCell {
     open override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
         super.configure(with: message, at: indexPath, and: messagesCollectionView)
         guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {
-            fatalError("MessagesDisplayDelegate is not set.")
+            fatalError(MessageKitError.nilMessagesDisplayDelegate)
         }
         let options = displayDelegate.snapshotOptionsForLocation(message: message, at: indexPath, in: messagesCollectionView)
         let annotationView = displayDelegate.annotationViewForLocation(message: message, at: indexPath, in: messagesCollectionView)

--- a/Sources/Views/Cells/MessageCollectionViewCell.swift
+++ b/Sources/Views/Cells/MessageCollectionViewCell.swift
@@ -91,10 +91,10 @@ open class MessageCollectionViewCell: UICollectionViewCell, CollectionViewReusab
 
     open func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
         guard let dataSource = messagesCollectionView.messagesDataSource else {
-            fatalError("MessagesDataSource is not set.")
+            fatalError(MessageKitError.nilMessagesDataSource)
         }
         guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {
-            fatalError("MessagesDisplayDelegate is not set.")
+            fatalError(MessageKitError.nilMessagesDisplayDelegate)
         }
 
         delegate = messagesCollectionView.messageCellDelegate

--- a/Sources/Views/Cells/MessageCollectionViewCell.swift
+++ b/Sources/Views/Cells/MessageCollectionViewCell.swift
@@ -53,7 +53,7 @@ open class MessageCollectionViewCell: UICollectionViewCell, CollectionViewReusab
 
     open weak var delegate: MessageCellDelegate?
 
-    override public init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
         contentView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         setupSubviews()

--- a/Sources/Views/Cells/TextMessageCell.swift
+++ b/Sources/Views/Cells/TextMessageCell.swift
@@ -64,7 +64,7 @@ open class TextMessageCell: MessageCollectionViewCell {
         super.configure(with: message, at: indexPath, and: messagesCollectionView)
 
         guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {
-            fatalError("MessagesDisplayDelegate not set.")
+            fatalError(MessageKitError.nilMessagesDisplayDelegate)
         }
 
         let textColor = displayDelegate.textColor(for: message, at: indexPath, in: messagesCollectionView)

--- a/Sources/Views/InputTextView.swift
+++ b/Sources/Views/InputTextView.swift
@@ -273,7 +273,7 @@ open class InputTextView: UITextView {
         
         var images = [UIImage]()
         let range = NSRange(location: 0, length: attributedText.length)
-        attributedText.enumerateAttribute(.attachment, in: range, options: [], using: { value, range, stop -> Void in
+        attributedText.enumerateAttribute(.attachment, in: range, options: [], using: { value, range, _ -> Void in
             
             if let attachment = value as? NSTextAttachment {
                 if let image = attachment.image {
@@ -296,7 +296,7 @@ open class InputTextView: UITextView {
         
         var components = [Any]()
         let range = NSRange(location: 0, length: attributedText.length)
-        attributedText.enumerateAttributes(in: range, options: []) { (object, range, stop) in
+        attributedText.enumerateAttributes(in: range, options: []) { (object, range, _) in
             
             if object.keys.contains(.attachment) {
                 if let attachment = object[.attachment] as? NSTextAttachment {
@@ -324,7 +324,7 @@ open class InputTextView: UITextView {
         
         guard images.count > 0 else { return }
         let range = NSRange(location: 0, length: attributedText.length)
-        attributedText.enumerateAttribute(.attachment, in: range, options: [], using: { value, range, stop -> Void in
+        attributedText.enumerateAttribute(.attachment, in: range, options: [], using: { value, _, _ -> Void in
             if let attachment = value as? NSTextAttachment, let image = attachment.image {
                 
                 // Calculates a new width/height ratio to fit the image in the current frame

--- a/Sources/Views/InputTextView.swift
+++ b/Sources/Views/InputTextView.swift
@@ -234,9 +234,9 @@ open class InputTextView: UITextView {
         newAttributedStingComponent.append(NSAttributedString(string: "\n"))
         
         // The attributes that should be applied to the new NSAttributedString to match the current attributes
-        let attributes: [NSAttributedStringKey:Any] = [
-            NSAttributedStringKey.font : font ?? UIFont.preferredFont(forTextStyle: .body),
-            NSAttributedStringKey.foregroundColor : textColor ?? .black,
+        let attributes: [NSAttributedStringKey: Any] = [
+            NSAttributedStringKey.font: font ?? UIFont.preferredFont(forTextStyle: .body),
+            NSAttributedStringKey.foregroundColor: textColor ?? .black
             ]
         newAttributedStingComponent.addAttributes(attributes, range: NSRange(location: 0, length: newAttributedStingComponent.length))
         
@@ -298,7 +298,7 @@ open class InputTextView: UITextView {
         let range = NSRange(location: 0, length: attributedText.length)
         attributedText.enumerateAttributes(in: range, options: []) { (object, range, stop) in
             
-            if object.keys.contains(.attachment){
+            if object.keys.contains(.attachment) {
                 if let attachment = object[.attachment] as? NSTextAttachment {
                     if let image = attachment.image {
                         components.append(image)

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -283,7 +283,7 @@ open class MessageLabel: UILabel {
         case .link:
             return urlAttributes
         default:
-            fatalError("Received an unrecognized NSTextCheckingResult.CheckingType")
+            fatalError(MessageKitError.unrecognizedCheckingResult)
         }
     }
 

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -412,7 +412,7 @@ open class MessageLabel: UILabel {
     
 }
 
-fileprivate enum MessageTextCheckingType {
+private enum MessageTextCheckingType {
     case addressComponents([NSTextCheckingKey: String]?)
     case date(Date?)
     case phoneNumber(String?)

--- a/Tests/ProtocolsTests/MessagesDisplayDelegateTests.swift
+++ b/Tests/ProtocolsTests/MessagesDisplayDelegateTests.swift
@@ -212,7 +212,8 @@ class TextMessageDisplayDelegateTests: XCTestCase {
     }
 
     func testTextColorWithoutDataSource_returnsDarkTextForDefault() {
-        sut.messagesCollectionView.messagesDataSource = nil
+        let dataSource = sut.makeDataSource()
+        sut.messagesCollectionView.messagesDataSource = dataSource
         let textColor = sut.textColor(for: sut.dataProvider.messages[1],
                                       at: IndexPath(item: 0, section: 0),
                                       in: sut.messagesCollectionView)
@@ -249,7 +250,7 @@ private class MockMessagesViewController: MessagesViewController, MessagesDispla
 
     }
 
-    private func makeDataSource() -> MockMessagesDataSource {
+    fileprivate func makeDataSource() -> MockMessagesDataSource {
         let dataSource = MockMessagesDataSource()
         dataSource.messages.append(MockMessage(text: "Text 1",
                                                sender: dataSource.senders[0],


### PR DESCRIPTION
This PR splits `MessagesViewController` functionality into separate files:
- MessagesViewController
- MessagesViewController+DataSource
- MessagesViewController+Delegate
- MessagesViewController+Keyboard
- MessagesViewController+Menu

And I added `MessageKitError` to clean up some of the strings that were bugging me 😅 

I also stopped returning default values like `.zero` in the case of `MessagesDataSource` being `nil`. This should be a `fatalError`.

@MessageKit/core-team let me know if you're ok with this setup