### PR TITLE
Fix issue #562

### DIFF
--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -54,21 +54,15 @@ extension MessagesViewController {
     private func handleKeyboardDidChangeState(_ notification: Notification) {
         guard let keyboardEndFrame = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? CGRect else { return }
 
-        if (keyboardEndFrame.origin.y + keyboardEndFrame.size.height) > UIScreen.main.bounds.height {
-            // Hardware keyboard is found
-            messageCollectionViewBottomInset = view.frame.size.height - keyboardEndFrame.origin.y - iPhoneXBottomInset
-        } else {
-            //Software keyboard is found
-            let afterBottomInset = keyboardEndFrame.height > keyboardOffsetFrame.height ? (keyboardEndFrame.height - iPhoneXBottomInset) : keyboardOffsetFrame.height
-            let differenceOfBottomInset = afterBottomInset - messageCollectionViewBottomInset
-
-            if maintainPositionOnKeyboardFrameChanged && differenceOfBottomInset != 0 {
-                let contentOffset = CGPoint(x: messagesCollectionView.contentOffset.x, y: messagesCollectionView.contentOffset.y + differenceOfBottomInset)
-                messagesCollectionView.setContentOffset(contentOffset, animated: false)
-            }
-
-            messageCollectionViewBottomInset = afterBottomInset
+        let afterBottomInset = keyboardEndFrame.height > keyboardOffsetFrame.height ? (keyboardEndFrame.height - iPhoneXBottomInset) : keyboardOffsetFrame.height
+        let differenceOfBottomInset = afterBottomInset - messageCollectionViewBottomInset
+        
+        if maintainPositionOnKeyboardFrameChanged && differenceOfBottomInset != 0 {
+            let contentOffset = CGPoint(x: messagesCollectionView.contentOffset.x, y: messagesCollectionView.contentOffset.y + differenceOfBottomInset)
+            messagesCollectionView.setContentOffset(contentOffset, animated: false)
         }
+        
+        messageCollectionViewBottomInset = afterBottomInset
     }
 
     @objc


### PR DESCRIPTION
Calculate height to judge wether or not hardware keyboard is not accuracy. Ex:
When we operate like #562, swipe to pop the controller, the `(keyboardEndFrame.origin.y + keyboardEndFrame.size.height)` would greater than `UIScreen.main.bounds.height`.

So I just remove hardware keyboard detection, and keep the same logic handler. I don't known wether it would have problems in hardware mode.