### PR TITLE
Fix url in changelog (ver 1.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@ classes that are responsible for sizing the `MessagesCollectionViewCell` types p
 ### Changed
 
 - **Breaking Change** Renamed `MessageData` enum to `MessageKind` and changed `MessageType`'s `data` property name to `kind`.
- [#658](https://github.com/MessageKit/MessageKit/658) by [@zhongwuzw](https://github.com/zhongwuzw).
+ [#658](https://github.com/MessageKit/MessageKit/pull/658) by [@zhongwuzw](https://github.com/zhongwuzw).
 
 - **Breaking Change** Changed the `messageFooterView(for:in)` and `messageHeaderView(for:in)` methods of
 `MessagesDisplayDelegate` by removing the `message` parameter.


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
A url in the changelog. It's missing a part of a slug.

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**iOS Version:** …

**Swift Version:** …

**MessageKit Version:** …


