### PR TITLE
Enhancement/transit info detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
   - `layoutBottomLabel(with attributes: MessagesCollectionViewLayoutAttributes)`
 [#491](https://github.com/MessageKit/MessageKit/pull/491) by [@SD10](https://github.com/SD10).
 
+- **Breaking Change** Adds new `DetectorType` called `TransitInformation`  to message label.
+[#520](https://github.com/MessageKit/MessageKit/pull/520) by [@nosarj](https://github.com/nosarj).
+
 ### [[Prerelease] 0.13.1](https://github.com/MessageKit/MessageKit/releases/tag/0.13.1)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ### Added
 
+- **Breaking Change** Adds new `DetectorType` called `.transitInformation`  to message label.
+[#520](https://github.com/MessageKit/MessageKit/pull/520) by [@nosarj](https://github.com/nosarj).
+
 - **Breaking Change** Adds `.custom(Any?)` case to `MessageData`.
 [#498](https://github.com/MessageKit/MessageKit/pull/498) by [@SD10](https://github.com/SD10).
 
@@ -33,9 +36,6 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
   - `layoutTopLabel(with attributes: MessagesCollectionViewLayoutAttributes)`
   - `layoutBottomLabel(with attributes: MessagesCollectionViewLayoutAttributes)`
 [#491](https://github.com/MessageKit/MessageKit/pull/491) by [@SD10](https://github.com/SD10).
-
-- **Breaking Change** Adds new `DetectorType` called `TransitInformation`  to message label.
-[#520](https://github.com/MessageKit/MessageKit/pull/520) by [@nosarj](https://github.com/nosarj).
 
 ### [[Prerelease] 0.13.1](https://github.com/MessageKit/MessageKit/releases/tag/0.13.1)
 

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -305,7 +305,7 @@ extension ConversationViewController: MessagesDisplayDelegate {
     }
 
     func enabledDetectors(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> [DetectorType] {
-        return [.url, .address, .phoneNumber, .date]
+        return [.url, .address, .phoneNumber, .date, .transitInformation]
     }
 
     // MARK: - All Messages
@@ -438,6 +438,10 @@ extension ConversationViewController: MessageLabelDelegate {
 
     func didSelectURL(_ url: URL) {
         print("URL Selected: \(url)")
+    }
+    
+    func didSelectTransitInformation(_ transitInformation: [String : String]) {
+        print("TransitInformation Selected: \(transitInformation)")
     }
 
 }

--- a/Sources/Models/DetectorType.swift
+++ b/Sources/Models/DetectorType.swift
@@ -30,6 +30,7 @@ public enum DetectorType {
     case date
     case phoneNumber
     case url
+    case transitInformation
 
     // MARK: - Not supported yet
 
@@ -43,6 +44,7 @@ public enum DetectorType {
         case .date: return .date
         case .phoneNumber: return .phoneNumber
         case .url: return .link
+        case .transitInformation: return .transitInformation
         }
     }
 

--- a/Sources/Protocols/MessageLabelDelegate.swift
+++ b/Sources/Protocols/MessageLabelDelegate.swift
@@ -33,6 +33,8 @@ public protocol MessageLabelDelegate: AnyObject {
     func didSelectPhoneNumber(_ phoneNumber: String)
 
     func didSelectURL(_ url: URL)
+    
+    func didSelectTransitInformation(_ transitInformation: [String: String])
 
 }
 
@@ -45,5 +47,8 @@ public extension MessageLabelDelegate {
     func didSelectPhoneNumber(_ phoneNumber: String) {}
 
     func didSelectURL(_ url: URL) {}
+    
+    func didSelectTransitInformation(_ transitInformation: [String: String]) {}
+
 
 }

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -335,7 +335,7 @@ open class MessageLabel: UILabel {
                 rangesForDetectors.updateValue(ranges, forKey: .url)
             case .transitInformation:
                 var ranges = rangesForDetectors[.transitInformation] ?? []
-                let tuple: (NSRange, MessageTextCheckingType) = (result.range, .transitInformationComponents(result.components))
+                let tuple: (NSRange, MessageTextCheckingType) = (result.range, .transitInfoComponents(result.components))
                 ranges.append(tuple)
                 rangesForDetectors.updateValue(ranges, forKey: .transitInformation)
 
@@ -406,7 +406,7 @@ open class MessageLabel: UILabel {
         case let .link(url):
             guard let url = url else { return }
             handleURL(url)
-        case let .transitInformationComponents(transitInformation):
+        case let .transitInfoComponents(transitInformation):
             var transformedTransitInformation = [String: String]()
             guard let transitInformation = transitInformation else { return }
             transitInformation.forEach { (key, value) in
@@ -432,8 +432,8 @@ open class MessageLabel: UILabel {
         delegate?.didSelectPhoneNumber(phoneNumber)
     }
     
-    private func handleTransitInformation(_ transitInformationComponents: [String: String]) {
-        delegate?.didSelectTransitInformation(transitInformationComponents)
+    private func handleTransitInformation(_ components: [String: String]) {
+        delegate?.didSelectTransitInformation(components)
     }
     
 }
@@ -443,5 +443,5 @@ private enum MessageTextCheckingType {
     case date(Date?)
     case phoneNumber(String?)
     case link(URL?)
-    case transitInformationComponents([NSTextCheckingKey: String]?)
+    case transitInfoComponents([NSTextCheckingKey: String]?)
 }

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -315,7 +315,7 @@ open class MessageLabel: UILabel {
             switch result.resultType {
             case .address:
                 var ranges = rangesForDetectors[.address] ?? []
-                let tuple: (NSRange, MessageTextCheckingType) = (result.range, .addressComponents(result.components))
+                let tuple: (NSRange, MessageTextCheckingType) = (result.range, .addressComponents(result.addressComponents))
                 ranges.append(tuple)
                 rangesForDetectors.updateValue(ranges, forKey: .address)
             case .date:

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -130,6 +130,9 @@ open class MessageLabel: UILabel {
     open internal(set) var phoneNumberAttributes: [NSAttributedStringKey: Any] = defaultAttributes
 
     open internal(set) var urlAttributes: [NSAttributedStringKey: Any] = defaultAttributes
+    
+    open internal(set) var transitInformationAttributes: [NSAttributedStringKey: Any] = defaultAttributes
+
 
     public func setAttributes(_ attributes: [NSAttributedStringKey: Any], detector: DetectorType) {
         switch detector {
@@ -141,6 +144,8 @@ open class MessageLabel: UILabel {
             dateAttributes = attributes
         case .url:
             urlAttributes = attributes
+        case .transitInformation:
+            transitInformationAttributes = attributes
         }
         if isConfiguring {
             attributesNeedUpdate = true
@@ -268,6 +273,8 @@ open class MessageLabel: UILabel {
             return phoneNumberAttributes
         case .url:
             return urlAttributes
+        case .transitInformation:
+            return transitInformationAttributes
         }
 
     }
@@ -282,6 +289,8 @@ open class MessageLabel: UILabel {
             return phoneNumberAttributes
         case .link:
             return urlAttributes
+        case .transitInformation:
+            return transitInformationAttributes
         default:
             fatalError(MessageKitError.unrecognizedCheckingResult)
         }
@@ -306,7 +315,7 @@ open class MessageLabel: UILabel {
             switch result.resultType {
             case .address:
                 var ranges = rangesForDetectors[.address] ?? []
-                let tuple: (NSRange, MessageTextCheckingType) = (result.range, .addressComponents(result.addressComponents))
+                let tuple: (NSRange, MessageTextCheckingType) = (result.range, .addressComponents(result.components))
                 ranges.append(tuple)
                 rangesForDetectors.updateValue(ranges, forKey: .address)
             case .date:
@@ -324,6 +333,12 @@ open class MessageLabel: UILabel {
                 let tuple: (NSRange, MessageTextCheckingType) = (result.range, .link(result.url))
                 ranges.append(tuple)
                 rangesForDetectors.updateValue(ranges, forKey: .url)
+            case .transitInformation:
+                var ranges = rangesForDetectors[.transitInformation] ?? []
+                let tuple: (NSRange, MessageTextCheckingType) = (result.range, .transitInformationComponents(result.components))
+                ranges.append(tuple)
+                rangesForDetectors.updateValue(ranges, forKey: .transitInformation)
+
             default:
                 fatalError("Received an unrecognized NSTextCheckingResult.CheckingType")
             }
@@ -391,6 +406,13 @@ open class MessageLabel: UILabel {
         case let .link(url):
             guard let url = url else { return }
             handleURL(url)
+        case let .transitInformationComponents(transitInformation):
+            var transformedTransitInformation = [String: String]()
+            guard let transitInformation = transitInformation else { return }
+            transitInformation.forEach { (key, value) in
+                transformedTransitInformation[key.rawValue] = value
+            }
+            handleTransitInformation(transformedTransitInformation)
         }
     }
     
@@ -410,6 +432,10 @@ open class MessageLabel: UILabel {
         delegate?.didSelectPhoneNumber(phoneNumber)
     }
     
+    private func handleTransitInformation(_ transitInformationComponents: [String: String]) {
+        delegate?.didSelectTransitInformation(transitInformationComponents)
+    }
+    
 }
 
 private enum MessageTextCheckingType {
@@ -417,4 +443,5 @@ private enum MessageTextCheckingType {
     case date(Date?)
     case phoneNumber(String?)
     case link(URL?)
+    case transitInformationComponents([NSTextCheckingKey: String]?)
 }

--- a/Tests/DetectorTypeSpec.swift
+++ b/Tests/DetectorTypeSpec.swift
@@ -54,6 +54,12 @@ final class DetectorTypeSpec: QuickSpec {
                     expect(phoneNumber).to(equal(NSTextCheckingResult.CheckingType.phoneNumber))
                 }
             }
+            context("case .transitInformation") {
+                it("should equal .transitInformation") {
+                    let transitInformation = DetectorType.transitInformation.textCheckingType
+                    expect(transitInformation).to(equal(NSTextCheckingResult.CheckingType.transitInformation))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds transit information detection option to message labels

Does this close any currently open issues?
------------------------------------------
Contributes but does not complete Data detectors for MessageLabel #71



Where has this been tested?
---------------------------
**Devices/Simulators:** iphone 8

**iOS Version:** … 11.2

**Swift Version:** …4

**MessageKit Version:** 0.13.1

