### PR TITLE
Enhancement/init reusable view with coder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - The `MessageData.emoji` case once again uses a default font of 2x the `messageLabelFont` size.
 [#795](https://github.com/MessageKit/MessageKit/pull/795) by [@Vortec4800](https://github.com/vortec4800).
 
+### Fixed
+
+- Fixed `MessagesCollectionView` to allow to use nibs with `MessageReusableView`.
+[#832](https://github.com/MessageKit/MessageKit/pull/832) by [@maxxx777](https://github.com/maxxx777).
+
 ## [1.0.0](https://github.com/MessageKit/MessageKit/releases/tag/1.0.0)
 
 - First major release.

--- a/Sources/Views/Headers & Footers/MessageReusableView.swift
+++ b/Sources/Views/Headers & Footers/MessageReusableView.swift
@@ -33,7 +33,7 @@ open class MessageReusableView: UICollectionReusableView {
     }
 
     public required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
 
 }

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -122,6 +122,13 @@ open class MessagesCollectionView: UICollectionView {
                  forSupplementaryViewOfKind: kind,
                  withReuseIdentifier: String(describing: T.self))
     }
+    
+    /// Registers a nib with reusable view for a specific SectionKind
+    public func registerNib<T: UICollectionReusableView>(_ nib: UINib? = UINib(nibName: String(describing: T.self), bundle: nil), with headerFooterClass: T.Type, forSupplementaryViewOfKind kind: String) {
+        register(nib,
+                 forSupplementaryViewOfKind: kind,
+                 withReuseIdentifier: String(describing: T.self))        
+    }
 
     /// Generically dequeues a cell of the correct type allowing you to avoid scattering your code with guard-let-else-fatal
     public func dequeueReusableCell<T: UICollectionViewCell>(_ cellClass: T.Type, for indexPath: IndexPath) -> T {

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -124,7 +124,7 @@ open class MessagesCollectionView: UICollectionView {
     }
     
     /// Registers a nib with reusable view for a specific SectionKind
-    public func registerNib<T: UICollectionReusableView>(_ nib: UINib? = UINib(nibName: String(describing: T.self), bundle: nil), with headerFooterClass: T.Type, forSupplementaryViewOfKind kind: String) {
+    public func register<T: UICollectionReusableView>(_ nib: UINib? = UINib(nibName: String(describing: T.self), bundle: nil), headerFooterClassOfNib headerFooterClass: T.Type, forSupplementaryViewOfKind kind: String) {
         register(nib,
                  forSupplementaryViewOfKind: kind,
                  withReuseIdentifier: String(describing: T.self))        


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
The change enables to init `Reusable View` with coder, that is to create `Reusable View` from `xib` file. Also it adds convenient method to register `Reusable View` from `nib`.

Does this close any currently open issues?
------------------------------------------
Although https://github.com/MessageKit/MessageKit/issues/715 is closed, the issue fix is desired for users.

Any other comments?
-------------------
it should not affect current using of the framework, because previously `init with coder` even was not called.

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone X simulator

**iOS Version:** 11.4

**Swift Version:** 4.1

**MessageKit Version:** 1.0.0

The screenshot of the result:

![reusable_view_xib_demo](https://user-images.githubusercontent.com/2142832/44883655-2d5f9980-acb8-11e8-976e-c384047cada0.png)

