### PR TITLE
Example chat screens do not scroll to the bottom on new message insertion.

### DIFF
--- a/Example/Sources/View Controllers/AdvancedExampleViewController.swift
+++ b/Example/Sources/View Controllers/AdvancedExampleViewController.swift
@@ -180,7 +180,7 @@ final class AdvancedExampleViewController: ChatViewController {
 //                self?.messagesCollectionView.scrollToBottom(animated: true)
 //            }
 //        }
-        messagesCollectionView.scrollToBottom(animated: true)
+//        messagesCollectionView.scrollToBottom(animated: true)
     }
     
     private func makeButton(named: String) -> InputBarButtonItem {

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -133,18 +133,7 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
         
         let lastIndexPath = IndexPath(item: 0, section: messageList.count - 1)
         
-        let frame = messagesCollectionView.layoutAttributesForItem(at: lastIndexPath)?.frame ?? .zero
-        var rect = messagesCollectionView.convert(frame, to: view)
-        
-        // substract 100 to make the "visible" area of a cell bigger
-        rect.origin.y -= 100
-        
-        var visibleRect = CGRect(x: messagesCollectionView.bounds.origin.x, y: messagesCollectionView.bounds.origin.y, width:
-            messagesCollectionView.bounds.size.width, height:
-            messagesCollectionView.bounds.size.height - messagesCollectionView.contentInset.bottom)
-        
-        visibleRect = messagesCollectionView.convert(visibleRect, to: view)
-        return visibleRect.contains(rect)
+        return messagesCollectionView.indexPathsForVisibleItems.contains(lastIndexPath)
     }
     
     // MARK: - MessagesDataSource


### PR DESCRIPTION
isLastSectionVisible method returns wrong results for the BasicExampleViewController. Moreover, there is an easier method to find the visible section.

It is unnecessary to scroll to the bottom when title view updated.

What does this implement/fix? Explain your changes.
---------------------------------------------------
If you check Example Chat app, it does not scroll to the bottom on BasicExampleViewController. Actually, it does not scroll to the bottom on the other sections, too. Therefore, i changed the method to find the last section is visible.

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**iOS Version:** …

**Swift Version:** …

**MessageKit Version:** …

