### PR TITLE
 Fix documentation error within MessagesDataSource.swift

### DIFF
--- a/Sources/Protocols/MessagesDataSource.swift
+++ b/Sources/Protocols/MessagesDataSource.swift
@@ -101,7 +101,7 @@ public protocol MessagesDataSource: AnyObject {
     ///   - messagesCollectionView: The `MessagesCollectionView` in which this cell will be displayed.
     ///
     /// - Note:
-    ///   This method will call fatalError() on default. You must override this method if you are using MessageType.custom messages.
+    ///   This method will call fatalError() on default. You must override this method if you are using MessageKind.custom messages.
     func customCell(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UICollectionViewCell
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
File: `MessageKit/Sources/Protocols/MessagesDataSource.swift`

The note attached to
```swift
func customCell(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UICollectionViewCell
```
mentions the need to override this method if one is using `MessageType.custom` messages. The `custom` case is attached to `MessageKind`, not `MessageType`.

