### PR TITLE
Added PrepareReuse override for MediaMessageCell

### DIFF
--- a/Sources/Views/Cells/MediaMessageCell.swift
+++ b/Sources/Views/Cells/MediaMessageCell.swift
@@ -52,6 +52,14 @@ open class MediaMessageCell: MessageCollectionViewCell {
         setupConstraints()
     }
 
+    open override func prepareForReuse() {
+        super.prepareForReuse()
+        messageContainerView.subviews.forEach({ $0.removeFromSuperview() })
+        messageContainerView.addSubview(imageView)
+        messageContainerView.addSubview(playButtonView)
+        setupConstraints()
+    }
+    
     open override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
         super.configure(with: message, at: indexPath, and: messagesCollectionView)
         switch message.data {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes the cell duplicating issue with videos in media cells, now in MediaMessageCell, I have implemented the override prepareForReuse to control the dequeuing, and inside the override function, I'm removing all the views and adding image and the triangle button again with constraints, because when I'm adding the video on didTapMessage delegate in MessageCellDelegate I'm adding it as a subview and I want the subviews gone on scrolling.

Does this close any currently open issues?
------------------------------------------
Yes, closes #506


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
I tested and it was all good, but if it affects anywhere else, let me know.

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 8 plus

**iOS Version:** 11

**Swift Version:** 4

**MessageKit Version:** 0.13.1


