### PR TITLE
Solves issue #546 ( https://github.com/MessageKit/MessageKit/issues/5…

### DIFF
--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -242,7 +242,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
             fatalError(MessageKitError.nilMessagesDataSource)
         }
         guard let layoutDelegate = messagesCollectionView.messagesLayoutDelegate else {
-            fatalError(MessageKitError.nilMessagesLayoutDeleagte)
+            fatalError(MessageKitError.nilMessagesLayoutDelegate)
         }
         // Could pose a problem if subclass behaviors allows more than one item per section
         let indexPath = IndexPath(item: 0, section: section)
@@ -258,7 +258,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
             fatalError(MessageKitError.nilMessagesDataSource)
         }
         guard let layoutDelegate = messagesCollectionView.messagesLayoutDelegate else {
-            fatalError(MessageKitError.nilMessagesLayoutDeleagte)
+            fatalError(MessageKitError.nilMessagesLayoutDelegate)
         }
         // Could pose a problem if subclass behaviors allows more than one item per section
         let indexPath = IndexPath(item: 0, section: section)

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -263,7 +263,7 @@ extension MessagesCollectionViewFlowLayout {
     /// Convenience property for unwrapping the `MessagesCollectionView`'s `MessagesLayoutDelegate`.
     internal var messagesLayoutDelegate: MessagesLayoutDelegate {
         guard let messagesLayoutDelegate = messagesCollectionView.messagesLayoutDelegate else {
-            fatalError(MessageKitError.nilMessagesLayoutDeleagte)
+            fatalError(MessageKitError.nilMessagesLayoutDelegate)
         }
         return messagesLayoutDelegate
     }

--- a/Sources/Models/MessageKitError.swift
+++ b/Sources/Models/MessageKitError.swift
@@ -26,7 +26,7 @@ enum MessageKitError {
     static let avatarPositionUnresolved = "AvatarPosition Horizontal.natural needs to be resolved."
     static let nilMessagesDataSource = "MessagesDataSource has not been set."
     static let nilMessagesDisplayDelegate = "MessagesDisplayDelegate has not been set."
-    static let nilMessagesLayoutDeleagte = "MessagesLayoutDelegate has not been set."
+    static let nilMessagesLayoutDelegate = "MessagesLayoutDelegate has not been set."
     static let notMessagesCollectionView = "The collectionView is not a MessagesCollectionView."
     static let layoutUsedOnForeignType = "MessagesCollectionViewFlowLayout is being used on a foreign type."
     static let unrecognizedSectionKind = "Received unrecognized element kind:"


### PR DESCRIPTION
What does this implement/fix?
---------------------------------------------------
Typo on 'nilMessagesLayoutDelegate' error

Does this close any currently open issues?
------------------------------------------
Fixes #546 

Any relevant logs, error output, etc?
-------------------------------------

Any other comments?
-------------------

Where has this been tested?
---------------------------
**Devices/Simulators:** 
Device: iPhone SE

**iOS Version:**
iOS 11

**Swift Version:** 
Swift 4

**MessageKit Version:** 
0.13.1

