### PR TITLE
Updated way to calculate the bottom content inset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - First major release.
 
+### Fixed
+
+- Fixed the way `MessagesViewController` calculates the bottom content inset when the keyboard is shown.
+[#761](https://github.com/MessageKit/MessageKit/issues/761) by [@davidvpe](https://github.com/davidvpe).
+
+
 ## [[Prerelease] 1.0.0-beta.2](https://github.com/MessageKit/MessageKit/releases/tag/1.0.0-beta.2)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 
+### Fixed
+
+- Fixed the calculation the bottom content inset for `MessagesCollectionView`.
+[#761](https://github.com/MessageKit/MessageKit/issues/761) by [@davidvpe](https://github.com/davidvpe).
+
 ## [1.0.0](https://github.com/MessageKit/MessageKit/releases/tag/1.0.0)
 
 - First major release.
-
-### Fixed
-
-- Fixed the way `MessagesViewController` calculates the bottom content inset when the keyboard is shown.
-[#761](https://github.com/MessageKit/MessageKit/issues/761) by [@davidvpe](https://github.com/davidvpe).
 
 
 ## [[Prerelease] 1.0.0-beta.2](https://github.com/MessageKit/MessageKit/releases/tag/1.0.0-beta.2)

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -56,7 +56,10 @@ extension MessagesViewController {
         
         guard !isMessagesControllerBeingDismissed else { return }
         
-        let newBottomInset = view.frame.height - keyboardEndFrame.minY - iPhoneXBottomInset
+        let convertedKeyboardEndFrame = messagesCollectionView.convert(keyboardEndFrame, from: nil)
+        let intersect = convertedKeyboardEndFrame.intersection(messagesCollectionView.bounds)
+        
+        let newBottomInset = intersect.size.height
         
         let differenceOfBottomInset = newBottomInset - messageCollectionViewBottomInset
         


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
-----------------------------------------------------
Modified the way MessagesViewController calculate the Collection View bottom content inset when showing the keyboard

Does this close any currently open issues?
------------------------------------------
https://github.com/MessageKit/MessageKit/issues/761

Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Devices/Simulators:** All simulators + Real iPhone 7

**iOS Version:** 11.3

**Swift Version:** 4.0

**MessageKit Version:** 1.0.0

