### PR TITLE
Fixed bubbleTailOutline of message bubble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 
+### Fixed
+
+- Fixed `bubbleTailOutline` invalidation of message bubble.
+[#633](https://github.com/MessageKit/MessageKit/pull/633) by [@zhongwuzw](https://github.com/zhongwuzw).
+
 ## [[Prerelease] 0.13.3](https://github.com/MessageKit/MessageKit/releases/tag/0.13.3)
 
 ### Fixed

--- a/Sources/Views/MessageContainerView.swift
+++ b/Sources/Views/MessageContainerView.swift
@@ -48,10 +48,8 @@ open class MessageContainerView: UIImageView {
         switch style {
         case .none, .custom:
             break
-        case .bubble, .bubbleTail:
+        case .bubble, .bubbleTail, .bubbleOutline, .bubbleTailOutline:
             imageMask.frame = bounds
-        case .bubbleOutline, .bubbleTailOutline:
-            imageMask.frame = bounds.insetBy(dx: 1.0, dy: 1.0)
         }
     }
 
@@ -70,11 +68,11 @@ open class MessageContainerView: UIImageView {
             image = style.image?.withRenderingMode(.alwaysTemplate)
             tintColor = color
         case .bubbleTailOutline(let color, let tail, let corner):
-            let bubbleStyle: MessageStyle = .bubbleTailOutline(.white, tail, corner)
+            let bubbleStyle: MessageStyle = .bubbleTail(tail, corner)
             imageMask.image = bubbleStyle.image
             sizeMaskToView()
             mask = imageMask
-            image = style.image
+            image = style.image?.withRenderingMode(.alwaysTemplate)
             tintColor = color
         case .none:
             mask = nil


### PR DESCRIPTION
Fixed #632 .

We cannot use `bubble_outlined_tail_v2` image as the `mask`, its opacity is 0.Instead use `bubbleTail` as the temporary substitution.