### PR TITLE
Fix font invalid for attributedString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 
+### Fixed
+
+- Fixed font invalidation of `attributedString` in `MessageLabel`.
+[#623](https://github.com/MessageKit/MessageKit/pull/623) by [@zhongwuzw](https://github.com/zhongwuzw).
+
 ## [[Prerelease] 0.13.2](https://github.com/MessageKit/MessageKit/releases/tag/0.13.2)
 
 ### Added
@@ -15,7 +20,7 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ### Fixed
 
-- Fix wrong separated components in messageInputBar.
+- Fixed wrong separated components in messageInputBar.
 [#577](https://github.com/MessageKit/MessageKit/pull/577) by [@zhongwuzw](https://github.com/zhongwuzw).
 
 ## [[Prerelease] 0.13.1](https://github.com/MessageKit/MessageKit/releases/tag/0.13.1)

--- a/Example/ChatExample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/ChatExample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/ChatExample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/ChatExample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MessageKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MessageKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/Views/Cells/TextMessageCell.swift
+++ b/Sources/Views/Cells/TextMessageCell.swift
@@ -44,7 +44,7 @@ open class TextMessageCell: MessageCollectionViewCell {
         super.apply(layoutAttributes)
         if let attributes = layoutAttributes as? MessagesCollectionViewLayoutAttributes {
             messageLabel.textInsets = attributes.messageLabelInsets
-            messageLabel.font = attributes.messageLabelFont
+            messageLabel.messageLabelFont = attributes.messageLabelFont
             messageLabel.frame = messageContainerView.bounds
         }
     }
@@ -79,6 +79,7 @@ open class TextMessageCell: MessageCollectionViewCell {
             switch message.data {
             case .text(let text), .emoji(let text):
                 messageLabel.text = text
+                messageLabel.applyMessageLableFont()
             case .attributedText(let text):
                 messageLabel.attributedText = text
             default:

--- a/Sources/Views/Cells/TextMessageCell.swift
+++ b/Sources/Views/Cells/TextMessageCell.swift
@@ -79,7 +79,9 @@ open class TextMessageCell: MessageCollectionViewCell {
             switch message.data {
             case .text(let text), .emoji(let text):
                 messageLabel.text = text
-                messageLabel.applyMessageLableFont()
+                if let font = messageLabel.messageLabelFont {
+                    messageLabel.font = font
+                }
             case .attributedText(let text):
                 messageLabel.attributedText = text
             default:

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -112,6 +112,8 @@ open class MessageLabel: UILabel {
             if !isConfiguring { setNeedsDisplay() }
         }
     }
+    
+    internal var messageLabelFont: UIFont?
 
     private var attributesNeedUpdate = false
 
@@ -189,6 +191,11 @@ open class MessageLabel: UILabel {
     }
 
     // MARK: - Private Methods
+    
+    internal func applyMessageLableFont() {
+        guard let font = messageLabelFont else { return }
+        self.font = font
+    }
 
     private func setTextStorage(_ newText: NSAttributedString?, shouldParse: Bool) {
 

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -191,11 +191,6 @@ open class MessageLabel: UILabel {
     }
 
     // MARK: - Private Methods
-    
-    internal func applyMessageLableFont() {
-        guard let font = messageLabelFont else { return }
-        self.font = font
-    }
 
     private func setTextStorage(_ newText: NSAttributedString?, shouldParse: Bool) {
 


### PR DESCRIPTION
* Fixed #557 . 
* Added `Xcode 9.3` related config file.

- [x] Added CHANGELOG.

Another issue still exist, like `textColor`, it would leads to invalidation of `attributedString`'s `color` attributes.

We need to investigate that wether remove `textColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor`, it also leads to invalidation of `attributedString`'s `color` attributes.