### PR TITLE
Relax MediaItem and LocationItem protocol set requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 
+### Changed
+
+- Relaxed the settable requirement for the `LocationItem` and `MediaItem` protocols.
+[#727](https://github.com/MessageKit/MessageKit/pull/716) by [@SD10](https://github.com/sd10).
+
 ### Fixed
 
 - Fixed `MessageContentCell`'s subviews `frame` when size equal to `.zero`.

--- a/Sources/Protocols/LocationItem.swift
+++ b/Sources/Protocols/LocationItem.swift
@@ -28,9 +28,9 @@ import class CoreLocation.CLLocation
 public protocol LocationItem {
 
     /// The location.
-    var location: CLLocation { get set }
+    var location: CLLocation { get }
 
     /// The size of the location item.
-    var size: CGSize { get set }
+    var size: CGSize { get }
 
 }

--- a/Sources/Protocols/MediaItem.swift
+++ b/Sources/Protocols/MediaItem.swift
@@ -28,15 +28,15 @@ import Foundation
 public protocol MediaItem {
 
     /// The url where the media is located.
-    var url: URL? { get set }
+    var url: URL? { get }
 
     /// The image.
-    var image: UIImage? { get set }
+    var image: UIImage? { get }
 
     /// A placeholder image for when the image is obtained asychronously.
-    var placeholderImage: UIImage { get set }
+    var placeholderImage: UIImage { get }
 
     /// The size of the media item.
-    var size: CGSize { get set }
+    var size: CGSize { get }
 
 }


### PR DESCRIPTION
## Summary
Relaxes the requirement that `MediaItem` and `LocationItem` be settable

## Related Issues
Closes #723 

## TODO ⏰
- [x] CHANGELOG entry