### PR TITLE
Fix intrinsic content size for multi-line text inside MessageLabel

### DIFF
--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -114,7 +114,9 @@ open class MessageLabel: UILabel {
     }
 
     open override var intrinsicContentSize: CGSize {
-        var size = super.intrinsicContentSize
+        let maxWidth = preferredMaxLayoutWidth - textInsets.horizontal
+        let constraintBox = CGSize(width: maxWidth, height: .greatestFiniteMagnitude)
+        var size = textStorage.boundingRect(with: constraintBox, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).integral.size
         size.width += textInsets.horizontal
         size.height += textInsets.vertical
         return size


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The superclass implementation of `intrinsicContentSize` doesn't take `textInsets` into consideration when breaking lines . The workaround is to manually implement the size calculation and take `preferredMaxLayoutWidth` into consideration as the line breaking width.

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**iOS Version:** …

**Swift Version:** …

**MessageKit Version:** …


