### PR TITLE
Solves issue #559 ( https://github.com/MessageKit/MessageKit/issues/559 )

### DIFF
--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -282,6 +282,7 @@ fileprivate extension MessagesCollectionViewFlowLayout {
         case .text:
             attributes.messageLabelFont = messageLabelFont
         case .attributedText(let text):
+            guard !text.string.isEmpty else { return }
             guard let font = text.attribute(.font, at: 0, effectiveRange: nil) as? UIFont else { return }
             attributes.messageLabelFont = font
         default:


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes crash with empty string passed into `MessageData.attributedText`

Does this close any currently open issues?
------------------------------------------
Resolves #559


Any relevant logs, error output, etc?
-------------------------------------
-

Any other comments?
-------------------
-

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 6, iPhone X

**iOS Version:** iOS 11.2.2

**Swift Version:** 4

**MessageKit Version:** 0.13.1


