### PR TITLE
Add a bit about positioning Avatars in FAQ

### DIFF
--- a/Documentation/FAQs.md
+++ b/Documentation/FAQs.md
@@ -52,6 +52,29 @@ if let layout = messagesCollectionView.collectionViewLayout as? MessagesCollecti
 }
 ```
 
+**How can I move the `AvatarView` to prevent it from overlapping text in the `MessageBottomLabel` or `CellTopLabel`?**
+
+If you have resized the `AvatarView` to be larger than the default size in MessageKit then you may notice that the
+`AvatarView` overlaps text either in the `MessageBottomLabel` or `CallTopLabel`. MessageKit allows the `AvatarView`
+to overlap this text on purpose so that users can create more complex layouts that fit their needs.
+
+If you would like to move the `AvatarView`, there are convenience methods that allow you to change the horizontal or
+vertical positioning of the `AvatarView` for both incoming and outgoing messages.
+
+```Swift
+if let layout = messagesCollectionView.collectionViewLayout as? MessagesCollectionViewFlowLayout {
+    // set the vertical position of the Avatar for incoming messages so that the bottom of the Avatar
+    // aligns with the bottom of the Message
+    layout.setMessageIncomingAvatarPosition(.init(vertical: .messageBottom))
+
+    // set the vertical position of the Avatar for outgoing messages so that the bottom of the Avatar
+    // aligns with the `cellBottom`
+    layout.setMessageOutgoingAvatarPosition(.init(vertical: .cellBottom))
+}
+```
+
+There are other options provided as well so take a look at the `AvatarPosition` struct to see what they are.
+
 **How can I dismiss the keyboard?**
 
 The `MessagesViewController` needs to resign the first responder.


### PR DESCRIPTION
👻

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds to the FAQ a note about positioning the `AvatarView` so that it does not overlap text in the `MessageBottomLabel` or the `CellTopLabel` if the `AvatarView` size has been increased from the default MessageKit size.

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
Feedback greatly appreciated on this documentation!
❤️ 

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 8 (physical device), iPhone X (simulator)

**iOS Version:** 11.4, 11.4.1, 12.0 Beta 3

**Swift Version:** 4.1

**MessageKit Version:** 1.0.0

