### PR TITLE
Update CFBundleShortVersionString

### DIFF
--- a/Sources/Supporting/Info.plist
+++ b/Sources/Supporting/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>2.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Updates `CFBundleShortVersionString`.

Does this close any currently open issues?
------------------------------------------
No.


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
Although version 2.0.0 was released in November 2018, `CFBundleShortVersionString` still has value set to `1.0.0`. This can be misleading when checking `MessageKit` version built by Carthage.

Where has this been tested?
---------------------------
**Devices/Simulators:**  
iPhone XR simulator

**iOS Version:** 
12.1

**Swift Version:** 
Swift 4.2

**MessageKit Version:** 
2.0.0

