### PR TITLE
Add boolean flag to disable auto updating send button enabled state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 
-### [[Prerelease] 0.13.1](https://github.com/MessageKit/MessageKit/releases/tag/0.13.1)
+### Added
+
+- Added `shouldManageSendButtonEnabledState` to `MessageInputBar` to disable automatically managing `MessageInputBar.sendButton`'s `isEnabled` state when text changes. (Default value is `true`).
+[#530](https://github.com/MessageKit/MessageKit/pull/530) by [@clayellis](https://github.com/clayellis).
+
+## [[Prerelease] 0.13.1](https://github.com/MessageKit/MessageKit/releases/tag/0.13.1)
 
 ### Fixed
 
@@ -43,10 +48,6 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - Added `UIImage` paste support to the `InputTextView`. Images can easily be accessed using the `InputTextView.images` property. 
 See the example project for an updated use case.  
 [#423](https://github.com/MessageKit/MessageKit/pull/423) by [@nathantannar4](https://github.com/nathantannar4).
-
-- Added `shouldManageSendButtonEnabledState` to `MessageInputBar` to disable automatically managing `MessageInputBar.sendButton`'s `isEnabled` state when text changes.
-This addition does not current default behavior (the default value is `true`).
-[#530](https://github.com/MessageKit/MessageKit/pull/530) by [@clayellis](https://github.com/clayellis).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 See the example project for an updated use case.  
 [#423](https://github.com/MessageKit/MessageKit/pull/423) by [@nathantannar4](https://github.com/nathantannar4).
 
+- Added `shouldManageSendButtonEnabledState` to `MessageInputBar` to disable automatically managing `MessageInputBar.sendButton`'s `isEnabled` state when text changes.
+This addition does not current default behavior (the default value is `true`).
+[#530](https://github.com/MessageKit/MessageKit/pull/530) by [@clayellis](https://github.com/clayellis).
+
 ### Removed
 
 - **Breaking Change** Removed `avatar(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView)` method of `MessagesDataSource`, use `configureAvatarView(_ avatarView: AvatarView, for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView)` instead.

--- a/Sources/Views/MessageInputBar.swift
+++ b/Sources/Views/MessageInputBar.swift
@@ -136,6 +136,9 @@ open class MessageInputBar: UIView {
                 $0.messageInputBar?.didSelectSendButton()
         }
     }()
+
+    /// A boolean that determines if the sendButton's `isEnabled` state should be auto updated on text changes.
+    open var shouldAutoUpdateSendButtonEnabledStateOnTextDidChange = true
     
     /**
      The anchor constants that inset the contentView
@@ -670,7 +673,9 @@ open class MessageInputBar: UIView {
     open func textViewDidChange() {
         let trimmedText = inputTextView.text.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        sendButton.isEnabled = !trimmedText.isEmpty || inputTextView.images.count > 0
+        if shouldAutoUpdateSendButtonEnabledStateOnTextDidChange {
+            sendButton.isEnabled = !trimmedText.isEmpty || inputTextView.images.count > 0
+        }
         inputTextView.placeholderLabel.isHidden = !inputTextView.text.isEmpty
 
         items.forEach { $0.textViewDidChangeAction(with: inputTextView) }

--- a/Sources/Views/MessageInputBar.swift
+++ b/Sources/Views/MessageInputBar.swift
@@ -137,8 +137,8 @@ open class MessageInputBar: UIView {
         }
     }()
 
-    /// A boolean that determines if the sendButton's `isEnabled` state should be auto updated on text changes.
-    open var shouldAutoUpdateSendButtonEnabledStateOnTextDidChange = true
+    /// A boolean that determines whether the sendButton's `isEnabled` state should be managed automatically.
+    open var shouldManageSendButtonEnabledState = true
     
     /**
      The anchor constants that inset the contentView
@@ -673,7 +673,7 @@ open class MessageInputBar: UIView {
     open func textViewDidChange() {
         let trimmedText = inputTextView.text.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        if shouldAutoUpdateSendButtonEnabledStateOnTextDidChange {
+        if shouldManageSendButtonEnabledState {
             sendButton.isEnabled = !trimmedText.isEmpty || inputTextView.images.count > 0
         }
         inputTextView.placeholderLabel.isHidden = !inputTextView.text.isEmpty


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds a boolean flag to disable auto updating send button enabled state on text did change. 


Does this close any currently open issues?
------------------------------------------
#529

Any other comments?
-------------------
This PR doesn't change any current default behavior. Use of the flag is completely optional. 


Where has this been tested?
---------------------------
**Devices/Simulators:** Both

**iOS Version:** iOS 11.2

**Swift Version:** 4

**MessageKit Version:** 0.13.1

