### PR TITLE
Stop sizing cellTopLabel and cellBottomLabel to fit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,20 @@ the `MessageData.location` case.
  `isEnabled` state when text changes. (Default value is `true`).
 [#530](https://github.com/MessageKit/MessageKit/pull/530) by [@clayellis](https://github.com/clayellis).
 
+- Added two new methods `cellTopLabelHeight(for:at:in)` and `cellBottomLabelHeight(for:at:in)` to `MessagesLayoutDelegate`
+[#580](https://github.com/MessageKit/MessageKit/pull/580) by [@SD10](https://github.com/sd10).
+
+- Added new class `InsetLabel`.
+[#580](https://github.com/MessageKit/MessageKit/pull/580) by [@SD10](https://github.com/sd10).
+
 ### Changed
+
+- **Breaking Change** Changed `LabelAlignment` to be a `struct` with properties of 
+`textAlignment: NSTextAlignment` and `textInsets: UIEdgeInsets` to position the text in the `cellTopLabel` and `cellBottomLabel`.
+[#580](https://github.com/MessageKit/MessageKit/pull/580) by [@SD10](https://github.com/sd10).
+
+- **Breaking Change** The type of `cellTopLabel` and `cellBottomLabel` has been changed to `InsetLabel`.
+[#580](https://github.com/MessageKit/MessageKit/pull/580) by [@SD10](https://github.com/sd10).
 
 - The `MessageData.emoji` case no longer uses a default font of 2x the `messageLabelFont` size.
 You must now set this font explicitly through the `emojiMessageSizeCalculator` on `MessagesCollectionViewFlowLayout`.

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -37,7 +37,7 @@ class ConversationViewController: MessagesViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
     
-        let messagesToFetch = UserDefaults.standard.mockMessagesCount()
+        let messagesToFetch = 10000 //UserDefaults.standard.mockMessagesCount()
         
         DispatchQueue.global(qos: .userInitiated).async {
             SampleData.shared.getMessages(count: messagesToFetch) { messages in

--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -37,7 +37,7 @@ class ConversationViewController: MessagesViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
     
-        let messagesToFetch = 10000 //UserDefaults.standard.mockMessagesCount()
+        let messagesToFetch = UserDefaults.standard.mockMessagesCount()
         
         DispatchQueue.global(qos: .userInitiated).async {
             SampleData.shared.getMessages(count: messagesToFetch) { messages in
@@ -356,6 +356,14 @@ extension ConversationViewController: MessagesDisplayDelegate {
 // MARK: - MessagesLayoutDelegate
 
 extension ConversationViewController: MessagesLayoutDelegate {
+
+    func cellTopLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
+        return 16
+    }
+
+    func cellBottomLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
+        return 16
+    }
 
     func footerViewSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize {
         return CGSize(width: messagesCollectionView.bounds.width, height: 10)

--- a/MessageKit.xcodeproj/project.pbxproj
+++ b/MessageKit.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		1FE783A220662905007FA024 /* TextMessageSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE783A120662905007FA024 /* TextMessageSizeCalculator.swift */; };
 		1FE783A4206629A5007FA024 /* MediaMessageSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE783A3206629A5007FA024 /* MediaMessageSizeCalculator.swift */; };
 		1FE783A6206629C2007FA024 /* LocationMessageSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE783A5206629C2007FA024 /* LocationMessageSizeCalculator.swift */; };
+		1FE783A8206633C0007FA024 /* InsetLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE783A7206633C0007FA024 /* InsetLabel.swift */; };
 		1FF377A420087C82004FD648 /* MessageKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF377A320087C82004FD648 /* MessageKitError.swift */; };
 		1FF377AA20087D78004FD648 /* MessagesViewController+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF377A920087D78004FD648 /* MessagesViewController+Menu.swift */; };
 		1FF377AC20087DA2004FD648 /* MessagesViewController+Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF377AB20087DA2004FD648 /* MessagesViewController+Keyboard.swift */; };
@@ -132,6 +133,7 @@
 		1FE783A120662905007FA024 /* TextMessageSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextMessageSizeCalculator.swift; sourceTree = "<group>"; };
 		1FE783A3206629A5007FA024 /* MediaMessageSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaMessageSizeCalculator.swift; sourceTree = "<group>"; };
 		1FE783A5206629C2007FA024 /* LocationMessageSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationMessageSizeCalculator.swift; sourceTree = "<group>"; };
+		1FE783A7206633C0007FA024 /* InsetLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetLabel.swift; sourceTree = "<group>"; };
 		1FF377A320087C82004FD648 /* MessageKitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageKitError.swift; sourceTree = "<group>"; };
 		1FF377A920087D78004FD648 /* MessagesViewController+Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessagesViewController+Menu.swift"; sourceTree = "<group>"; };
 		1FF377AB20087DA2004FD648 /* MessagesViewController+Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessagesViewController+Keyboard.swift"; sourceTree = "<group>"; };
@@ -409,6 +411,7 @@
 				B7A03F411F86694F006AEF79 /* InputBarItem.swift */,
 				B7A03F401F86694F006AEF79 /* InputTextView.swift */,
 				38C57C7B1F9AE4870043CC03 /* InputStackView.swift */,
+				1FE783A7206633C0007FA024 /* InsetLabel.swift */,
 				B7A03F431F86694F006AEF79 /* MessageContainerView.swift */,
 				B7A03F421F86694F006AEF79 /* MessageInputBar.swift */,
 				B7A03F3F1F86694F006AEF79 /* MessageLabel.swift */,
@@ -603,6 +606,7 @@
 				B7A03F5B1F8669CA006AEF79 /* MessageType.swift in Sources */,
 				B7A03F491F86694F006AEF79 /* InputBarItem.swift in Sources */,
 				B7A03F601F8669CA006AEF79 /* MessagesDisplayDelegate.swift in Sources */,
+				1FE783A8206633C0007FA024 /* InsetLabel.swift in Sources */,
 				1FE783A02066286A007FA024 /* CellSizeCalculator.swift in Sources */,
 				B7A03F5C1F8669CA006AEF79 /* MessageCellDelegate.swift in Sources */,
 				1FF377A420087C82004FD648 /* MessageKitError.swift in Sources */,

--- a/Sources/Layout/MessageSizeCalculator.swift
+++ b/Sources/Layout/MessageSizeCalculator.swift
@@ -41,11 +41,11 @@ open class MessageSizeCalculator: CellSizeCalculator {
     public var incomingMessagePadding = UIEdgeInsets(top: 0, left: 4, bottom: 0, right: 30)
     public var outgoingMessagePadding = UIEdgeInsets(top: 0, left: 30, bottom: 0, right: 4)
 
-    public var incomingCellTopLabelAlignment = LabelAlignment(textAlignment: .left, textInsets: .zero)
-    public var outgoingCellTopLabelAlignment = LabelAlignment(textAlignment: .right, textInsets: .zero)
+    public var incomingCellTopLabelAlignment = LabelAlignment(textAlignment: .left, textInsets: UIEdgeInsets(left: 42))
+    public var outgoingCellTopLabelAlignment = LabelAlignment(textAlignment: .right, textInsets: UIEdgeInsets(right: 42))
 
-    public var incomingCellBottomLabelAlignment = LabelAlignment(textAlignment: .right, textInsets: .zero)
-    public var outgoingCellBottomLabelAlignment = LabelAlignment(textAlignment: .left, textInsets: .zero)
+    public var incomingCellBottomLabelAlignment = LabelAlignment(textAlignment: .left, textInsets: UIEdgeInsets(left: 42))
+    public var outgoingCellBottomLabelAlignment = LabelAlignment(textAlignment: .right, textInsets: UIEdgeInsets(right: 42))
 
     open func configure(attributes: UICollectionViewLayoutAttributes) {
         guard let attributes = attributes as? MessagesCollectionViewLayoutAttributes else { return }
@@ -193,5 +193,11 @@ open class MessageSizeCalculator: CellSizeCalculator {
         let finalWidth = estimatedWidth > maxWidth ? maxWidth : ceil(estimatedWidth)
 
         return CGSize(width: finalWidth, height: finalHeight)
+    }
+}
+
+fileprivate extension UIEdgeInsets {
+    init(top: CGFloat = 0, bottom: CGFloat = 0, left: CGFloat = 0, right: CGFloat = 0) {
+        self.init(top: top, left: left, bottom: bottom, right: right)
     }
 }

--- a/Sources/Layout/MessageSizeCalculator.swift
+++ b/Sources/Layout/MessageSizeCalculator.swift
@@ -129,7 +129,7 @@ open class MessageSizeCalculator: CellSizeCalculator {
 
     // MARK: - Top Label
 
-    internal func cellTopLabelSize(for message: MessageType, at indexPath: IndexPath) -> CGSize {
+    open func cellTopLabelSize(for message: MessageType, at indexPath: IndexPath) -> CGSize {
         let layoutDelegate = messagesLayout.messagesLayoutDelegate
         let collectionView = messagesLayout.messagesCollectionView
         let height = layoutDelegate.cellTopLabelHeight(for: message, at: indexPath, in: collectionView)

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -157,4 +157,11 @@ extension MessagesCollectionViewFlowLayout {
         }
         return messagesDataSource
     }
+
+    internal var messagesLayoutDelegate: MessagesLayoutDelegate {
+        guard let messagesLayoutDelegate = messagesCollectionView.messagesLayoutDelegate else {
+            fatalError(MessageKitError.nilMessagesLayoutDelegate)
+        }
+        return messagesLayoutDelegate
+    }
 }

--- a/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
+++ b/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
@@ -37,10 +37,10 @@ open class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttribu
     var messageLabelFont: UIFont = UIFont.preferredFont(forTextStyle: .body)
     var messageLabelInsets: UIEdgeInsets = .zero
 
-    var topLabelAlignment = LabelAlignment.cellCenter(.zero)
+    var topLabelAlignment = LabelAlignment(textAlignment: .center, textInsets: .zero)
     var topLabelSize: CGSize = .zero
 
-    var bottomLabelAlignment = LabelAlignment.cellCenter(.zero)
+    var bottomLabelAlignment = LabelAlignment(textAlignment: .center, textInsets: .zero)
     var bottomLabelSize: CGSize = .zero
 
     // MARK: - Methods

--- a/Sources/Models/LabelAlignment.swift
+++ b/Sources/Models/LabelAlignment.swift
@@ -24,38 +24,9 @@
 
 import UIKit
 
-/// An enum represnting the horizontal alignment of a `MessageCollectionViewCell`'s top and bottom labels.
-public enum LabelAlignment {
+public struct LabelAlignment {
 
-    /// Aligns the label's trailing edge to the cell's trailing edge.
-    /// The `UIEdgeInsets` associated value represents the offset from this position.
-    case cellTrailing(UIEdgeInsets)
-    
-    /// Aligns the label's leading edge to the cell's leading edge.
-    /// The `UIEdgeInsets` associated value represents the offset from this position.
-    case cellLeading(UIEdgeInsets)
-    
-    /// Aligns the label's center to the cell's center.
-    /// The `UIEdgeInsets` associated value represents the offset from this position.
-    case cellCenter(UIEdgeInsets)
-    
-    /// Aligns the label's trailing edge to the `MessageContainerView`'s trailing edge.
-    /// The `UIEdgeInsets` associated value represents the offset from this position.
-    case messageTrailing(UIEdgeInsets)
-    
-    /// Aligns the label's leading edge to the `MessageContainerView`'s leading edge.
-    /// The `UIEdgeInsets` associated value represents the offset from this position.
-    case messageLeading(UIEdgeInsets)
-
-    /// Returns the `UIEdgeInsets` associated value for the `LabelAlignment` case.
-    public var insets: UIEdgeInsets {
-        switch self {
-        case .cellTrailing(let insets): return insets
-        case .cellLeading(let insets): return insets
-        case .cellCenter(let insets): return insets
-        case .messageTrailing(let insets): return insets
-        case .messageLeading(let insets): return insets
-        }
-    }
+    public var textAlignment: NSTextAlignment
+    public var textInsets: UIEdgeInsets
 
 }

--- a/Sources/Protocols/MessagesLayoutDelegate.swift
+++ b/Sources/Protocols/MessagesLayoutDelegate.swift
@@ -81,9 +81,26 @@ public protocol MessagesLayoutDelegate: AnyObject {
 
     @available(*, deprecated: 1.0, message: "heightForLocation(message:at:with:in) has been removed in MessageKit 1.0.")
     func heightForLocation(message: MessageType, at indexPath: IndexPath, with maxWidth: CGFloat, in messagesCollectionView: MessagesCollectionView) -> CGFloat
+
+    func cellTopLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat
+
+    func cellBottomLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat
+
 }
 
 public extension MessagesLayoutDelegate {
+
+    // MARK: - All Messages Defaults
+
+    func cellTopLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
+        // TODO: - More sensible default, this is just for testing
+        return 10
+    }
+
+    func cellBottomLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
+        // TODO: - More sensible default, this is just for testing
+        return 10
+    }
 
     func headerViewSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize {
         guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {

--- a/Sources/Protocols/MessagesLayoutDelegate.swift
+++ b/Sources/Protocols/MessagesLayoutDelegate.swift
@@ -23,7 +23,6 @@
  */
 
 import Foundation
-import AVFoundation
 
 /// A protocol used by the `MessagesCollectionViewFlowLayout` object to determine
 /// the size and layout of a `MessageCollectionViewCell` and its contents.
@@ -48,6 +47,26 @@ public protocol MessagesLayoutDelegate: AnyObject {
     ///
     /// The default value returned by this method is a size of `GGSize.zero`.
     func footerViewSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize
+
+    /// Specifies the height for the `MessageCollectionViewCell`'s top label.
+    ///
+    /// - Parameters:
+    ///   - message: The `MessageType` that will be displayed for this cell.
+    ///   - indexPath: The `IndexPath` of the cell.
+    ///   - messagesCollectionView: The `MessagesCollectionView` in which this cell will be displayed.
+    ///
+    /// The default value returned by this method is zero.
+    func cellTopLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat
+
+    /// Specifies the height for the `MessageCollectionViewCell`'s bottom label.
+    ///
+    /// - Parameters:
+    ///   - message: The `MessageType` that will be displayed for this cell.
+    ///   - indexPath: The `IndexPath` of the cell.
+    ///   - messagesCollectionView: The `MessagesCollectionView` in which this cell will be displayed.
+    ///
+    /// The default value returned by this method is zero.
+    func cellBottomLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat
 
     @available(*, deprecated: 1.0, message: "avatarSize(for:at:in) has been removed in MessageKit 1.0")
     func shouldCacheLayoutAttributes(for message: MessageType) -> Bool
@@ -82,25 +101,9 @@ public protocol MessagesLayoutDelegate: AnyObject {
     @available(*, deprecated: 1.0, message: "heightForLocation(message:at:with:in) has been removed in MessageKit 1.0.")
     func heightForLocation(message: MessageType, at indexPath: IndexPath, with maxWidth: CGFloat, in messagesCollectionView: MessagesCollectionView) -> CGFloat
 
-    func cellTopLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat
-
-    func cellBottomLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat
-
 }
 
 public extension MessagesLayoutDelegate {
-
-    // MARK: - All Messages Defaults
-
-    func cellTopLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
-        // TODO: - More sensible default, this is just for testing
-        return 10
-    }
-
-    func cellBottomLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
-        // TODO: - More sensible default, this is just for testing
-        return 10
-    }
 
     func headerViewSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize {
         guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {
@@ -112,5 +115,13 @@ public extension MessagesLayoutDelegate {
 
     func footerViewSize(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGSize {
         return .zero
+    }
+
+    func cellTopLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
+        return 0
+    }
+
+    func cellBottomLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
+        return 0
     }
 }

--- a/Sources/Views/Cells/MessageCollectionViewCell.swift
+++ b/Sources/Views/Cells/MessageCollectionViewCell.swift
@@ -39,14 +39,14 @@ open class MessageCollectionViewCell: UICollectionViewCell, CollectionViewReusab
         return containerView
     }()
 
-    open var cellTopLabel: UILabel = {
-        let label = UILabel()
+    open var cellTopLabel: InsetLabel = {
+        let label = InsetLabel()
         label.numberOfLines = 0
         return label
     }()
 
-    open var cellBottomLabel: UILabel = {
-        let label = UILabel()
+    open var cellBottomLabel: InsetLabel = {
+        let label = InsetLabel()
         label.numberOfLines = 0
         return label
     }()
@@ -185,7 +185,7 @@ open class MessageCollectionViewCell: UICollectionViewCell, CollectionViewReusab
         guard attributes.messageContainerSize != .zero else { return }
 
         var origin: CGPoint = .zero
-        origin.y = attributes.topLabelSize.height + attributes.messageContainerPadding.top + attributes.topLabelAlignment.insets.vertical
+        origin.y = attributes.topLabelSize.height + attributes.messageContainerPadding.top
 
         switch attributes.avatarPosition.horizontal {
         case .cellLeading:
@@ -204,28 +204,10 @@ open class MessageCollectionViewCell: UICollectionViewCell, CollectionViewReusab
     open func layoutTopLabel(with attributes: MessagesCollectionViewLayoutAttributes) {
         guard attributes.topLabelSize != .zero else { return }
 
-        let topLabelAlignment = attributes.topLabelAlignment
-        let topLabelPadding = topLabelAlignment.insets
-        let topLabelSize = attributes.topLabelSize
+        cellTopLabel.textAlignment = attributes.topLabelAlignment.textAlignment
+        cellTopLabel.textInsets = attributes.topLabelAlignment.textInsets
 
-        var origin: CGPoint = .zero
-
-        origin.y = topLabelPadding.top
-
-        switch attributes.topLabelAlignment {
-        case .cellLeading:
-            origin.x = topLabelPadding.left
-        case .cellCenter:
-            origin.x = (attributes.frame.width/2) + topLabelPadding.left - topLabelPadding.right
-        case .cellTrailing:
-            origin.x = attributes.frame.width - topLabelSize.width - topLabelPadding.right
-        case .messageLeading: // Needs messageContainerView frame to be set
-            origin.x = messageContainerView.frame.minX + topLabelPadding.left
-        case .messageTrailing: // Needs messageContainerView frame to be set
-            origin.x = messageContainerView.frame.maxX - topLabelSize.width - topLabelPadding.right
-        }
-
-        cellTopLabel.frame = CGRect(origin: origin, size: topLabelSize)
+        cellTopLabel.frame = CGRect(origin: .zero, size: attributes.topLabelSize)
     }
 
     /// Positions the cell's bottom label.
@@ -233,27 +215,13 @@ open class MessageCollectionViewCell: UICollectionViewCell, CollectionViewReusab
     open func layoutBottomLabel(with attributes: MessagesCollectionViewLayoutAttributes) {
         guard attributes.bottomLabelSize != .zero else { return }
 
-        let bottomLabelAlignment = attributes.bottomLabelAlignment
-        let bottomLabelPadding = bottomLabelAlignment.insets
-        let bottomLabelSize = attributes.bottomLabelSize
+        cellBottomLabel.textAlignment = attributes.bottomLabelAlignment.textAlignment
+        cellBottomLabel.textInsets = attributes.bottomLabelAlignment.textInsets
 
-        var origin: CGPoint = .zero
+        let y = messageContainerView.frame.maxY + attributes.messageContainerPadding.bottom
+        let origin = CGPoint(x: 0, y: y)
 
-        origin.y = messageContainerView.frame.maxY + attributes.messageContainerPadding.bottom + bottomLabelPadding.top
 
-        switch bottomLabelAlignment {
-        case .cellLeading:
-            origin.x = bottomLabelPadding.left
-        case .cellCenter:
-            origin.x = (attributes.frame.width/2) + bottomLabelPadding.left - bottomLabelPadding.right
-        case .cellTrailing:
-            origin.x = attributes.frame.width - bottomLabelSize.width - bottomLabelPadding.right
-        case .messageLeading:
-            origin.x = messageContainerView.frame.minX + bottomLabelPadding.left
-        case .messageTrailing:
-            origin.x = messageContainerView.frame.maxX - bottomLabelSize.width - bottomLabelPadding.right
-        }
-
-        cellBottomLabel.frame = CGRect(origin: origin, size: bottomLabelSize)
+        cellBottomLabel.frame = CGRect(origin: origin, size: attributes.bottomLabelSize)
     }
 }

--- a/Sources/Views/InsetLabel.swift
+++ b/Sources/Views/InsetLabel.swift
@@ -1,0 +1,38 @@
+/*
+ MIT License
+
+ Copyright (c) 2017-2018 MessageKit
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+import UIKit
+
+open class InsetLabel: UILabel {
+
+    open var textInsets: UIEdgeInsets = .zero {
+        didSet { setNeedsDisplay() }
+    }
+
+    open override func drawText(in rect: CGRect) {
+        let insetRect = UIEdgeInsetsInsetRect(rect, textInsets)
+        super.drawText(in: insetRect)
+    }
+
+}

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -24,6 +24,19 @@
 
 import UIKit
 
+open class InsetLabel: UILabel {
+
+    open var textInsets: UIEdgeInsets = .zero {
+        didSet { setNeedsDisplay() }
+    }
+
+    open override func drawText(in rect: CGRect) {
+        let insetRect = UIEdgeInsetsInsetRect(rect, textInsets)
+        super.drawText(in: insetRect)
+    }
+
+}
+
 open class MessageLabel: UILabel {
 
     // MARK: - Private Properties

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -24,19 +24,6 @@
 
 import UIKit
 
-open class InsetLabel: UILabel {
-
-    open var textInsets: UIEdgeInsets = .zero {
-        didSet { setNeedsDisplay() }
-    }
-
-    open override func drawText(in rect: CGRect) {
-        let insetRect = UIEdgeInsetsInsetRect(rect, textInsets)
-        super.drawText(in: insetRect)
-    }
-
-}
-
 open class MessageLabel: UILabel {
 
     // MARK: - Private Properties


### PR DESCRIPTION
TODO: Better PR description

Layout time of 10,000 messages (includes time to create mock messages)

Before:
<img width="302" alt="screen shot 2018-03-21 at 3 18 37 am" src="https://user-images.githubusercontent.com/7445580/37700486-b87eaaee-2cb9-11e8-9d2e-0db85d81b167.png">

After:
<img width="303" alt="screen shot 2018-03-21 at 3 18 08 am" src="https://user-images.githubusercontent.com/7445580/37700487-b9925930-2cb9-11e8-83d5-49d4ee007521.png">

cc @zhongwuzw 

TODO:
- [x] CHANGELOG entry
- [x] More sensible defaults
