### PR TITLE
Fix scrollsToBottomOnKeybordBeginsEditing typo (development branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,14 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ### Fixed
 
+- **Breaking Change** Fixed typo of `scrollsToBottomOnKeybordBeginsEditing` to `scrollsToBottomOnKeyboardBeginsEditing`.
+[#856](https://github.com/MessageKit/MessageKit/pull/856) by [@p-petrenko](https://github.com/p-petrenko)
+
 - Fixed bottom content inset adjustment when using an undocked keyboard on iPad, or when `edgesForExtendedLayout` does not include `.top`, or when a parent container view controller adds extra views at the top of the screen. 
 [#787](https://github.com/MessageKit/MessageKit/pull/787) by [@andreyvit](https://github.com/andreyvit)
 
 - Fixed the `MessageData.emoji` case to use 2x the `messageLabelFont` size by default.
 [#795](https://github.com/MessageKit/MessageKit/pull/795) by [@Vortec4800](https://github.com/vortec4800).
-
-- **Breaking Change** Renamed `scrollsToBottomOnKeybordBeginsEditing` to `scrollsToBottomOnKeyboardBeginsEditing`.
 
 ## [1.0.0](https://github.com/MessageKit/MessageKit/releases/tag/1.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - Fixed the `MessageData.emoji` case to use 2x the `messageLabelFont` size by default.
 [#795](https://github.com/MessageKit/MessageKit/pull/795) by [@Vortec4800](https://github.com/vortec4800).
 
+- **Breaking Change** Renamed `scrollsToBottomOnKeybordBeginsEditing` to `scrollsToBottomOnKeyboardBeginsEditing`.
+
 ## [1.0.0](https://github.com/MessageKit/MessageKit/releases/tag/1.0.0)
 
 - First major release.

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -96,7 +96,7 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
         messagesCollectionView.messagesDataSource = self
         messagesCollectionView.messageCellDelegate = self
         
-        scrollsToBottomOnKeybordBeginsEditing = true // default false
+        scrollsToBottomOnKeyboardBeginsEditing = true // default false
         maintainPositionOnKeyboardFrameChanged = true // default false
         
         messagesCollectionView.addSubview(refreshControl)

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -44,7 +44,7 @@ extension MessagesViewController {
 
     @objc
     private func handleTextViewDidBeginEditing(_ notification: Notification) {
-        if scrollsToBottomOnKeybordBeginsEditing {
+        if scrollsToBottomOnKeyboardBeginsEditing {
             guard let inputTextView = notification.object as? InputTextView, inputTextView === messageInputBar.inputTextView else { return }
             messagesCollectionView.scrollToBottom(animated: true)
         }

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -39,7 +39,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
     /// bottom whenever the `InputTextView` begins editing.
     ///
     /// The default value of this property is `false`.
-    open var scrollsToBottomOnKeybordBeginsEditing: Bool = false
+    open var scrollsToBottomOnKeyboardBeginsEditing: Bool = false
     
     /// A Boolean value that determines whether the `MessagesCollectionView`
     /// maintains it's current position when the height of the `MessageInputBar` changes.

--- a/Tests/ControllersTest/MessagesViewControllerSpec.swift
+++ b/Tests/ControllersTest/MessagesViewControllerSpec.swift
@@ -40,7 +40,7 @@ final class MessagesViewControllerSpec: QuickSpec {
         describe("default property values") {
             context("after initialization") {
                 it("sets scrollsToBottomOnKeyboardBeginsEditing to false") {
-                    expect(controller.scrollsToBottomOnKeybordBeginsEditing).to(beFalse())
+                    expect(controller.scrollsToBottomOnKeyboardBeginsEditing).to(beFalse())
                 }
                 it("sets canBecomeFirstResponder to true") {
                     expect(controller.canBecomeFirstResponder).to(beTrue())
@@ -124,12 +124,12 @@ final class MessagesViewControllerSpec: QuickSpec {
         }
 
         describe("scrolling behavior when keyboard begins editing") {
-            context("scrollsToBottomOnKeybordBeginsEditing is true") {
+            context("scrollsToBottomOnKeyboardBeginsEditing is true") {
                 it("should scroll to bottom") {
 
                 }
             }
-            context("scrollsToBottomOnKeybordBeginsEditing is false") {
+            context("scrollsToBottomOnKeyboardBeginsEditing is false") {
                 it("should not scroll to bottom") {
 
                 }


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix a typo in scrollsToBottomOnKeybordBeginsEditing : change it to scrollsToBottomOnKeyboardBeginsEditing

Does this close any currently open issues?
------------------------------------------
Yes, issue #829


Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone8 simulator

**iOS Version:** iOS 11.4

**Swift Version:** Swift 4.1

**MessageKit Version:** 1.0.0

