### PR TITLE
Move test to Quick/Nimble

### DIFF
--- a/Tests/ControllersTest/MessagesViewControllerSpec.swift
+++ b/Tests/ControllersTest/MessagesViewControllerSpec.swift
@@ -56,6 +56,9 @@ final class MessagesViewControllerSpec: QuickSpec {
                 it("has a MessagesCollectionView") {
                     expect(controller.messagesCollectionView).toNot(beNil())
                 }
+                it("sets the CollectionView's layout to be an instance of MessagesCollectionViewFlowLayout") {
+                    expect(controller.messagesCollectionView.collectionViewLayout).to(beAnInstanceOf(MessagesCollectionViewFlowLayout.self))
+                }
             }
             context("after viewDidLoad") {
                 beforeEach {

--- a/Tests/ControllersTest/MessagesViewControllerTests.swift
+++ b/Tests/ControllersTest/MessagesViewControllerTests.swift
@@ -55,18 +55,6 @@ class MessagesViewControllerTests: XCTestCase {
 
     // MARK: - Test
 
-    func testMessageCollectionViewLayout_isMessageCollectionViewLayout() {
-        XCTAssertNotNil(sut.messagesCollectionView.collectionViewLayout)
-        XCTAssertTrue(sut.messagesCollectionView.collectionViewLayout is MessagesCollectionViewFlowLayout)
-    }
-
-    func testMessageCollectionView_hasMessageCollectionFlowLayoutAfterViewDidLoad() {
-        let layout = sut.messagesCollectionView.collectionViewLayout
-
-        XCTAssertNotNil(layout)
-        XCTAssertTrue(layout is MessagesCollectionViewFlowLayout)
-    }
-
     func testViewDidLoad_shouldSetDelegateAndDataSourceToTheSameObject() {
         XCTAssertEqual(sut.messagesCollectionView.delegate as? MessagesViewController,
                        sut.messagesCollectionView.dataSource as? MessagesViewController)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
👻 Moved `testMessageCollectionView_hasMessageCollectionFlowLayoutAfterViewDidLoad` to **MessagesViewControlerSpec.swift** and removed a duplication of this test (`testMessageCollectionViewLayout_isMessageCollectionViewLayout`)

Does this close any currently open issues?
------------------------------------------
No, but it's related to #369 