### PR TITLE
Fix scrollsToBottomOnKeybordBeginsEditing typo

### DIFF
--- a/Example/Sources/ConversationViewController.swift
+++ b/Example/Sources/ConversationViewController.swift
@@ -62,7 +62,7 @@ internal class ConversationViewController: MessagesViewController {
         messageInputBar.delegate = self
 
         messageInputBar.sendButton.tintColor = UIColor(red: 69/255, green: 193/255, blue: 89/255, alpha: 1)
-        scrollsToBottomOnKeybordBeginsEditing = true // default false
+        scrollsToBottomOnKeyboardBeginsEditing = true // default false
         maintainPositionOnKeyboardFrameChanged = true // default false
         
         messagesCollectionView.addSubview(refreshControl)

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -44,7 +44,7 @@ extension MessagesViewController {
 
     @objc
     private func handleTextViewDidBeginEditing(_ notification: Notification) {
-        if scrollsToBottomOnKeybordBeginsEditing {
+        if scrollsToBottomOnKeyboardBeginsEditing {
             guard let inputTextView = notification.object as? InputTextView, inputTextView === messageInputBar.inputTextView else { return }
             messagesCollectionView.scrollToBottom(animated: true)
         }

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -39,7 +39,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
     /// bottom whenever the `InputTextView` begins editing.
     ///
     /// The default value of this property is `false`.
-    open var scrollsToBottomOnKeybordBeginsEditing: Bool = false
+    open var scrollsToBottomOnKeyboardBeginsEditing: Bool = false
     
     /// A Boolean value that determines whether the `MessagesCollectionView`
     /// maintains it's current position when the height of the `MessageInputBar` changes.

--- a/Tests/ControllersTest/MessagesViewControllerSpec.swift
+++ b/Tests/ControllersTest/MessagesViewControllerSpec.swift
@@ -40,7 +40,7 @@ final class MessagesViewControllerSpec: QuickSpec {
         describe("default property values") {
             context("after initialization") {
                 it("sets scrollsToBottomOnKeyboardBeginsEditing to false") {
-                    expect(controller.scrollsToBottomOnKeybordBeginsEditing).to(beFalse())
+                    expect(controller.scrollsToBottomOnKeyboardBeginsEditing).to(beFalse())
                 }
                 it("sets canBecomeFirstResponder to true") {
                     expect(controller.canBecomeFirstResponder).to(beTrue())
@@ -124,12 +124,12 @@ final class MessagesViewControllerSpec: QuickSpec {
         }
 
         describe("scrolling behavior when keyboard begins editing") {
-            context("scrollsToBottomOnKeybordBeginsEditing is true") {
+            context("scrollsToBottomOnKeyboardBeginsEditing is true") {
                 it("should scroll to bottom") {
 
                 }
             }
-            context("scrollsToBottomOnKeybordBeginsEditing is false") {
+            context("scrollsToBottomOnKeyboardBeginsEditing is false") {
                 it("should not scroll to bottom") {
 
                 }


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix scrollsToBottomOnKeybordBeginsEditing typo,
change it to scrollsToBottomOnKeyboardBeginsEditing

Does this close any currently open issues?
------------------------------------------
Yes, issue #829

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone8 simulator

**iOS Version:** iOS 11.4

**Swift Version:** Swift 4.1

**MessageKit Version:** 1.0.0

