### PR TITLE
Fix bubble backgroundColor deranged when swipe

### DIFF
--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -82,6 +82,12 @@ open class MessagesViewController: UIViewController {
         setupDelegates()
         addMenuControllerObservers()
     }
+    
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        view.layoutIfNeeded()
+        messagesCollectionView.collectionViewLayout.invalidateLayout()
+    }
 
     open override func viewDidLayoutSubviews() {
         // Hack to prevent animation of the contentInset after viewDidAppear


### PR DESCRIPTION
TODO:
- [ ] Add CHANGELOG

message bubble backgroundColor would deranged that operation the same as #448 

<img width="379" alt="message-color-bug" src="https://user-images.githubusercontent.com/5061845/34923378-3e46922a-f9d6-11e7-9f02-a42bd9b33ab5.png">
<img width="379" alt="message-bubble-backcolor-disorder" src="https://user-images.githubusercontent.com/5061845/34923379-408b0714-f9d6-11e7-9595-15608fa9454d.png">
