### PR TITLE
Setup stale to close issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,35 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 14
+
+# Number of days of inactivity before a stale Issue or Pull Request is closed
+daysUntilClose: 7
+
+# Issues or Pull Requests with these labels will never be considered stale
+exemptLabels:
+  - "enhancement"
+  - "confirmed bug"
+  - "discussion"
+  - "feature request"
+  - "documentation"
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. 
+
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+
+# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
+closeComment: >
+  This issue has been auto-closed because there hasn't been any activity for at least 21 days.
+  However, we really appreciate your contribution, so thank you for that! 🙏
+  Also, feel free to [open a new issue](https://github.com/MessageKit/MessageKit/issues/new) if you still experience this problem 👍.
+
+# Limit to only `issues`
+only: issues


### PR DESCRIPTION
## Summary
Sets up [probot/stale](https://github.com/probot/stale) to automatically close issues after 3 weeks of inactivity.

## Related Issues
#490 

## TODO ⏰
N/A