### PR TITLE
Feature/text messages settings

### DIFF
--- a/Example/.idea/vcs.xml
+++ b/Example/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/Example/.idea/vcs.xml
+++ b/Example/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
-  </component>
-</project>

--- a/Example/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/ChatExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2C85B1F57387B7352E93BFDE /* SampleDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C85BC5D71440D97D0B56820 /* SampleDataTests.swift */; };
 		37D3EAC41F390E5F00DD6A55 /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D3EAC31F390E5F00DD6A55 /* SampleData.swift */; };
 		882B5E811CF7D53600B6E160 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882B5E781CF7D53600B6E160 /* AppDelegate.swift */; };
 		882B5E821CF7D53600B6E160 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 882B5E791CF7D53600B6E160 /* Assets.xcassets */; };
@@ -57,6 +58,7 @@
 /* Begin PBXFileReference section */
 		0364943D08CDBE656E6F6DF8 /* Pods-ChatExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ChatExampleTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ChatExampleTests/Pods-ChatExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2AC6E3F5C11E39F57598DBE6 /* Pods_ChatExampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ChatExampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2C85BC5D71440D97D0B56820 /* SampleDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleDataTests.swift; sourceTree = "<group>"; };
 		37D3EAC31F390E5F00DD6A55 /* SampleData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleData.swift; sourceTree = "<group>"; };
 		3B316705C4717C3B4C916D62 /* Pods_ChatExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ChatExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		56F0AC85B38034EC92CCBC7D /* Pods_ChatExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ChatExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -179,6 +181,7 @@
 			children = (
 				882B5E931CF7D56E00B6E160 /* ChatExampleTests.swift */,
 				882B5E941CF7D56E00B6E160 /* Info.plist */,
+				2C85BC5D71440D97D0B56820 /* SampleDataTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -505,6 +508,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				882B5E951CF7D56E00B6E160 /* ChatExampleTests.swift in Sources */,
+				2C85B1F57387B7352E93BFDE /* SampleDataTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Sources/MockMessage.swift
+++ b/Example/Sources/MockMessage.swift
@@ -32,37 +32,38 @@ struct MockMessage: MessageType {
 	var sender: Sender
 	var sentDate: Date
 	var data: MessageData
+    var type: String
 	
-    init(data: MessageData, sender: Sender, messageId: String, date: Date) {
+    init(data: MessageData, sender: Sender, messageId: String, date: Date, type: String) {
 		self.data = data
 		self.sender = sender
 		self.messageId = messageId
 		self.sentDate = date
+        self.type = type
 	}
 	
     init(text: String, sender: Sender, messageId: String, date: Date) {
-        self.init(data: .text(text), sender: sender, messageId: messageId, date: date)
+        self.init(data: .text(text), sender: sender, messageId: messageId, date: date, type: "text")
 	}
 	
     init(attributedText: NSAttributedString, sender: Sender, messageId: String, date: Date) {
-        self.init(data: .attributedText(attributedText), sender: sender, messageId: messageId, date: date)
+        self.init(data: .attributedText(attributedText), sender: sender, messageId: messageId, date: date, type: "attributedText")
 	}
 
     init(image: UIImage, sender: Sender, messageId: String, date: Date) {
-        self.init(data: .photo(image), sender: sender, messageId: messageId, date: date)
+        self.init(data: .photo(image), sender: sender, messageId: messageId, date: date, type: "photo")
     }
 
     init(thumbnail: UIImage, sender: Sender, messageId: String, date: Date) {
         let url = URL(fileURLWithPath: "")
-        self.init(data: .video(file: url, thumbnail: thumbnail), sender: sender, messageId: messageId, date: date)
+        self.init(data: .video(file: url, thumbnail: thumbnail), sender: sender, messageId: messageId, date: date, type: "video")
     }
 
     init(location: CLLocation, sender: Sender, messageId: String, date: Date) {
-        self.init(data: .location(location), sender: sender, messageId: messageId, date: date)
+        self.init(data: .location(location), sender: sender, messageId: messageId, date: date, type: "location")
     }
 
     init(emoji: String, sender: Sender, messageId: String, date: Date) {
-        self.init(data: .emoji(emoji), sender: sender, messageId: messageId, date: date)
+        self.init(data: .emoji(emoji), sender: sender, messageId: messageId, date: date, type: "emoji")
     }
-
 }

--- a/Example/Sources/MockMessage.swift
+++ b/Example/Sources/MockMessage.swift
@@ -32,38 +32,36 @@ struct MockMessage: MessageType {
 	var sender: Sender
 	var sentDate: Date
 	var data: MessageData
-    var type: String
 	
-    init(data: MessageData, sender: Sender, messageId: String, date: Date, type: String) {
+    init(data: MessageData, sender: Sender, messageId: String, date: Date) {
 		self.data = data
 		self.sender = sender
 		self.messageId = messageId
 		self.sentDate = date
-        self.type = type
 	}
 	
     init(text: String, sender: Sender, messageId: String, date: Date) {
-        self.init(data: .text(text), sender: sender, messageId: messageId, date: date, type: "text")
+        self.init(data: .text(text), sender: sender, messageId: messageId, date: date)
 	}
 	
     init(attributedText: NSAttributedString, sender: Sender, messageId: String, date: Date) {
-        self.init(data: .attributedText(attributedText), sender: sender, messageId: messageId, date: date, type: "attributedText")
+        self.init(data: .attributedText(attributedText), sender: sender, messageId: messageId, date: date)
 	}
 
     init(image: UIImage, sender: Sender, messageId: String, date: Date) {
-        self.init(data: .photo(image), sender: sender, messageId: messageId, date: date, type: "photo")
+        self.init(data: .photo(image), sender: sender, messageId: messageId, date: date)
     }
 
     init(thumbnail: UIImage, sender: Sender, messageId: String, date: Date) {
         let url = URL(fileURLWithPath: "")
-        self.init(data: .video(file: url, thumbnail: thumbnail), sender: sender, messageId: messageId, date: date, type: "video")
+        self.init(data: .video(file: url, thumbnail: thumbnail), sender: sender, messageId: messageId, date: date)
     }
 
     init(location: CLLocation, sender: Sender, messageId: String, date: Date) {
-        self.init(data: .location(location), sender: sender, messageId: messageId, date: date, type: "location")
+        self.init(data: .location(location), sender: sender, messageId: messageId, date: date)
     }
 
     init(emoji: String, sender: Sender, messageId: String, date: Date) {
-        self.init(data: .emoji(emoji), sender: sender, messageId: messageId, date: date, type: "emoji")
+        self.init(data: .emoji(emoji), sender: sender, messageId: messageId, date: date)
     }
 }

--- a/Example/Sources/SampleData.swift
+++ b/Example/Sources/SampleData.swift
@@ -72,7 +72,7 @@ final class SampleData {
 
     var now = Date()
 
-    var messageTypes = ["text", "attributedText", "photo", "video", "location", "emoji"]
+    var messageTypes: [String] = []
 
     let attributes = ["Font1", "Font2", "Font3", "Font4", "Color", "Combo"]
 
@@ -202,32 +202,24 @@ final class SampleData {
     func updateMessageTypes() {
         resetMessageTypes()
 
-        if UserDefaults.standard.shouldHideTextMessages() {
-            hideMessageTypes(types: "text")
+        if !UserDefaults.standard.shouldHideTextMessages() {
+            messageTypes.append("text")
         }
 
-        if UserDefaults.standard.shouldHideAttributedTextMessages() {
-            hideMessageTypes(types: "attributedText")
+        if !UserDefaults.standard.shouldHideAttributedTextMessages() {
+            messageTypes.append("attributedText")
         }
 
-        if UserDefaults.standard.shouldHidePhotoMessages() {
-            hideMessageTypes(types: "photo")
+        if !UserDefaults.standard.shouldHidePhotoMessages() {
+            messageTypes.append("photo")
         }
 
-        if UserDefaults.standard.shouldHideVideoMessages() {
-            hideMessageTypes(types: "video")
-        }
-    }
-
-    func hideMessageTypes(types: String...) {
-        types.forEach { type in
-            if let indexToRemove = messageTypes.index(of: type) {
-                messageTypes.remove(at: indexToRemove)
-            }
+        if !UserDefaults.standard.shouldHideVideoMessages() {
+            messageTypes.append("video")
         }
     }
 
     func resetMessageTypes() {
-        messageTypes = ["text", "attributedText", "photo", "video", "location", "emoji"]
+        messageTypes = ["location", "emoji"]
     }
 }

--- a/Example/Sources/SampleData.swift
+++ b/Example/Sources/SampleData.swift
@@ -29,7 +29,9 @@ final class SampleData {
 
     static let shared = SampleData()
 
-    private init() {}
+    private init() {
+        updateMessageTypes()
+    }
 
     let messageTextValues = [
         "Ok",
@@ -70,7 +72,7 @@ final class SampleData {
 
     var now = Date()
 
-    let messageTypes = ["Text", "Text", "Text", "AttributedText", "Photo", "Video", "Location", "Emoji"]
+    var messageTypes = ["text", "attributedText", "photo", "video", "location", "emoji"]
 
     let attributes = ["Font1", "Font2", "Font3", "Font4", "Color", "Combo"]
 
@@ -154,20 +156,20 @@ final class SampleData {
         let date = dateAddingRandomTime()
 
         switch messageTypes[randomMessageType] {
-        case "Text":
+        case "text":
             return MockMessage(text: messageTextValues[randomNumberText], sender: sender, messageId: uniqueID, date: date)
-        case "AttributedText":
+        case "attributedText":
             let attributedText = attributedString(with: messageTextValues[randomNumberText])
             return MockMessage(attributedText: attributedText, sender: senders[randomNumberSender], messageId: uniqueID, date: date)
-        case "Photo":
+        case "photo":
             let image = messageImages[randomNumberImage]
             return MockMessage(image: image, sender: sender, messageId: uniqueID, date: date)
-        case "Video":
+        case "video":
             let image = messageImages[randomNumberImage]
             return MockMessage(thumbnail: image, sender: sender, messageId: uniqueID, date: date)
-        case "Location":
+        case "location":
             return MockMessage(location: locations[randomNumberLocation], sender: sender, messageId: uniqueID, date: date)
-        case "Emoji":
+        case "emoji":
             return MockMessage(emoji: emojis[randomNumberEmoji], sender: sender, messageId: uniqueID, date: date)
         default:
             fatalError("Unrecognized mock message type")
@@ -197,4 +199,35 @@ final class SampleData {
         }
     }
 
+    func updateMessageTypes() {
+        resetMessageTypes()
+
+        if UserDefaults.standard.shouldHideTextMessages() {
+            hideMessageTypes(types: .text(""))
+        }
+
+        if UserDefaults.standard.shouldHideAttributedTextMessages() {
+            hideMessageTypes(types: .attributedText(NSAttributedString()))
+        }
+
+        if UserDefaults.standard.shouldHidePhotoMessages() {
+            hideMessageTypes(types: .photo(UIImage()))
+        }
+
+        if UserDefaults.standard.shouldHideVideoMessages() {
+            hideMessageTypes(types: .video(file: URL(string: "http://")!, thumbnail: UIImage()))
+        }
+    }
+
+    func hideMessageTypes(types: MessageData...) {
+        types.forEach { type in
+            if let indexToRemove = messageTypes.index(of: type.rawValue) {
+                messageTypes.remove(at: indexToRemove)
+            }
+        }
+    }
+
+    func resetMessageTypes() {
+        messageTypes = ["text", "attributedText", "photo", "video", "location", "emoji"]
+    }
 }

--- a/Example/Sources/SampleData.swift
+++ b/Example/Sources/SampleData.swift
@@ -203,25 +203,25 @@ final class SampleData {
         resetMessageTypes()
 
         if UserDefaults.standard.shouldHideTextMessages() {
-            hideMessageTypes(types: .text(""))
+            hideMessageTypes(types: "text")
         }
 
         if UserDefaults.standard.shouldHideAttributedTextMessages() {
-            hideMessageTypes(types: .attributedText(NSAttributedString()))
+            hideMessageTypes(types: "attributedText")
         }
 
         if UserDefaults.standard.shouldHidePhotoMessages() {
-            hideMessageTypes(types: .photo(UIImage()))
+            hideMessageTypes(types: "photo")
         }
 
         if UserDefaults.standard.shouldHideVideoMessages() {
-            hideMessageTypes(types: .video(file: URL(string: "http://")!, thumbnail: UIImage()))
+            hideMessageTypes(types: "video")
         }
     }
 
-    func hideMessageTypes(types: MessageData...) {
+    func hideMessageTypes(types: String...) {
         types.forEach { type in
-            if let indexToRemove = messageTypes.index(of: type.rawValue) {
+            if let indexToRemove = messageTypes.index(of: type) {
                 messageTypes.remove(at: indexToRemove)
             }
         }

--- a/Example/Sources/Settings+UserDefaults.swift
+++ b/Example/Sources/Settings+UserDefaults.swift
@@ -24,21 +24,69 @@
 
 import Foundation
 
+let messagesKey = "mockMessages"
+let hideTextMessagesKey = "hideTextMessages"
+let hideAttributedTextMessagesKey = "hideAttributedTextMessages"
+let hidePhotoMessagesKey = "hidePhotoMessages"
+let hideVideoMessagesKey = "hideVideoMessages"
+
 extension UserDefaults {
-    
-    static let messagesKey = "mockMessages"
     
     // MARK: - Mock Messages
     
     func setMockMessages(count: Int) {
-        set(count, forKey: "mockMessages")
+        set(count, forKey: messagesKey)
         synchronize()
     }
     
     func mockMessagesCount() -> Int {
-        if let value = object(forKey: "mockMessages") as? Int {
+        if let value = object(forKey: messagesKey) as? Int {
             return value
         }
         return 20
+    }
+
+    // MARK: - Text Messages
+
+    func setShouldHideTextMessages(value: Bool) {
+        set(value, forKey: hideTextMessagesKey)
+        synchronize()
+    }
+
+    func shouldHideTextMessages() -> Bool {
+        return bool(forKey: hideTextMessagesKey)
+    }
+
+    // MARK: - AttributedText Messages
+
+    func setShouldHideAttributedTextMessages(value: Bool) {
+        set(value, forKey: hideAttributedTextMessagesKey)
+        synchronize()
+    }
+
+    func shouldHideAttributedTextMessages() -> Bool {
+        return bool(forKey: hideAttributedTextMessagesKey)
+    }
+
+    // MARK: - Photo messages
+
+    func setShouldHidePhotoMessages(value: Bool) {
+        set(value, forKey: hidePhotoMessagesKey)
+        synchronize()
+    }
+
+    func shouldHidePhotoMessages() -> Bool {
+        return bool(forKey: hidePhotoMessagesKey)
+    }
+
+    // MARK: - Video messages
+
+    func setShouldHideVideoMessages(value: Bool) {
+        set(value, forKey: hideVideoMessagesKey)
+        synchronize()
+    }
+
+    func shouldHideVideoMessages() -> Bool {
+        return bool(forKey: hideVideoMessagesKey)
     }
 }

--- a/Example/Sources/TableViewCells.swift
+++ b/Example/Sources/TableViewCells.swift
@@ -24,9 +24,17 @@
 
 import UIKit
 
-class TextFieldTableViewCell: UITableViewCell {
+protocol UITableViewCellIdentifier {
+    static var identifier: String { get }
+}
 
-    static let identifier = "TextFieldTableViewCellIdentifier"
+// MARK: - TextFieldTableViewCell
+
+class TextFieldTableViewCell: UITableViewCell, UITableViewCellIdentifier {
+
+    // MARK: - Properties
+
+    static var identifier = "TextFieldTableViewCellIdentifier"
     
     var mainLabel = UILabel()
     var textField = UITextField()
@@ -58,5 +66,59 @@ class TextFieldTableViewCell: UITableViewCell {
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - LabelSwitchTableViewCell
+
+protocol LabelSwitchTableViewDelegate: class {
+    func labelSwitchTableViewCell(_ cell: LabelSwitchTableViewCell, onSwitchValueChanged isOn: Bool)
+}
+
+class LabelSwitchTableViewCell: UITableViewCell, UITableViewCellIdentifier {
+
+    // MARK: - Properties
+
+    static let identifier = "LabelSwitchTableViewCellIdentifier"
+
+    weak var delegate: LabelSwitchTableViewDelegate?
+
+    var mainLabel = UILabel()
+    var cellSwitch = UISwitch()
+
+    // MARK: - View lifecycle
+
+    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        mainLabel.translatesAutoresizingMaskIntoConstraints = false
+        cellSwitch.translatesAutoresizingMaskIntoConstraints = false
+
+        contentView.addSubview(mainLabel)
+        contentView.addSubview(cellSwitch)
+
+        NSLayoutConstraint.activate([
+            mainLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            mainLabel.widthAnchor.constraint(equalToConstant: 200),
+            mainLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            cellSwitch.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            cellSwitch.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            cellSwitch.widthAnchor.constraint(equalToConstant: 50)
+        ])
+
+        cellSwitch.addTarget(self, action: #selector(onSwitchValueChanged), for: .valueChanged)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Actions
+
+    @objc func onSwitchValueChanged() {
+        let isOn = cellSwitch.isOn
+        delegate?.labelSwitchTableViewCell(self, onSwitchValueChanged: isOn)
     }
 }

--- a/Example/Tests/SampleDataTests.swift
+++ b/Example/Tests/SampleDataTests.swift
@@ -23,9 +23,6 @@
  */
 
 import XCTest
-import MessageKit
-import MapKit
-@testable import ChatExample
 
 final class SampleDataTests: XCTestCase {
 

--- a/Example/Tests/SampleDataTests.swift
+++ b/Example/Tests/SampleDataTests.swift
@@ -28,7 +28,7 @@ import MapKit
 @testable import ChatExample
 
 final class SampleDataTests: XCTestCase {
-    
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -38,113 +38,5 @@ final class SampleDataTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
         SampleData.shared.resetMessageTypes()
-    }
-    
-    func testHideTextMessages() {
-        let testExpectation = expectation(description: "hideTextMessagesExpectation")
-
-        // Given
-        SampleData.shared.hideMessageTypes(types: "text")
-
-        // When
-        SampleData.shared.getMessages(count: 50) { messages in
-            messages.forEach { message in
-                // Then
-                XCTAssertNotEqual(message.type, "text", "messageData is type .text, expected all but .text")
-            }
-            testExpectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 10)
-    }
-
-    func testHideAttributedTextMessages() {
-        let testExpectation = expectation(description: "hideAttributedTextMessagesExpectation")
-
-        // Given
-        SampleData.shared.hideMessageTypes(types: "attributedText")
-
-        // When
-        SampleData.shared.getMessages(count: 50) { messages in
-            messages.forEach { message in
-                // Then
-                XCTAssertNotEqual(message.type, "attributedText", "messageData is type .attributedText, expected all but .attributedText")
-            }
-            testExpectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 10)
-    }
-
-    func testHidePhotoMessages() {
-        let testExpectation = expectation(description: "hidePhotoMessagesExpectation")
-
-        // Given
-        SampleData.shared.hideMessageTypes(types: "photo")
-
-        // When
-        SampleData.shared.getMessages(count: 50) { messages in
-            messages.forEach { message in
-                // Then
-                XCTAssertNotEqual(message.type, "photo", "messageData is type .photo, expected all but .photo")
-            }
-            testExpectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 10)
-    }
-
-    func testHideVideoMessages() {
-        let testExpectation = expectation(description: "hideVideoMessagesExpectation")
-
-        // Given
-        SampleData.shared.hideMessageTypes(types: "video")
-
-        // When
-        SampleData.shared.getMessages(count: 50) { messages in
-            messages.forEach { message in
-                // Then
-                XCTAssertNotEqual(message.type, "video", "messageData is type .video, expected all but .video")
-            }
-            testExpectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 10)
-    }
-
-    func testHideLocationMessages() {
-        let testExpectation = expectation(description: "hideLocationMessagesExpectation")
-
-        // Given
-        SampleData.shared.hideMessageTypes(types: "location")
-
-        // When
-        SampleData.shared.getMessages(count: 50) { messages in
-            messages.forEach { message in
-                // Then
-                XCTAssertNotEqual(message.type, "location", "messageData is type .location, expected all but .location")
-            }
-            testExpectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 10)
-    }
-
-    func testHideEmojiMessages() {
-        let testExpectation = expectation(description: "hideEmojiMessagesExpectation")
-
-        // Given
-        SampleData.shared.hideMessageTypes(types: "emoji")
-
-        // When
-        SampleData.shared.getMessages(count: 50) { messages in
-            messages.forEach { message in
-                // Then
-                XCTAssertNotEqual(message.type, "emoji", "messageData is type .emoji, expected all but .emoji")
-            }
-            testExpectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 10)
     }
 }

--- a/Example/Tests/SampleDataTests.swift
+++ b/Example/Tests/SampleDataTests.swift
@@ -19,7 +19,7 @@
  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- SOFTWARE.
+ SOFTWARE.s
  */
 
 import XCTest
@@ -27,7 +27,7 @@ import MessageKit
 import MapKit
 @testable import ChatExample
 
-class SampleDataTests: XCTestCase {
+final class SampleDataTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
@@ -44,13 +44,13 @@ class SampleDataTests: XCTestCase {
         let testExpectation = expectation(description: "hideTextMessagesExpectation")
 
         // Given
-        SampleData.shared.hideMessageTypes(types: .text(""))
+        SampleData.shared.hideMessageTypes(types: "text")
 
         // When
         SampleData.shared.getMessages(count: 50) { messages in
             messages.forEach { message in
                 // Then
-                XCTAssertTrue(message.data != .text(""), "messageData is type .text, expected all but .text")
+                XCTAssertNotEqual(message.type, "text", "messageData is type .text, expected all but .text")
             }
             testExpectation.fulfill()
         }
@@ -62,13 +62,13 @@ class SampleDataTests: XCTestCase {
         let testExpectation = expectation(description: "hideAttributedTextMessagesExpectation")
 
         // Given
-        SampleData.shared.hideMessageTypes(types: .attributedText(NSAttributedString()))
+        SampleData.shared.hideMessageTypes(types: "attributedText")
 
         // When
         SampleData.shared.getMessages(count: 50) { messages in
             messages.forEach { message in
                 // Then
-                XCTAssertTrue(message.data != .attributedText(NSAttributedString()), "messageData is type .attributedText, expected all but .attributedText")
+                XCTAssertNotEqual(message.type, "attributedText", "messageData is type .attributedText, expected all but .attributedText")
             }
             testExpectation.fulfill()
         }
@@ -80,13 +80,13 @@ class SampleDataTests: XCTestCase {
         let testExpectation = expectation(description: "hidePhotoMessagesExpectation")
 
         // Given
-        SampleData.shared.hideMessageTypes(types: .photo(UIImage()))
+        SampleData.shared.hideMessageTypes(types: "photo")
 
         // When
         SampleData.shared.getMessages(count: 50) { messages in
             messages.forEach { message in
                 // Then
-                XCTAssertTrue(message.data != .photo(UIImage()), "messageData is type .photo, expected all but .photo")
+                XCTAssertNotEqual(message.type, "photo", "messageData is type .photo, expected all but .photo")
             }
             testExpectation.fulfill()
         }
@@ -98,13 +98,13 @@ class SampleDataTests: XCTestCase {
         let testExpectation = expectation(description: "hideVideoMessagesExpectation")
 
         // Given
-        SampleData.shared.hideMessageTypes(types: .video(file: URL(string: "http://")!, thumbnail: UIImage()))
+        SampleData.shared.hideMessageTypes(types: "video")
 
         // When
         SampleData.shared.getMessages(count: 50) { messages in
             messages.forEach { message in
                 // Then
-                XCTAssertTrue(message.data != .video(file: URL(string: "http://")!, thumbnail: UIImage()), "messageData is type .video, expected all but .video")
+                XCTAssertNotEqual(message.type, "video", "messageData is type .video, expected all but .video")
             }
             testExpectation.fulfill()
         }
@@ -116,13 +116,13 @@ class SampleDataTests: XCTestCase {
         let testExpectation = expectation(description: "hideLocationMessagesExpectation")
 
         // Given
-        SampleData.shared.hideMessageTypes(types: .location(CLLocation(latitude: 0, longitude: 0)))
+        SampleData.shared.hideMessageTypes(types: "location")
 
         // When
         SampleData.shared.getMessages(count: 50) { messages in
             messages.forEach { message in
                 // Then
-                XCTAssertTrue(message.data != .location(CLLocation(latitude: 0, longitude: 0)), "messageData is type .location, expected all but .location")
+                XCTAssertNotEqual(message.type, "location", "messageData is type .location, expected all but .location")
             }
             testExpectation.fulfill()
         }
@@ -134,13 +134,13 @@ class SampleDataTests: XCTestCase {
         let testExpectation = expectation(description: "hideEmojiMessagesExpectation")
 
         // Given
-        SampleData.shared.hideMessageTypes(types: .emoji(""))
+        SampleData.shared.hideMessageTypes(types: "emoji")
 
         // When
         SampleData.shared.getMessages(count: 50) { messages in
             messages.forEach { message in
                 // Then
-                XCTAssertTrue(message.data != .emoji(""), "messageData is type .emoji, expected all but .emoji")
+                XCTAssertNotEqual(message.type, "emoji", "messageData is type .emoji, expected all but .emoji")
             }
             testExpectation.fulfill()
         }

--- a/Example/Tests/SampleDataTests.swift
+++ b/Example/Tests/SampleDataTests.swift
@@ -1,0 +1,134 @@
+//
+//  SampleDataTests.swift
+//  ChatExample
+//
+//  Created by Alessio Arsuffi on 28/01/2018.
+//  Copyright © 2018 MessageKit. All rights reserved.
+//
+
+import XCTest
+import MessageKit
+import MapKit
+@testable import ChatExample
+
+class SampleDataTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+        SampleData.shared.resetMessageTypes()
+    }
+    
+    func testHideTextMessages() {
+        let testExpectation = expectation(description: "hideTextMessagesExpectation")
+
+        // Given
+        SampleData.shared.hideMessageTypes(types: .text(""))
+
+        // When
+        SampleData.shared.getMessages(count: 50) { messages in
+            messages.forEach { message in
+                // Then
+                XCTAssertTrue(message.data != .text(""), "messageData is type .text, expected all but .text")
+            }
+            testExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 10)
+    }
+
+    func testHideAttributedTextMessages() {
+        let testExpectation = expectation(description: "hideAttributedTextMessagesExpectation")
+
+        // Given
+        SampleData.shared.hideMessageTypes(types: .attributedText(NSAttributedString()))
+
+        // When
+        SampleData.shared.getMessages(count: 50) { messages in
+            messages.forEach { message in
+                // Then
+                XCTAssertTrue(message.data != .attributedText(NSAttributedString()), "messageData is type .attributedText, expected all but .attributedText")
+            }
+            testExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 10)
+    }
+
+    func testHidePhotoMessages() {
+        let testExpectation = expectation(description: "hidePhotoMessagesExpectation")
+
+        // Given
+        SampleData.shared.hideMessageTypes(types: .photo(UIImage()))
+
+        // When
+        SampleData.shared.getMessages(count: 50) { messages in
+            messages.forEach { message in
+                // Then
+                XCTAssertTrue(message.data != .photo(UIImage()), "messageData is type .photo, expected all but .photo")
+            }
+            testExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 10)
+    }
+
+    func testHideVideoMessages() {
+        let testExpectation = expectation(description: "hideVideoMessagesExpectation")
+
+        // Given
+        SampleData.shared.hideMessageTypes(types: .video(file: URL(string: "http://")!, thumbnail: UIImage()))
+
+        // When
+        SampleData.shared.getMessages(count: 50) { messages in
+            messages.forEach { message in
+                // Then
+                XCTAssertTrue(message.data != .video(file: URL(string: "http://")!, thumbnail: UIImage()), "messageData is type .video, expected all but .video")
+            }
+            testExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 10)
+    }
+
+    func testHideLocationMessages() {
+        let testExpectation = expectation(description: "hideLocationMessagesExpectation")
+
+        // Given
+        SampleData.shared.hideMessageTypes(types: .location(CLLocation(latitude: 0, longitude: 0)))
+
+        // When
+        SampleData.shared.getMessages(count: 50) { messages in
+            messages.forEach { message in
+                // Then
+                XCTAssertTrue(message.data != .location(CLLocation(latitude: 0, longitude: 0)), "messageData is type .location, expected all but .location")
+            }
+            testExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 10)
+    }
+
+    func testHideEmojiMessages() {
+        let testExpectation = expectation(description: "hideEmojiMessagesExpectation")
+
+        // Given
+        SampleData.shared.hideMessageTypes(types: .emoji(""))
+
+        // When
+        SampleData.shared.getMessages(count: 50) { messages in
+            messages.forEach { message in
+                // Then
+                XCTAssertTrue(message.data != .emoji(""), "messageData is type .emoji, expected all but .emoji")
+            }
+            testExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 10)
+    }
+}

--- a/Example/Tests/SampleDataTests.swift
+++ b/Example/Tests/SampleDataTests.swift
@@ -1,10 +1,26 @@
-//
-//  SampleDataTests.swift
-//  ChatExample
-//
-//  Created by Alessio Arsuffi on 28/01/2018.
-//  Copyright © 2018 MessageKit. All rights reserved.
-//
+/*
+ MIT License
+
+ Copyright (c) 2017-2018 MessageKit
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
 
 import XCTest
 import MessageKit

--- a/Sources/Models/MessageData.swift
+++ b/Sources/Models/MessageData.swift
@@ -26,7 +26,7 @@ import Foundation
 import class CoreLocation.CLLocation
 
 /// An enum representing the kind of message and its underlying data.
-public enum MessageData: Equatable {
+public enum MessageData {
 
     /// A standard text message.
     ///
@@ -61,68 +61,4 @@ public enum MessageData: Equatable {
 //    case custom(Any)
 //    
 //    case placeholder
-
-    // MARK: - Equatable
-
-    public static func ==(lhs: MessageData, rhs: MessageData) -> Bool {
-        switch (lhs, rhs) {
-        case (let .text(string1), let .text(string2)):
-            return true
-
-        case (let .attributedText(string1), let .attributedText(string2)):
-            return true
-
-        case (let .photo(image1), let .photo(image2)):
-             return true
-
-        case (let .video(file: url1, thumbnail: thumbnail1), let .video(file: url2, thumbnail: thumbnail2)):
-            return true
-
-        case (let .location(location1), let .location(location2)):
-            return true
-
-        case (let .emoji(string1), let .emoji(string2)):
-            return true
-
-        default:
-            return false
-        }
-    }
-}
-
-extension MessageData: RawRepresentable {
-    public typealias RawValue = String
-
-    public init?(rawValue: RawValue) {
-        switch rawValue {
-        case "text": self = .text("")
-        case "attributedText": self = .attributedText(NSAttributedString())
-        case "photo": self = .photo(UIImage())
-        case "video": self = .video(file: URL(string: "")!, thumbnail: UIImage())
-        case "emoji": self = .emoji("")
-        default: return nil
-        }
-    }
-
-    public var rawValue: RawValue {
-        switch self {
-        case let .text(string1):
-            return "text"
-
-        case let .attributedText(string1):
-            return "attributedText"
-
-        case let .photo(image1):
-            return "photo"
-
-        case let .video(file: url1, thumbnail: thumbnail1):
-            return "video"
-
-        case let .location(location1):
-            return "location"
-
-        case let .emoji(string1):
-            return "emoji"
-        }
-    }
 }

--- a/Sources/Models/MessageData.swift
+++ b/Sources/Models/MessageData.swift
@@ -26,7 +26,7 @@ import Foundation
 import class CoreLocation.CLLocation
 
 /// An enum representing the kind of message and its underlying data.
-public enum MessageData {
+public enum MessageData: Equatable {
 
     /// A standard text message.
     ///
@@ -62,4 +62,67 @@ public enum MessageData {
 //    
 //    case placeholder
 
+    // MARK: - Equatable
+
+    public static func ==(lhs: MessageData, rhs: MessageData) -> Bool {
+        switch (lhs, rhs) {
+        case (let .text(string1), let .text(string2)):
+            return true
+
+        case (let .attributedText(string1), let .attributedText(string2)):
+            return true
+
+        case (let .photo(image1), let .photo(image2)):
+             return true
+
+        case (let .video(file: url1, thumbnail: thumbnail1), let .video(file: url2, thumbnail: thumbnail2)):
+            return true
+
+        case (let .location(location1), let .location(location2)):
+            return true
+
+        case (let .emoji(string1), let .emoji(string2)):
+            return true
+
+        default:
+            return false
+        }
+    }
+}
+
+extension MessageData: RawRepresentable {
+    public typealias RawValue = String
+
+    public init?(rawValue: RawValue) {
+        switch rawValue {
+        case "text": self = .text("")
+        case "attributedText": self = .attributedText(NSAttributedString())
+        case "photo": self = .photo(UIImage())
+        case "video": self = .video(file: URL(string: "")!, thumbnail: UIImage())
+        case "emoji": self = .emoji("")
+        default: return nil
+        }
+    }
+
+    public var rawValue: RawValue {
+        switch self {
+        case let .text(string1):
+            return "text"
+
+        case let .attributedText(string1):
+            return "attributedText"
+
+        case let .photo(image1):
+            return "photo"
+
+        case let .video(file: url1, thumbnail: thumbnail1):
+            return "video"
+
+        case let .location(location1):
+            return "location"
+
+        case let .emoji(string1):
+            return "emoji"
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
In settings now you can hide text, attributedText, photo and video messages.

Does this close any currently open issues?
------------------------------------------
it is related to #362 


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->
Nothing

Any other comments?
-------------------
Let me know if everything is ok for you :)

Where has this been tested?
---------------------------
**Devices/Simulators:** 
iPhone 4s (iOS 9.0)
iPhone SE, 7, 7 plus, X (iOS 11)

**iOS Version:** 11.2

**Swift Version:** 4

**MessageKit Version:** 0.13.1
