### PR TITLE
Add hook to configure async media on cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ the `MessageData.location` case.
 - Added new class `InsetLabel`.
 [#580](https://github.com/MessageKit/MessageKit/pull/580) by [@SD10](https://github.com/sd10).
 
+- Added new method `configureMediaMessageImageView(_:for:at:in)` to configure the `UIImageView` of a
+`MediaMessageCell` asynchronously.
+[#592](https://github.com/MessageKit/MessageKit/pull/592) by [@zhongwuzw](https://github.com/zhongwuzw), [@SD10](https://github.com/sd10)
+
 ### Changed
 
 - **Breaking Change** Changed `LabelAlignment` to be a `struct` with properties of 

--- a/Sources/Protocols/MessagesDisplayDelegate.swift
+++ b/Sources/Protocols/MessagesDisplayDelegate.swift
@@ -164,6 +164,20 @@ public protocol MessagesDisplayDelegate: AnyObject {
     ///   - messagesCollectionView: The collection view requesting the information
     /// - Returns: Your customized animation block.
     func animationBlockForLocation(message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> ((UIImageView) -> Void)?
+
+    // MARK: - Media Messages
+
+    /// Configure the `MediaMessageCell`s `UIImageView`.
+    ///
+    /// - Parameters:
+    ///   - imageView: The `UIImageView` of the cell.
+    ///   - message: The `MessageType` that will be displayed by this cell.
+    ///   - indexPath: The `IndexPath` of the cell.
+    ///   - messagesCollectionView: The `MessagesCollectionView` in which this cell will be displayed.
+    /// - Note:
+    ///   The default implementation of this method does nothing.
+    func configureMediaMessageImageView(_ imageView: UIImageView, for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView)
+
 }
 
 public extension MessagesDisplayDelegate {
@@ -240,4 +254,10 @@ public extension MessagesDisplayDelegate {
         return nil
     }
 
+    // MARK: - Media Message Defaults
+
+    func configureMediaMessageImageView(_ imageView: UIImageView, for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) {
+
+        /* No-op Default */
+    }
 }

--- a/Sources/Views/Cells/MediaMessageCell.swift
+++ b/Sources/Views/Cells/MediaMessageCell.swift
@@ -58,6 +58,11 @@ open class MediaMessageCell: MessageCollectionViewCell {
 
     open override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
         super.configure(with: message, at: indexPath, and: messagesCollectionView)
+
+        guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {
+            fatalError(MessageKitError.nilMessagesDisplayDelegate)
+        }
+
         switch message.data {
         case .photo(let mediaItem):
             imageView.image = mediaItem.image ?? mediaItem.placeholderImage
@@ -68,5 +73,7 @@ open class MediaMessageCell: MessageCollectionViewCell {
         default:
             break
         }
+
+        displayDelegate.configureMediaMessageImageView(imageView, for: message, at: indexPath, in: messagesCollectionView)
     }
 }


### PR DESCRIPTION
Resolves: #588 

This gives users a hook to apply an image to a `MediaMessageCell`s underlying `imageView` asynchronously.

TODO: 
- [x] CHANGELOG entry

