### PR TITLE
Double the font size of emoji messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 
+### Changed
+
+- The `MessageData.emoji` case once again uses a default font of 2x the `messageLabelFont` size.
+[#795](https://github.com/MessageKit/MessageKit/pull/795) by [@Vortec4800](https://github.com/vortec4800).
+
 ## [1.0.0](https://github.com/MessageKit/MessageKit/releases/tag/1.0.0)
 
 - First major release.

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -126,7 +126,11 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
     lazy open var textMessageSizeCalculator = TextMessageSizeCalculator(layout: self)
     lazy open var attributedTextMessageSizeCalculator = TextMessageSizeCalculator(layout: self)
-    lazy open var emojiMessageSizeCalculator = TextMessageSizeCalculator(layout: self)
+    lazy open var emojiMessageSizeCalculator: TextMessageSizeCalculator = {
+        let sizeCalculator = TextMessageSizeCalculator(layout: self)
+        sizeCalculator.messageLabelFont = UIFont.systemFont(ofSize: sizeCalculator.messageLabelFont.pointSize * 2)
+        return sizeCalculator
+    }()
     lazy open var photoMessageSizeCalculator = MediaMessageSizeCalculator(layout: self)
     lazy open var videoMessageSizeCalculator = MediaMessageSizeCalculator(layout: self)
     lazy open var locationMessageSizeCalculator = LocationMessageSizeCalculator(layout: self)


### PR DESCRIPTION
Modifies the emoji size calculator to set a new font, which has a size that is double the size of the default font.

What does this implement/fix? Explain your changes.
---------------------------------------------------
This re-instates old functionality where Emoji messages would have a larger font size.

Does this close any currently open issues?
------------------------------------------
This is related to issue #794


Any other comments?
-------------------
This seemed like the best way/place to do this, although if you have a better place or method of setting this I would be happy to refactor.

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 8 simulator, iPhone X device

**iOS Version:** iOS 11.4 and iOS 12 beta 5

**Swift Version:** Swift 4

**MessageKit Version:** 1.0.0

