### PR TITLE
Issue 663: MessageLabel touch calculation

### DIFF
--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -340,10 +340,9 @@ open class MessageLabel: UILabel {
         guard textStorage.length > 0 else { return nil }
 
         var location = location
-        let textOffset = CGPoint(x: textInsets.left, y: textInsets.right)
 
-        location.x -= textOffset.x
-        location.y -= textOffset.y
+        location.x -= textInsets.left
+        location.y -= textInsets.top
 
         let index = layoutManager.glyphIndex(for: location, in: textContainer)
 


### PR DESCRIPTION
- Removed `textOffset` `CGPoint`
- Adjusted touch location offset calculation to use `textInsets`'s `.left`/`.top` directly

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes calculation for MessageLabel touch offset

Does this close any currently open issues?
------------------------------------------
https://github.com/MessageKit/MessageKit/issues/663


Any relevant logs, error output, etc?
-------------------------------------

Any other comments?
-------------------

Where has this been tested?
---------------------------
**Devices/Simulators:** 
Simulator: iPhone 8 Plus

**iOS Version:**
11.2

**Swift Version:** 
Swift 4.0

**MessageKit Version:**
0.13.4 (master)


