### PR TITLE
Fixed wrong bubble size calculation in some fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - Fixed `bubbleTailOutline` invalidation of message bubble.
 [#633](https://github.com/MessageKit/MessageKit/pull/633) by [@zhongwuzw](https://github.com/zhongwuzw).
 
+- Fixed `boundingRect(with:options:attributes:context)` wrong size calculation when use some font, e.g. custom font.
+[#645](https://github.com/MessageKit/MessageKit/pull/645) by [@zhongwuzw](https://github.com/zhongwuzw).
+
 ## [[Prerelease] 0.13.3](https://github.com/MessageKit/MessageKit/releases/tag/0.13.3)
 
 ### Fixed

--- a/Sources/Extensions/NSAttributedString+Extensions.swift
+++ b/Sources/Extensions/NSAttributedString+Extensions.swift
@@ -29,7 +29,7 @@ extension NSAttributedString {
     func height(considering width: CGFloat) -> CGFloat {
 
         let constraintBox = CGSize(width: width, height: .greatestFiniteMagnitude)
-        let rect = self.boundingRect(with: constraintBox, options: .usesLineFragmentOrigin, context: nil)
+        let rect = self.boundingRect(with: constraintBox, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
         return rect.height
 
     }
@@ -37,7 +37,7 @@ extension NSAttributedString {
     func width(considering height: CGFloat) -> CGFloat {
 
         let constraintBox = CGSize(width: .greatestFiniteMagnitude, height: height)
-        let rect = self.boundingRect(with: constraintBox, options: .usesLineFragmentOrigin, context: nil)
+        let rect = self.boundingRect(with: constraintBox, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
         return rect.width
         
     }

--- a/Sources/Extensions/String+Extensions.swift
+++ b/Sources/Extensions/String+Extensions.swift
@@ -29,7 +29,7 @@ extension String {
     func height(considering width: CGFloat, and font: UIFont) -> CGFloat {
 
         let constraintBox = CGSize(width: width, height: .greatestFiniteMagnitude)
-      let rect = self.boundingRect(with: constraintBox, options: .usesLineFragmentOrigin, attributes: [NSAttributedStringKey.font: font], context: nil)
+      let rect = self.boundingRect(with: constraintBox, options: [.usesLineFragmentOrigin, .usesFontLeading], attributes: [NSAttributedStringKey.font: font], context: nil)
         return rect.height
 
     }
@@ -37,7 +37,7 @@ extension String {
     func width(considering height: CGFloat, and font: UIFont) -> CGFloat {
 
         let constraintBox = CGSize(width: .greatestFiniteMagnitude, height: height)
-      let rect = self.boundingRect(with: constraintBox, options: .usesLineFragmentOrigin, attributes: [NSAttributedStringKey.font: font], context: nil)
+      let rect = self.boundingRect(with: constraintBox, options: [.usesLineFragmentOrigin, .usesFontLeading], attributes: [NSAttributedStringKey.font: font], context: nil)
         return rect.width
 
     }


### PR DESCRIPTION
Fixed #639.
`boundingRect` would return wrong size in some fonts, so add `usesFontLeading` option to use font leading for calculating line heights.