### PR TITLE
Move LabelSize function into Extensions

### DIFF
--- a/Sources/Extensions/NSAttributedString+Extensions.swift
+++ b/Sources/Extensions/NSAttributedString+Extensions.swift
@@ -41,4 +41,19 @@ extension NSAttributedString {
         return rect.width
         
     }
+    
+    /// Returns the size required fit a NSAttributedString considering a constrained max width.
+    ///
+    /// - Parameters:
+    ///   - attributedText: The `NSAttributedString` used to calculate a size that fits.
+    ///   - maxWidth: The max width available for the label.
+    func labelSize(considering maxWidth: CGFloat) -> CGSize {
+        let estimatedHeight = self.height(considering: maxWidth)
+        let estimatedWidth = self.width(considering: estimatedHeight)
+        
+        let finalHeight = estimatedHeight.rounded(.up)
+        let finalWidth = estimatedWidth > maxWidth ? maxWidth : estimatedWidth.rounded(.up)
+        
+        return CGSize(width: finalWidth, height: finalHeight)
+    }
 }

--- a/Sources/Extensions/String+Extensions.swift
+++ b/Sources/Extensions/String+Extensions.swift
@@ -41,4 +41,20 @@ extension String {
         return rect.width
 
     }
+    
+    /// Returns the size required to fit a String considering a constrained max width.
+    ///
+    /// - Parameters:
+    ///   - text: The `String` used to calculate a size that fits.
+    ///   - maxWidth: The max width available for the label.
+    func labelSize(considering maxWidth: CGFloat, and font: UIFont) -> CGSize {
+        
+        let estimatedHeight = self.height(considering: maxWidth, and: font)
+        let estimatedWidth = self.width(considering: estimatedHeight, and: font)
+        
+        let finalHeight = estimatedHeight.rounded(.up)
+        let finalWidth = estimatedWidth > maxWidth ? maxWidth : estimatedWidth.rounded(.up)
+        
+        return CGSize(width: finalWidth, height: finalHeight)
+    }
 }

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -328,44 +328,6 @@ fileprivate extension MessagesCollectionViewFlowLayout {
     
 }
 
-// MARK: - General Label Size Calculations
-
-private extension MessagesCollectionViewFlowLayout {
-    
-    /// Returns the size required fit a NSAttributedString considering a constrained max width.
-    ///
-    /// - Parameters:
-    ///   - attributedText: The `NSAttributedString` used to calculate a size that fits.
-    ///   - maxWidth: The max width available for the label.
-    func labelSize(for attributedText: NSAttributedString, considering maxWidth: CGFloat) -> CGSize {
-        
-        let estimatedHeight = attributedText.height(considering: maxWidth)
-        let estimatedWidth = attributedText.width(considering: estimatedHeight)
-        
-        let finalHeight = estimatedHeight.rounded(.up)
-        let finalWidth = estimatedWidth > maxWidth ? maxWidth : estimatedWidth.rounded(.up)
-        
-        return CGSize(width: finalWidth, height: finalHeight)
-    }
-    
-    /// Returns the size required to fit a String considering a constrained max width.
-    ///
-    /// - Parameters:
-    ///   - text: The `String` used to calculate a size that fits.
-    ///   - maxWidth: The max width available for the label.
-    func labelSize(for text: String, considering maxWidth: CGFloat, and font: UIFont) -> CGSize {
-        
-        let estimatedHeight = text.height(considering: maxWidth, and: font)
-        let estimatedWidth = text.width(considering: estimatedHeight, and: font)
-        
-        let finalHeight = estimatedHeight.rounded(.up)
-        let finalWidth = estimatedWidth > maxWidth ? maxWidth : estimatedWidth.rounded(.up)
-        
-        return CGSize(width: finalWidth, height: finalHeight)
-    }
-    
-}
-
 // MARK: - MessageContainerView Calculations [ D - G ]
 
 private extension MessagesCollectionViewFlowLayout {
@@ -424,15 +386,15 @@ private extension MessagesCollectionViewFlowLayout {
         
         switch attributes.message.data {
         case .text(let text):
-            messageContainerSize = labelSize(for: text, considering: maxWidth, and: messageLabelFont)
+            messageContainerSize = text.labelSize(considering: maxWidth, and: messageLabelFont)
             messageContainerSize.width += attributes.messageLabelHorizontalInsets
             messageContainerSize.height += attributes.messageLabelVerticalInsets
         case .attributedText(let text):
-            messageContainerSize = labelSize(for: text, considering: maxWidth)
+            messageContainerSize = text.labelSize(considering: maxWidth)
             messageContainerSize.width += attributes.messageLabelHorizontalInsets
             messageContainerSize.height += attributes.messageLabelVerticalInsets
         case .emoji(let text):
-            messageContainerSize = labelSize(for: text, considering: maxWidth, and: emojiLabelFont)
+            messageContainerSize =  text.labelSize(considering: maxWidth, and: emojiLabelFont)
             messageContainerSize.width += attributes.messageLabelHorizontalInsets
             messageContainerSize.height += attributes.messageLabelVerticalInsets
         case .photo, .video:
@@ -519,7 +481,7 @@ private extension MessagesCollectionViewFlowLayout {
         let text = messagesDataSource.cellBottomLabelAttributedText(for: attributes.message, at: attributes.indexPath)
         
         guard let bottomLabelText = text else { return .zero }
-        return labelSize(for: bottomLabelText, considering: attributes.bottomLabelMaxWidth)
+        return bottomLabelText.labelSize(considering: attributes.bottomLabelMaxWidth)
     }
 
 }
@@ -593,7 +555,7 @@ private extension MessagesCollectionViewFlowLayout {
         
         guard let topLabelText = text else { return .zero }
 
-        return labelSize(for: topLabelText, considering: attributes.topLabelMaxWidth)
+        return topLabelText.labelSize(considering: attributes.topLabelMaxWidth)
 
     }
     


### PR DESCRIPTION
Change-Id: Ie288df107e64d47049cf399e93226f0751c5c355

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Simple Cleaning codes. moving that function into extension let others use that function in any custom cell

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators: Simulator iPhone 8

**iOS Version: iOS 10

**Swift Version: 3.0

**MessageKit Version: 0.13.4


