### PR TITLE
Update documentation for `MessageSizeCalculator.messageContainerSize(at:)'

### DIFF
--- a/Sources/Layout/MessageSizeCalculator.swift
+++ b/Sources/Layout/MessageSizeCalculator.swift
@@ -219,8 +219,15 @@ open class MessageSizeCalculator: CellSizeCalculator {
         return isFromCurrentSender ? outgoingMessagePadding : incomingMessagePadding
     }
 
+    /// Size of the message container to the right of the avatar. Returns .zero by default.
+    ///
+    /// If you are using a custom cell and wish to keep the avatar, add your subviews
+    /// under `messageContainerView` and override this method. Otherwise, you can add your
+    /// subviews under `contentView` and override `sizeForItem(at:)`
+    ///
+    /// - Parameter message: The message object protocol
+    /// - Returns: Size of the message content container
     open func messageContainerSize(for message: MessageType) -> CGSize {
-        // Returns .zero by default
         return .zero
     }
 


### PR DESCRIPTION
In the example app, only `sizeForItem(at:)` was being overridden. I was upgrading from 0.13 and I tried borrowing the example code, but my view wouldn't appear. Turns out `messageContainerSize` set my content view to 0. It wasn't clear what methods I had to override, and the original comment is hidden under the function instead of being part of the Xcode hover-documentation.
