### PR TITLE
Adjust contentInset for the keyboard frame properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - Added customizable `accessoryView`, with a new `MessagesDisplayDelegate` function `configureAccessoryView`, and corresponding size & padding properties in `MessageSizeCalculator`. [#710](https://github.com/MessageKit/MessageKit/pull/710) by [@hyouuu](https://github.com/hyouuu)
 
+- Added `extraBottomInset` property that allows to adjust the bottom content inset automatically set on the messages collection view by the view controller. [#787](https://github.com/MessageKit/MessageKit/pull/787) by [@andreyvit](https://github.com/andreyvit)
+
+### Fixed
+
+- Fixed bottom content inset adjustment when using an undocked keyboard on iPad, or when `edgesForExtendedLayout` does not include `.top`, or when a parent container view controller adds extra views at the top of the screen. [#787](https://github.com/MessageKit/MessageKit/pull/787) by [@andreyvit](https://github.com/andreyvit)
+
+
 ## [1.0.0](https://github.com/MessageKit/MessageKit/releases/tag/1.0.0)
 
 - First major release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - Added customizable `accessoryView`, with a new `MessagesDisplayDelegate` function `configureAccessoryView`, and corresponding size & padding properties in `MessageSizeCalculator`. [#710](https://github.com/MessageKit/MessageKit/pull/710) by [@hyouuu](https://github.com/hyouuu)
 
-- Added `extraBottomInset` property that allows to adjust the bottom content inset automatically set on the messages collection view by the view controller. [#787](https://github.com/MessageKit/MessageKit/pull/787) by [@andreyvit](https://github.com/andreyvit)
+- Added `additionalBottomInset` property that allows to adjust the bottom content inset automatically set on the messages collection view by the view controller. [#787](https://github.com/MessageKit/MessageKit/pull/787) by [@andreyvit](https://github.com/andreyvit)
 
 ### Fixed
 

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -115,15 +115,15 @@ extension MessagesViewController {
         if intersection.isNull || intersection.maxY < messagesCollectionView.frame.maxY - coordinatePrecision /* never compare floats without a tolerance */ {
             // The keyboard is hidden, is a hardware one, or is undocked and does not cover the bottom of the collection view.
             // Note: intersection.maxY may be less than messagesCollectionView.frame.maxY when dealing with undocked keyboards.
-            return 0
+            return max(0, extraBottomInset - automaticallyAddedBottomInset)
         } else {
-            return max(0, intersection.height - automaticallyAddedBottomInset)
+            return max(0, intersection.height + extraBottomInset - automaticallyAddedBottomInset)
         }
     }
 
     internal func requiredInitialScrollViewBottomInset() -> CGFloat {
         guard let inputAccessoryView = inputAccessoryView else { return 0 }
-        return max(0, inputAccessoryView.frame.height - automaticallyAddedBottomInset)
+        return max(0, inputAccessoryView.frame.height + extraBottomInset - automaticallyAddedBottomInset)
     }
 
     /// iOS 11's UIScrollView can automatically add safe area insets to its contentInset,

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -93,7 +93,8 @@ extension MessagesViewController {
     }
 
     private func computeScrollViewBottomInset(forKeyboardFrame keyboardFrame: CGRect) -> CGFloat {
-        // we only need to adjust for the part of the keyboard that covers (i.e. intersects) our collection view
+        // we only need to adjust for the part of the keyboard that covers (i.e. intersects) our collection view;
+        // see https://developer.apple.com/videos/play/wwdc2017/242/ for more details
         let intersection = messagesCollectionView.frame.intersection(keyboardFrame)
         
         if intersection.isNull || intersection.maxY < messagesCollectionView.frame.maxY - 1e-6 /* never compare floats without a tolerance */ {

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -52,6 +52,8 @@ extension MessagesViewController {
 
     @objc
     private func handleKeyboardDidChangeState(_ notification: Notification) {
+        guard !isMessagesControllerBeingDismissed else { return }
+
         guard let keyboardStartFrameInScreenCoords = notification.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? CGRect else { return }
         guard !keyboardStartFrameInScreenCoords.isEmpty else {
             // WORKAROUND for what seems to be a bug in iPad's keyboard handling in iOS 11: we receive an extra spurious frame change
@@ -62,8 +64,6 @@ extension MessagesViewController {
         
         guard let keyboardEndFrameInScreenCoords = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? CGRect else { return }
         let keyboardEndFrame = view.convert(keyboardEndFrameInScreenCoords, from: view.window)
-        
-        guard !isMessagesControllerBeingDismissed else { return }
         
         let newBottomInset = computeScrollViewBottomInset(forKeyboardFrame: keyboardEndFrame)
         let differenceOfBottomInset = newBottomInset - messageCollectionViewBottomInset

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -112,7 +112,7 @@ extension MessagesViewController {
         // see https://developer.apple.com/videos/play/wwdc2017/242/ for more details
         let intersection = messagesCollectionView.frame.intersection(keyboardFrame)
         
-        if intersection.isNull || intersection.maxY < messagesCollectionView.frame.maxY - 1e-6 /* never compare floats without a tolerance */ {
+        if intersection.isNull || intersection.maxY < messagesCollectionView.frame.maxY - coordinatePrecision /* never compare floats without a tolerance */ {
             // The keyboard is hidden, is a hardware one, or is undocked and does not cover the bottom of the collection view.
             // Note: intersection.maxY may be less than messagesCollectionView.frame.maxY when dealing with undocked keyboards.
             return 0

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -80,7 +80,7 @@ extension MessagesViewController {
         guard let keyboardEndFrameInScreenCoords = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? CGRect else { return }
         let keyboardEndFrame = view.convert(keyboardEndFrameInScreenCoords, from: view.window)
         
-        let newBottomInset = computeScrollViewBottomInset(forKeyboardFrame: keyboardEndFrame)
+        let newBottomInset = requiredScrollViewBottomInset(forKeyboardFrame: keyboardEndFrame)
         let differenceOfBottomInset = newBottomInset - messageCollectionViewBottomInset
         
         if maintainPositionOnKeyboardFrameChanged && differenceOfBottomInset != 0 {
@@ -107,7 +107,7 @@ extension MessagesViewController {
         }
     }
 
-    private func computeScrollViewBottomInset(forKeyboardFrame keyboardFrame: CGRect) -> CGFloat {
+    private func requiredScrollViewBottomInset(forKeyboardFrame keyboardFrame: CGRect) -> CGFloat {
         // we only need to adjust for the part of the keyboard that covers (i.e. intersects) our collection view;
         // see https://developer.apple.com/videos/play/wwdc2017/242/ for more details
         let intersection = messagesCollectionView.frame.intersection(keyboardFrame)
@@ -121,7 +121,7 @@ extension MessagesViewController {
         }
     }
 
-    internal func computeInitialScrollViewBottomInset() -> CGFloat {
+    internal func requiredInitialScrollViewBottomInset() -> CGFloat {
         guard let inputAccessoryView = inputAccessoryView else { return 0 }
         return max(0, inputAccessoryView.frame.height - automaticallyAddedBottomInset)
     }

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -112,18 +112,18 @@ extension MessagesViewController {
         // see https://developer.apple.com/videos/play/wwdc2017/242/ for more details
         let intersection = messagesCollectionView.frame.intersection(keyboardFrame)
         
-        if intersection.isNull || intersection.maxY < messagesCollectionView.frame.maxY - coordinatePrecision /* never compare floats without a tolerance */ {
+        if intersection.isNull || intersection.maxY < messagesCollectionView.frame.maxY {
             // The keyboard is hidden, is a hardware one, or is undocked and does not cover the bottom of the collection view.
             // Note: intersection.maxY may be less than messagesCollectionView.frame.maxY when dealing with undocked keyboards.
-            return max(0, extraBottomInset - automaticallyAddedBottomInset)
+            return max(0, additionalBottomInset - automaticallyAddedBottomInset)
         } else {
-            return max(0, intersection.height + extraBottomInset - automaticallyAddedBottomInset)
+            return max(0, intersection.height + additionalBottomInset - automaticallyAddedBottomInset)
         }
     }
 
     internal func requiredInitialScrollViewBottomInset() -> CGFloat {
         guard let inputAccessoryView = inputAccessoryView else { return 0 }
-        return max(0, inputAccessoryView.frame.height + extraBottomInset - automaticallyAddedBottomInset)
+        return max(0, inputAccessoryView.frame.height + additionalBottomInset - automaticallyAddedBottomInset)
     }
 
     /// iOS 11's UIScrollView can automatically add safe area insets to its contentInset,

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -99,9 +99,9 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
         if isFirstLayout {
             defer { isFirstLayout = false }
             addKeyboardObservers()
-            messageCollectionViewBottomInset = keyboardOffsetFrame.height
+            messageCollectionViewBottomInset = computeInitialScrollViewBottomInset()
         }
-        adjustScrollViewInset()
+        adjustScrollViewTopInset()
     }
 
     // MARK: - Initializers

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -24,6 +24,8 @@
 
 import UIKit
 
+internal let coordinatePrecision: CGFloat = 1e-6
+
 /// A subclass of `UIViewController` with a `MessagesCollectionView` object
 /// that is used to display conversation interfaces.
 open class MessagesViewController: UIViewController,
@@ -57,6 +59,18 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
 
     open override var shouldAutorotate: Bool {
         return false
+    }
+
+    /// A CGFloat value that adds to (or, if negative, subtracts from) the automatically
+    /// computed value of `messagesCollectionView.contentInset.bottom`. Meant to be used
+    /// as a measure of last resort when the built-in algorithm does not produce the right
+    /// value for your app. Please let us know when you end up having to use this property.
+    open var extraBottomInset: CGFloat = 0 {
+        didSet {
+            let delta = extraBottomInset - oldValue
+            guard abs(delta) > coordinatePrecision else { return }
+            messageCollectionViewBottomInset += delta
+        }
     }
 
     private var isFirstLayout: Bool = true

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -99,7 +99,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
         if isFirstLayout {
             defer { isFirstLayout = false }
             addKeyboardObservers()
-            messageCollectionViewBottomInset = computeInitialScrollViewBottomInset()
+            messageCollectionViewBottomInset = requiredInitialScrollViewBottomInset()
         }
         adjustScrollViewTopInset()
     }

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -24,8 +24,6 @@
 
 import UIKit
 
-internal let coordinatePrecision: CGFloat = 1e-6
-
 /// A subclass of `UIViewController` with a `MessagesCollectionView` object
 /// that is used to display conversation interfaces.
 open class MessagesViewController: UIViewController,
@@ -65,10 +63,9 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
     /// computed value of `messagesCollectionView.contentInset.bottom`. Meant to be used
     /// as a measure of last resort when the built-in algorithm does not produce the right
     /// value for your app. Please let us know when you end up having to use this property.
-    open var extraBottomInset: CGFloat = 0 {
+    open var additionalBottomInset: CGFloat = 0 {
         didSet {
-            let delta = extraBottomInset - oldValue
-            guard abs(delta) > coordinatePrecision else { return }
+            let delta = additionalBottomInset - oldValue
             messageCollectionViewBottomInset += delta
         }
     }
@@ -106,6 +103,11 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
     open override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         isMessagesControllerBeingDismissed = true
+    }
+    
+    open override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        isMessagesControllerBeingDismissed = false
     }
     
     open override func viewDidLayoutSubviews() {


### PR DESCRIPTION
I know that modifying the keyboard handling logic is all the rage these days, and wanted to get in on the action. :-) More seriously, I've been figuring out some keyboard handling issues in my app with a more complex structure of view controllers, and produced this PR to fix the issues found.

I believe this PR makes the code cleaner and more logical. It handles undocked keyboards and a bunch of other scenarios, and does *not* introduce weird hacks, animation blocks and the like.

Commit desciption follows:

This change provides better handling of keyboard frames. It copes with different values of UIViewController.edgesForExtendedLayout, UIScrollView.contentInsetAdjumentBehavior, view controller containment scenarios and undocked keyboards, and uses cleaner code.

Improvements and fixes in this change:

1. Translates keyboard frame from screen coordinates into view controller coordinates. They aren’t the same thing when containment is involved, or edgesForExtendedLayout does not include .top.

2. Avoids special casing any iPhone models and avoids dealing with safeAreaInsets manually. In iOS 11, UIScrollView may behave differently depending on contentInsetAdjumentBehavior, and the old code incorrectly assumed that the mode is .always (while it is in fact is .automatic) and that no extra safe area insets have been introduced at the bottom edge. Best part, we don’t have to deal with any of this at all, we can offload the logic to UIScrollView itself by looking at the difference between adjustedContentInset and contentInset.

3. Handles view controller containment and undocked keyboards by taking into account an intersection of the scroll view frame and the keyboard’s frame. I think Apple demoes this in one of the WWDC videos, but I couldn’t find which one (or if I’m misremembering). Regardless, this technique makes sure we compute and use a sensible number.


Does this close any currently open issues?
------------------------------------------

#296 and likely #761.


Where has this been tested?
---------------------------

**Devices/Simulators:** Device: iPhone 8, Simulators: iPhone 8, iPhone X, iPhone SE, iPhone 6 Plus, iPad Pro 10", iPad Air 2.

**iOS Version:** 11.4, 10.3.1, 9.3

**Swift Version:** 4

**MessageKit Version:** on top of commit 57165b7, development branch, on top of 1.0.0.