### PR TITLE
add getting started section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ To integrate MessageKit using Carthage, add the following to your `Cartfile`:
 github "MessageKit/MessageKit"
 ````
 
+## Getting Started
+
+Please have a look at the [Quick Start guide](https://github.com/MessageKit/MessageKit/blob/master/Documentation/QuickStart.md), the [FAQs](https://github.com/MessageKit/MessageKit/blob/master/Documentation/FAQs.md) and the [MessageInputBar docs](https://github.com/MessageKit/MessageKit/blob/master/Documentation/MessageInputBar.md).
+
+If you have any issues have a look at the [Example](https://github.com/MessageKit/MessageKit/tree/master/Example) project or write a question with the "messagekit" tag on [Stack Overflow](https://stackoverflow.com/questions/tagged/messagekit).
+
+
 ## Requirements
 
 - **iOS9** or later


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
There is no reference to the documentation in the README so these changes help to make it quick and easy for people to get started with the library and point the right places for help.

Does this close any currently open issues?
------------------------------------------
no