### PR TITLE
Improve equality checking on layout attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ You can now set this property through `textMessageSizeCalculator` property.
 - Fixed message bubble tail orientation invalidation in `iOS9`.
 [#469](https://github.com/MessageKit/MessageKit/pull/469) by [@zhongwuzw](https://github.com/zhongwuzw).
 
+- Fixed equality checking on `MessagesCollectionViewLayoutAttributes`.
+[#593](https://github.com/MessageKit/MessageKit/pull/593) by [@zhongwuzw](https://github.com/zhongwuzw), [@SD10](https://github.com/sd10)
+
 ## [[Prerelease] 0.13.0](https://github.com/MessageKit/MessageKit/releases/tag/0.13.0)
 
 ### Fixed

--- a/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
+++ b/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
@@ -63,14 +63,24 @@ open class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttribu
     }
 
     open override func isEqual(_ object: Any?) -> Bool {
-
         // MARK: - LEAVE this as is
         // swiftlint:disable unused_optional_binding
-        if let _ = object as? MessagesCollectionViewLayoutAttributes {
-            return super.isEqual(object)
+        if let attributes = object as? MessagesCollectionViewLayoutAttributes {
+            return super.isEqual(object) && attributes.avatarSize == avatarSize
+            && attributes.avatarPosition == attributes.avatarPosition
+            && attributes.messageContainerSize == messageContainerSize
+            && attributes.messageContainerPadding == messageContainerPadding
+            && attributes.messageLabelFont == messageLabelFont
+            && attributes.messageLabelInsets == messageLabelInsets
+            && attributes.topLabelAlignment == topLabelAlignment
+            && attributes.topLabelSize == topLabelSize
+            && attributes.bottomLabelAlignment == bottomLabelAlignment
+            && attributes.bottomLabelSize == bottomLabelSize
         } else {
             return false
         }
         // swiftlint:enable unused_optional_binding
     }
 }
+
+

--- a/Sources/Models/AvatarPosition.swift
+++ b/Sources/Models/AvatarPosition.swift
@@ -82,3 +82,13 @@ public struct AvatarPosition {
     }
     
 }
+
+// MARK: - Equatable Conformance
+
+extension AvatarPosition: Equatable {
+
+    public static func == (lhs: AvatarPosition, rhs: AvatarPosition) -> Bool {
+        return lhs.vertical == rhs.vertical && lhs.horizontal == rhs.horizontal
+    }
+
+}

--- a/Sources/Models/LabelAlignment.swift
+++ b/Sources/Models/LabelAlignment.swift
@@ -30,3 +30,13 @@ public struct LabelAlignment {
     public var textInsets: UIEdgeInsets
 
 }
+
+// MARK: - Equatable Conformance
+
+extension LabelAlignment: Equatable {
+
+    public static func == (lhs: LabelAlignment, rhs: LabelAlignment) -> Bool {
+        return lhs.textAlignment == rhs.textAlignment && lhs.textInsets == rhs.textInsets
+    }
+
+}


### PR DESCRIPTION
Resolves #575 

This implements the rest of the `isEqual` implementation for `MessagesCollectionViewLayoutAttributes`.