### PR TITLE
Add in-memory caching for bubble outline images

### DIFF
--- a/Sources/Models/MessageStyle.swift
+++ b/Sources/Models/MessageStyle.swift
@@ -102,6 +102,8 @@ public enum MessageStyle {
 
     // MARK: - Private
 
+    internal static let bubbleImageCache = NSCache<NSString, UIImage>()
+
     private var imageName: String? {
         switch self {
         case .bubble:
@@ -128,6 +130,4 @@ public enum MessageStyle {
         let capInsets = UIEdgeInsets(top: center.y, left: center.x, bottom: center.y, right: center.x)
         return image.resizableImage(withCapInsets: capInsets, resizingMode: .stretch)
     }
-
-    private static let bubbleImageCache = NSCache<NSString, UIImage>()
 }

--- a/Sources/Models/MessageStyle.swift
+++ b/Sources/Models/MessageStyle.swift
@@ -77,6 +77,12 @@ public enum MessageStyle {
 
         guard let path = imagePath else { return nil }
 
+        let cache = MessageStyle.bubbleImageCache
+
+        if let cachedImage = cache.object(forKey: path as NSString) {
+            return cachedImage
+        }
+
         guard var image = UIImage(contentsOfFile: path) else { return nil }
 
         switch self {
@@ -89,7 +95,9 @@ public enum MessageStyle {
             image = UIImage(cgImage: cgImage, scale: image.scale, orientation: corner.imageOrientation)
         }
 
-        return stretch(image)
+        let stretchedImage = stretch(image)
+        cache.setObject(stretchedImage, forKey: path as NSString)
+        return stretchedImage
     }
 
     // MARK: - Private
@@ -121,4 +129,5 @@ public enum MessageStyle {
         return image.resizableImage(withCapInsets: capInsets, resizingMode: .stretch)
     }
 
+    private static let bubbleImageCache = NSCache<NSString, UIImage>()
 }

--- a/Tests/ModelTests/MessageStyleTests.swift
+++ b/Tests/ModelTests/MessageStyleTests.swift
@@ -153,10 +153,13 @@ class MessageStyleTests: XCTestCase {
         XCTAssertEqual(originalData, testData)
     }
 
-    func testCachesIdenticalOutlineImages() {
+    func testCachesIdenticalOutlineImagesFromCache() {
         let image1 = MessageStyle.bubbleTail(.topLeft, .pointedEdge).image ?? UIImage()
         let image2 = MessageStyle.bubbleTail(.topLeft, .pointedEdge).image ?? UIImage()
         XCTAssertEqual(image1, image2)
+        // After clearing cache a new image instance will be loaded from disk
+        MessageStyle.bubbleImageCache.removeAllObjects()
+        XCTAssertNotEqual(image1, MessageStyle.bubbleTail(.topLeft, .pointedEdge).image)
     }
 
     private func stretch(_ image: UIImage) -> UIImage {

--- a/Tests/ModelTests/MessageStyleTests.swift
+++ b/Tests/ModelTests/MessageStyleTests.swift
@@ -153,6 +153,12 @@ class MessageStyleTests: XCTestCase {
         XCTAssertEqual(originalData, testData)
     }
 
+    func testCachesIdenticalOutlineImages() {
+        let image1 = MessageStyle.bubbleTail(.topLeft, .pointedEdge).image ?? UIImage()
+        let image2 = MessageStyle.bubbleTail(.topLeft, .pointedEdge).image ?? UIImage()
+        XCTAssertEqual(image1, image2)
+    }
+
     private func stretch(_ image: UIImage) -> UIImage {
         let center = CGPoint(x: image.size.width / 2, y: image.size.height / 2)
         let capInsets = UIEdgeInsets(top: center.y, left: center.x, bottom: center.y, right: center.x)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This changed adds an in-memory `NSCache` for stretchable message bubble images. The way `MessageStyle` is currently implemented, a unique image will be loaded from the disk every time an outline image is requested, which is a significant performance issue since this happens every time a message cell is configured (see CPU trace screenshots below). The outline images are identical for each unique bubble style, there's no reason to reload them from disk every time. 

Does this close any currently open issues?
------------------------------------------
No, but it may eventually be made obsolete by PR #324 


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

These are screenshots of the CPU profiler instrument run on a basic integration of MessageKit where I loaded a page of messages and scrolled up and down for a bit.

**Top CPU Traces Before Change (system frameworks hidden)**

<img width="1025" alt="caching-before" src="https://user-images.githubusercontent.com/1433497/36110908-311f1b62-0fd9-11e8-955d-0c3801f5dfc8.png">

Note that `UIImage.init(contentsOf:)` is the top trace

**Top CPU Traces After Change (system frameworks hidden)**

<img width="1024" alt="caching-after" src="https://user-images.githubusercontent.com/1433497/36110917-3f91cf1e-0fd9-11e8-8577-daf0a80c945f.png">

Any other comments?
-------------------
Qualitatively, this appears to have a noticeable impact on scrolling and initial collection view rendering performance on a physical device.

Where has this been tested?
---------------------------

I've tested on a physical device and in a few simulators. Also the changes here include a unit test asserting image equality for the same `MessageStyle` which fails when run without the caching enhancement.

**Devices/Simulators:** iPhone 6 device, various simulators.

**iOS Version:** iOS 11.2, iOS 10.3

**Swift Version:** Swift 4.0 (should be compatible with earlier versions)

**MessageKit Version:** 0.13.1


