### PR TITLE
Coredata integration with MessageKit

### DIFF
--- a/Documentation/Coredata.md
+++ b/Documentation/Coredata.md
@@ -1,0 +1,125 @@
+# Coredata
+
+## Coredata for Persistence
+
+Coredata is used for persistence of the chat history. Coredata is supposedly the best way to store data in Apple eco-system. There is a direct iCloud, spotlight etc. integration which can be further leveraged.
+
+## Files:
+
+MessageKit.xcdatamodelId file defines the relationship between coredata entities.
+There is a coredata wrapper file for each of ChatSender, ChatMessage and ChatMessageKind original structures / enum model files. This wrapper objects retain the contents of respective structure and enum model values but only act as an interface or a medium to store the data into persistence layer. When a coredata object is created from the persistence layer the corresponding struct or enum will be created back using respective setters and getters.
+
+## Usage:
+
+### Creating an user (Loading existing user if it already exists):
+
+```Swift
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: "ChatSender")
+        var anUser:ChatSender?
+        request.predicate = NSPredicate(format: "senderID != %@", "001")    // 001 is the ID of the current user!! So, we try to first sender here for demo purpose who is not me!
+        request.returnsObjectsAsFaults = false
+        do {
+            let result = try context.fetch(request)
+            for data in result as! [NSManagedObject] {
+                anUser = data as? ChatSender
+                break
+            }
+        } catch {
+            print("Failed")
+        }
+        
+        if (anUser == nil) {
+            let entity = NSEntityDescription.entity(forEntityName: "ChatSender", in: context)
+            anUser = NSManagedObject(entity: entity!, insertInto: context) as? ChatSender
+            anUser?.senderID = "007"
+            anUser?.displayName = "Bot"
+            /*do {
+             try context.save()
+             } catch {
+             print("Failed saving")
+             }*/
+        }
+```
+
+### Creating ChatMessageKind and ChatMessage 
+
+```Swift
+                let appDelegate = UIApplication.shared.delegate as! AppDelegate
+                let context = appDelegate.persistentContainer.viewContext
+                let entity = NSEntityDescription.entity(forEntityName: "ChatMessage", in: context)
+                let message = NSManagedObject(entity: entity!, insertInto: context) as? ChatMessage
+                message?.chatMessageID = UUID().uuidString
+                message?.chatMessageSentDate = Date() as NSDate
+                let mk:MessageKind = MessageKind.text(str)
+                let mkEntity = NSEntityDescription.entity(forEntityName: "ChatMessageKind", in: context)
+                let messageKindManagedObject:ChatMessageKind = NSManagedObject (entity: mkEntity!, insertInto: context) as! ChatMessageKind
+                messageKindManagedObject.kind = mk
+                message?.chatMessageKind = messageKindManagedObject
+                message?.chatMessageSender = <<<User created in step above>>>
+```
+
+## Coredata initialization
+
+This is the standard way to initialize the coredata in AppDelegate
+
+```Swift
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+        // Saves changes in the application's managed object context before the application terminates.
+        self.saveContext()
+    }
+    
+    // MARK: - Core Data stack
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        /*
+         The persistent container for the application. This implementation
+         creates and returns a container, having loaded the store for the
+         application to it. This property is optional since there are legitimate
+         error conditions that could cause the creation of the store to fail.
+         */
+        // Raj: To get the Bundle from a project within Pods - https://stackoverflow.com/a/35903720/260665
+        let frameworkBundle = Bundle(for: ChatSender.self)
+        let container = NSPersistentContainer(name: "MessageKit", bundle: frameworkBundle)
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                
+                /*
+                 Typical reasons for an error here include:
+                 * The parent directory does not exist, cannot be created, or disallows writing.
+                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
+                 * The device is out of space.
+                 * The store could not be migrated to the current model version.
+                 Check the error message to determine what the actual problem was.
+                 */
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+    
+    // MARK: - Core Data Saving support
+    
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
+```
+
+## Consideration:
+
+- Make sure that `MessageKit.xcdatamodelId` file is part of the Build Copy phase of the parent project.
+- Refer to `ChatExample` project's `CoredataChatViewController.swift` file for an example implementation.

--- a/Example/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/ChatExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02B968A12242459700104734 /* CoredataChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B968A02242459600104734 /* CoredataChatViewController.swift */; };
 		385C2922211FF32E0010B4BA /* CustomCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385C2920211FF32E0010B4BA /* CustomCell.swift */; };
 		385C2923211FF32E0010B4BA /* TableViewCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385C2921211FF32E0010B4BA /* TableViewCells.swift */; };
 		385C2927211FF33B0010B4BA /* MockSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385C2925211FF33A0010B4BA /* MockSocket.swift */; };
@@ -65,6 +66,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		02B968A02242459600104734 /* CoredataChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoredataChatViewController.swift; sourceTree = "<group>"; };
 		0364943D08CDBE656E6F6DF8 /* Pods-ChatExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ChatExampleTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ChatExampleTests/Pods-ChatExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2AC6E3F5C11E39F57598DBE6 /* Pods_ChatExampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ChatExampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		385C2920211FF32E0010B4BA /* CustomCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomCell.swift; sourceTree = "<group>"; };
@@ -181,6 +183,7 @@
 			children = (
 				385C293B211FF38E0010B4BA /* AdvancedExampleViewController.swift */,
 				385C2940211FF38F0010B4BA /* BasicExampleViewController.swift */,
+				02B968A02242459600104734 /* CoredataChatViewController.swift */,
 				385C2941211FF38F0010B4BA /* ChatViewController.swift */,
 				385C293F211FF38F0010B4BA /* LaunchViewController.swift */,
 				385C293D211FF38F0010B4BA /* MessageContainerController.swift */,
@@ -588,6 +591,7 @@
 				385C2937211FF37B0010B4BA /* SampleData.swift in Sources */,
 				385C2931211FF3630010B4BA /* UIColor+Extensions.swift in Sources */,
 				385C2932211FF3630010B4BA /* UIViewController+Extensions.swift in Sources */,
+				02B968A12242459700104734 /* CoredataChatViewController.swift in Sources */,
 				385C292B211FF3450010B4BA /* Settings+UserDefaults.swift in Sources */,
 				385C2945211FF38F0010B4BA /* NavigationController.swift in Sources */,
 				385C2948211FF38F0010B4BA /* ChatViewController.swift in Sources */,

--- a/Example/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/ChatExample.xcodeproj/project.pbxproj
@@ -758,6 +758,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.messagekit.ChatExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -773,6 +774,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.messagekit.ChatExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/ChatExample.xcodeproj/project.pbxproj
@@ -285,6 +285,7 @@
 				882B5EA41CF7D8D100B6E160 /* Embed Frameworks */,
 				3C8DFCD3063DA0DF099EC7B6 /* [CP] Embed Pods Frameworks */,
 				7E0AFF9D207BB460004DFD4C /* ShellScript */,
+				27D9BCE2E846814B176ACB3B /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -303,6 +304,8 @@
 				882B5E451CF7D4B900B6E160 /* Sources */,
 				882B5E461CF7D4B900B6E160 /* Frameworks */,
 				882B5E471CF7D4B900B6E160 /* Resources */,
+				847217C2D96FF164675BA48B /* [CP] Embed Pods Frameworks */,
+				A3EEA7E414D8150D8ED63845 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -322,6 +325,8 @@
 				882B5E501CF7D4B900B6E160 /* Sources */,
 				882B5E511CF7D4B900B6E160 /* Frameworks */,
 				882B5E521CF7D4B900B6E160 /* Resources */,
+				D8A719AE4F596CEC37A53D75 /* [CP] Embed Pods Frameworks */,
+				FE7504275979222F35F517AB /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -441,6 +446,21 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		27D9BCE2E846814B176ACB3B /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ChatExample/Pods-ChatExample-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3C8DFCD3063DA0DF099EC7B6 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -491,6 +511,66 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+		847217C2D96FF164675BA48B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ChatExampleTests/Pods-ChatExampleTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A3EEA7E414D8150D8ED63845 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ChatExampleTests/Pods-ChatExampleTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D8A719AE4F596CEC37A53D75 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ChatExampleUITests/Pods-ChatExampleUITests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FE7504275979222F35F517AB /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ChatExampleUITests/Pods-ChatExampleUITests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 target 'ChatExample' do
   use_frameworks!

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - MessageInputBar (0.4.1):
     - MessageInputBar/Core (= 0.4.1)
   - MessageInputBar/Core (0.4.1)
-  - MessageKit (1.0.0):
+  - MessageKit (2.0.0):
     - MessageInputBar/Core
 
 DEPENDENCIES:
@@ -14,7 +14,7 @@ EXTERNAL SOURCES:
     :branch: master
     :git: https://github.com/MessageKit/MessageInputBar.git
   MessageKit:
-    :path: "../"
+    :path: ../
 
 CHECKOUT OPTIONS:
   MessageInputBar:
@@ -23,8 +23,8 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   MessageInputBar: e81c7535347f1f7b923de7080409a535a004b6e4
-  MessageKit: 2bbd13dd6a7c06f42f2d13ed8871d1fe5383b477
+  MessageKit: e86b06ad2eb2d4ddea3ba29c4d9d13edf78843d1
 
 PODFILE CHECKSUM: 04c1a805e1997e83bacab1a34787e71e9fe4432b
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.4.0

--- a/Example/Sources/AppDelegate.swift
+++ b/Example/Sources/AppDelegate.swift
@@ -23,7 +23,7 @@
  */
 
 import UIKit
-import CoreData
+import CoreData 
 
 @UIApplicationMain
 final internal class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Example/Sources/AppDelegate.swift
+++ b/Example/Sources/AppDelegate.swift
@@ -24,6 +24,7 @@
 
 import UIKit
 import CoreData 
+import MessageKit
 
 @UIApplicationMain
 final internal class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -59,7 +60,9 @@ final internal class AppDelegate: UIResponder, UIApplicationDelegate {
          application to it. This property is optional since there are legitimate
          error conditions that could cause the creation of the store to fail.
          */
-        let container = NSPersistentContainer(name: "ConversationAI")
+        // Raj: To get the Bundle from a project within Pods - https://stackoverflow.com/a/35903720/260665
+        let frameworkBundle = Bundle(for: ChatSender.self)
+        let container = NSPersistentContainer(name: "MessageKit", bundle: frameworkBundle)
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
                 // Replace this implementation with code to handle the error appropriately.

--- a/Example/Sources/AppDelegate.swift
+++ b/Example/Sources/AppDelegate.swift
@@ -23,6 +23,7 @@
  */
 
 import UIKit
+import CoreData
 
 @UIApplicationMain
 final internal class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -43,4 +44,54 @@ final internal class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+        // Saves changes in the application's managed object context before the application terminates.
+        self.saveContext()
+    }
+    
+    // MARK: - Core Data stack
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        /*
+         The persistent container for the application. This implementation
+         creates and returns a container, having loaded the store for the
+         application to it. This property is optional since there are legitimate
+         error conditions that could cause the creation of the store to fail.
+         */
+        let container = NSPersistentContainer(name: "ConversationAI")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                
+                /*
+                 Typical reasons for an error here include:
+                 * The parent directory does not exist, cannot be created, or disallows writing.
+                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
+                 * The device is out of space.
+                 * The store could not be migrated to the current model version.
+                 Check the error message to determine what the actual problem was.
+                 */
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+    
+    // MARK: - Core Data Saving support
+    
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
 }

--- a/Example/Sources/View Controllers/CoredataChatViewController.swift
+++ b/Example/Sources/View Controllers/CoredataChatViewController.swift
@@ -1,0 +1,366 @@
+//
+//  CoredataChatViewController.swift
+//  ChatExample
+//
+//  Created by Gumdal, Raj Pawan on 20/03/19.
+//  Copyright © 2019 MessageKit. All rights reserved.
+//
+
+import Foundation
+import MapKit
+import MessageKit
+import MessageInputBar
+import CoreData
+
+class CoredataChatViewController: MessagesViewController {
+    let refreshControl = UIRefreshControl()
+    let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter
+    }()
+    private lazy var chatUser:ChatSender = {
+        // From: https://medium.com/swift-programming/how-to-do-proper-lazy-loading-in-swift-b8bc57dbc7b9
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: "ChatSender")
+        var anUser:ChatSender?
+        request.predicate = NSPredicate(format: "senderID != %@", "001")    // 001 is the ID of the current user!! So, we try to first sender here for demo purpose who is not me!
+        request.returnsObjectsAsFaults = false
+        do {
+            let result = try context.fetch(request)
+            for data in result as! [NSManagedObject] {
+                anUser = data as? ChatSender
+                break
+            }
+        } catch {
+            print("Failed")
+        }
+        
+        if (anUser == nil) {
+            let entity = NSEntityDescription.entity(forEntityName: "ChatSender", in: context)
+            anUser = NSManagedObject(entity: entity!, insertInto: context) as? ChatSender
+            anUser?.senderID = "007"
+            anUser?.displayName = "Bot"
+            /*do {
+             try context.save()
+             } catch {
+             print("Failed saving")
+             }*/
+        }
+        return anUser!
+    }()
+    private lazy var currentUser:ChatSender = {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: "ChatSender")
+        var anUser:ChatSender?
+        request.predicate = NSPredicate(format: "senderID = %@", "001")
+        request.returnsObjectsAsFaults = false
+        do {
+            let result = try context.fetch(request)
+            for data in result as! [NSManagedObject] {
+                anUser = data as? ChatSender
+                break
+            }
+        } catch {
+            print("Failed")
+        }
+        
+        if (anUser == nil) {
+            let entity = NSEntityDescription.entity(forEntityName: "ChatSender", in: context)
+            anUser = NSManagedObject(entity: entity!, insertInto: context) as? ChatSender
+            anUser?.senderID = "001"
+            anUser?.displayName = "Human"
+            /*do {
+             try context.save()
+             } catch {
+             print("Failed saving")
+             }*/
+        }
+        return anUser!
+    }()
+    
+    private lazy var messagesFetchedResultsController:NSFetchedResultsController<ChatMessage> = {
+        let request: NSFetchRequest<ChatMessage> = ChatMessage.fetchRequest()
+        let sort = NSSortDescriptor(key: "chatMessageSentDate", ascending: true)
+        request.sortDescriptors = [sort]
+        //        request.fetchBatchSize = 20
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let context = appDelegate.persistentContainer.viewContext
+        
+        let fetchedResultsController = NSFetchedResultsController(fetchRequest: request, managedObjectContext: context, sectionNameKeyPath: nil, cacheName: nil)
+        fetchedResultsController.delegate = self as! NSFetchedResultsControllerDelegate
+        
+        do {
+            try fetchedResultsController.performFetch()
+        } catch {
+            print("Fetch failed")
+        }
+        
+        return fetchedResultsController
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+        
+        configureMessageCollectionView()
+        configureMessageInputBar()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        MockSocket.shared.connect(with: [SampleData.shared.steven, SampleData.shared.wu])
+            .onNewMessage { [weak self] message in
+                var textResponse : String? = nil
+                switch message.kind {
+                case .text(let textValue):
+                    textResponse = textValue
+                default:
+                    textResponse = nil
+                }
+                if (nil != textResponse) {
+                    let creatingChatUser = self!.chatUser // Creating this to avoid a crash later!!
+                    let appDelegate = UIApplication.shared.delegate as! AppDelegate
+                    let context = appDelegate.persistentContainer.viewContext
+                    let entity = NSEntityDescription.entity(forEntityName: "ChatMessage", in: context)
+                    let mkEntity = NSEntityDescription.entity(forEntityName: "ChatMessageKind", in: context)
+                    let responseMessage = NSManagedObject(entity: entity!, insertInto: context) as? ChatMessage
+                    responseMessage?.chatMessageID = UUID().uuidString
+                    responseMessage?.chatMessageSentDate = Date() as NSDate
+                    let responseMK:MessageKind = MessageKind.text(textResponse!)
+                    let responseMessageKindManagedObject:ChatMessageKind = NSManagedObject (entity: mkEntity!, insertInto: context) as! ChatMessageKind
+                    responseMessageKindManagedObject.kind = responseMK
+                    responseMessage?.chatMessageKind = responseMessageKindManagedObject
+                    responseMessage?.chatMessageSender = self!.chatUser
+                    do {
+                        try context.save()
+                    } catch {
+                        print("Failed saving")
+                    }
+                }
+        }
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        MockSocket.shared.disconnect()
+    }
+
+    func configureMessageCollectionView() {
+        
+        messagesCollectionView.messagesDataSource = self
+        messagesCollectionView.messageCellDelegate = self
+        
+        scrollsToBottomOnKeyboardBeginsEditing = true // default false
+        maintainPositionOnKeyboardFrameChanged = true // default false
+        messagesCollectionView.addSubview(refreshControl)
+        refreshControl.addTarget(self, action: #selector(refreshChat), for: .valueChanged)
+        
+        messagesCollectionView.messagesLayoutDelegate = self
+        messagesCollectionView.messagesDisplayDelegate = self
+    }
+    func configureMessageInputBar() {
+        messageInputBar.delegate = self
+        messageInputBar.inputTextView.tintColor = .primaryColor
+        messageInputBar.sendButton.tintColor = .primaryColor
+    }
+    
+    @objc func refreshChat() {
+        
+    }
+}
+
+extension CoredataChatViewController : MessagesDataSource {
+    //  MARK: - MessagesDataSource
+    func currentSender() -> Sender {
+        let theCurrentSender:ChatSender = self.currentUser
+        return theCurrentSender.sender
+    }
+    
+    func messageForItem(at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageType {
+        return self.messagesFetchedResultsController.fetchedObjects![indexPath.section] as! MessageType
+    }
+    
+    func numberOfSections(in messagesCollectionView: MessagesCollectionView) -> Int {
+        return (self.messagesFetchedResultsController.fetchedObjects?.count)!
+    }
+    
+    func cellTopLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
+        if indexPath.section % 3 == 0 {
+            return NSAttributedString(string: MessageKitDateFormatter.shared.string(from: message.sentDate), attributes: [NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 10), NSAttributedString.Key.foregroundColor: UIColor.darkGray])
+        }
+        return nil
+    }
+    
+    func messageTopLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
+        let name = message.sender.displayName
+        return NSAttributedString(string: name, attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .caption1)])
+    }
+    
+    func messageBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
+        let dateString = formatter.string(from: message.sentDate)
+        return NSAttributedString(string: dateString, attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .caption2)])
+    }
+}
+
+extension CoredataChatViewController : MessageCellDelegate {
+    func didTapBackground(in cell: MessageCollectionViewCell) {}
+    
+    func didTapMessage(in cell: MessageCollectionViewCell) {}
+    
+    func didTapAvatar(in cell: MessageCollectionViewCell) {}
+    
+    func didTapCellTopLabel(in cell: MessageCollectionViewCell) {}
+    
+    func didTapCellBottomLabel(in cell: MessageCollectionViewCell) {}
+    
+    func didTapMessageTopLabel(in cell: MessageCollectionViewCell) {}
+    
+    func didTapMessageBottomLabel(in cell: MessageCollectionViewCell) {}
+    
+    func didTapAccessoryView(in cell: MessageCollectionViewCell) {}
+}
+
+
+// MARK: - MessageInputBarDelegate
+extension CoredataChatViewController: MessageInputBarDelegate {
+    func messageInputBar(_ inputBar: MessageInputBar, didPressSendButtonWith text: String) {
+        for component in inputBar.inputTextView.components {
+            if let str = component as? String {
+                let appDelegate = UIApplication.shared.delegate as! AppDelegate
+                let context = appDelegate.persistentContainer.viewContext
+                let entity = NSEntityDescription.entity(forEntityName: "ChatMessage", in: context)
+                let message = NSManagedObject(entity: entity!, insertInto: context) as? ChatMessage
+                message?.chatMessageID = UUID().uuidString
+                message?.chatMessageSentDate = Date() as NSDate
+                let mk:MessageKind = MessageKind.text(str)
+                let mkEntity = NSEntityDescription.entity(forEntityName: "ChatMessageKind", in: context)
+                let messageKindManagedObject:ChatMessageKind = NSManagedObject (entity: mkEntity!, insertInto: context) as! ChatMessageKind
+                messageKindManagedObject.kind = mk
+                message?.chatMessageKind = messageKindManagedObject
+                message?.chatMessageSender = self.currentUser
+                let creatingChatUser = self.chatUser // Creating this to avoid a crash later!!
+                
+                // Save context:
+                do {
+                    try context.save()
+                } catch {
+                    print("Failed saving")
+                }
+            } /*else if let img = component as? UIImage {
+             let message = MockMessage(image: img, sender: currentSender(), messageId: UUID().uuidString, date: Date())
+             insertMessage(message)
+             }*/
+        }
+        inputBar.inputTextView.text = String()
+        messagesCollectionView.scrollToBottom(animated: true)
+    }
+}
+
+extension CoredataChatViewController: NSFetchedResultsControllerDelegate {
+    //    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
+        if (type == .insert) {
+            messagesCollectionView.performBatchUpdates({
+                messagesCollectionView.insertSections([self.messagesFetchedResultsController.fetchedObjects!.count - 1])
+                if self.messagesFetchedResultsController.fetchedObjects!.count >= 2 {
+                    messagesCollectionView.reloadSections([self.messagesFetchedResultsController.fetchedObjects!.count - 2])
+                }
+            }, completion: { [weak self] _ in
+                if self?.isLastSectionVisible() == true {
+                    self?.messagesCollectionView.scrollToBottom(animated: true)
+                }
+            })
+        }
+    }
+    func isLastSectionVisible() -> Bool {
+        
+        guard !self.messagesFetchedResultsController.fetchedObjects!.isEmpty else { return false }
+        
+        let lastIndexPath = IndexPath(item: 0, section: self.messagesFetchedResultsController.fetchedObjects!.count - 1)
+        
+        return messagesCollectionView.indexPathsForVisibleItems.contains(lastIndexPath)
+    }
+}
+
+extension CoredataChatViewController : MessagesLayoutDelegate {
+    
+    func cellTopLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
+        return 18
+    }
+    
+    func messageTopLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
+        return 20
+    }
+    
+    func messageBottomLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
+        return 16
+    }
+    
+}
+
+extension CoredataChatViewController : MessagesDisplayDelegate {
+    
+    // MARK: - Text Messages
+    
+    func textColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
+        return isFromCurrentSender(message: message) ? .white : .darkText
+    }
+    
+    func detectorAttributes(for detector: DetectorType, and message: MessageType, at indexPath: IndexPath) -> [NSAttributedString.Key: Any] {
+        return MessageLabel.defaultAttributes
+    }
+    
+    func enabledDetectors(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> [DetectorType] {
+        return [.url, .address, .phoneNumber, .date, .transitInformation]
+    }
+    
+    // MARK: - All Messages
+    
+    func backgroundColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
+        return isFromCurrentSender(message: message) ? .primaryColor : UIColor(red: 230/255, green: 230/255, blue: 230/255, alpha: 1)
+    }
+    
+    func messageStyle(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageStyle {
+        
+        let tail: MessageStyle.TailCorner = isFromCurrentSender(message: message) ? .bottomRight : .bottomLeft
+        return .bubbleTail(tail, .curved)
+    }
+    
+    func configureAvatarView(_ avatarView: AvatarView, for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) {
+        let sender = message.sender
+        let firstName = sender.displayName.components(separatedBy: " ").first
+        let lastName = sender.displayName.components(separatedBy: " ").first
+        let initials = "\(firstName?.first ?? "A")\(lastName?.first ?? "A")"
+        let avatar = Avatar(image: nil, initials: initials)
+        avatarView.set(avatar: avatar)
+    }
+    
+    // MARK: - Location Messages
+    
+    func annotationViewForLocation(message: MessageType, at indexPath: IndexPath, in messageCollectionView: MessagesCollectionView) -> MKAnnotationView? {
+        let annotationView = MKAnnotationView(annotation: nil, reuseIdentifier: nil)
+        let pinImage = #imageLiteral(resourceName: "ic_map_marker")
+        annotationView.image = pinImage
+        annotationView.centerOffset = CGPoint(x: 0, y: -pinImage.size.height / 2)
+        return annotationView
+    }
+    
+    func animationBlockForLocation(message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> ((UIImageView) -> Void)? {
+        return { view in
+            view.layer.transform = CATransform3DMakeScale(2, 2, 2)
+            UIView.animate(withDuration: 0.6, delay: 0, usingSpringWithDamping: 0.9, initialSpringVelocity: 0, options: [], animations: {
+                view.layer.transform = CATransform3DIdentity
+            }, completion: nil)
+        }
+    }
+    
+    func snapshotOptionsForLocation(message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> LocationMessageSnapshotOptions {
+        
+        return LocationMessageSnapshotOptions(showsBuildings: true, showsPointsOfInterest: true, span: MKCoordinateSpan(latitudeDelta: 10, longitudeDelta: 10))
+    }
+}
+

--- a/Example/Sources/View Controllers/LaunchViewController.swift
+++ b/Example/Sources/View Controllers/LaunchViewController.swift
@@ -33,7 +33,7 @@ final internal class LaunchViewController: UITableViewController {
         return .lightContent
     }
 
-    let cells = ["Basic Example", "Advanced Example", "Embedded Example", "Settings", "Source Code", "Contributors"]
+    let cells = ["Basic Example", "Coredata Basic Example", "Advanced Example", "Embedded Example", "Settings", "Source Code", "Contributors"]
     
     // MARK: - View Life Cycle
     
@@ -78,6 +78,8 @@ final internal class LaunchViewController: UITableViewController {
         let cell = cells[indexPath.row]
         switch cell {
         case "Basic Example":
+            navigationController?.pushViewController(BasicExampleViewController(), animated: true)
+        case "Coredata Basic Example":
             navigationController?.pushViewController(BasicExampleViewController(), animated: true)
         case "Advanced Example":
             navigationController?.pushViewController(AdvancedExampleViewController(), animated: true)

--- a/Example/Sources/View Controllers/LaunchViewController.swift
+++ b/Example/Sources/View Controllers/LaunchViewController.swift
@@ -80,7 +80,7 @@ final internal class LaunchViewController: UITableViewController {
         case "Basic Example":
             navigationController?.pushViewController(BasicExampleViewController(), animated: true)
         case "Coredata Basic Example":
-            navigationController?.pushViewController(BasicExampleViewController(), animated: true)
+            navigationController?.pushViewController(CoredataChatViewController(), animated: true)
         case "Advanced Example":
             navigationController?.pushViewController(AdvancedExampleViewController(), animated: true)
         case "Embedded Example":

--- a/MessageKit.podspec
+++ b/MessageKit.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
       "SWIFT_VERSION" => "4.0",
    }
 
-   s.ios.deployment_target = '9.0'
+   s.ios.deployment_target = '10.0'
    s.ios.resource_bundle = { 'MessageKitAssets' => 'Assets/MessageKitAssets.bundle/Images' }
 
    s.requires_arc = true

--- a/Sources/Coredata/MessageKit.xcdatamodeld/.xccurrentversion
+++ b/Sources/Coredata/MessageKit.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>MessageKit.xcdatamodel</string>
+</dict>
+</plist>

--- a/Sources/Coredata/MessageKit.xcdatamodeld/MessageKit.xcdatamodel/contents
+++ b/Sources/Coredata/MessageKit.xcdatamodeld/MessageKit.xcdatamodel/contents
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18A391" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="ChatMessage" representedClassName="ChatMessage" syncable="YES" codeGenerationType="class">
+        <attribute name="chatMessageID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="chatMessageSentDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="chatMessageKind" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChatMessageKind" syncable="YES"/>
+        <relationship name="chatMessageSender" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChatSender" syncable="YES"/>
+    </entity>
+    <entity name="ChatMessageKind" representedClassName="ChatMessageKind" syncable="YES" codeGenerationType="class">
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="ChatSender" representedClassName="ChatSender" syncable="YES" codeGenerationType="class">
+        <attribute name="displayName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="senderID" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="ChatMessage" positionX="-63" positionY="-18" width="128" height="105"/>
+        <element name="ChatMessageKind" positionX="-36" positionY="27" width="128" height="60"/>
+        <element name="ChatSender" positionX="-54" positionY="9" width="128" height="75"/>
+    </elements>
+</model>

--- a/Sources/Coredata/Model Classes/ChatMessage+CoreDataClass.swift
+++ b/Sources/Coredata/Model Classes/ChatMessage+CoreDataClass.swift
@@ -1,6 +1,6 @@
 //
 //  ChatMessage+CoreDataClass.swift
-//  ConversationAI
+//  MessageKit
 //
 //  Created by Gumdal, Raj Pawan on 14/03/19.
 //  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.

--- a/Sources/Coredata/Model Classes/ChatMessage+CoreDataClass.swift
+++ b/Sources/Coredata/Model Classes/ChatMessage+CoreDataClass.swift
@@ -1,0 +1,16 @@
+//
+//  ChatMessage+CoreDataClass.swift
+//  ConversationAI
+//
+//  Created by Gumdal, Raj Pawan on 14/03/19.
+//  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(ChatMessage)
+public class ChatMessage: NSManagedObject {
+
+}

--- a/Sources/Coredata/Model Classes/ChatMessage+CoreDataProperties.swift
+++ b/Sources/Coredata/Model Classes/ChatMessage+CoreDataProperties.swift
@@ -1,6 +1,6 @@
 //
 //  ChatMessage+CoreDataProperties.swift
-//  ConversationAI
+//  MessageKit
 //
 //  Created by Gumdal, Raj Pawan on 14/03/19.
 //  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.

--- a/Sources/Coredata/Model Classes/ChatMessage+CoreDataProperties.swift
+++ b/Sources/Coredata/Model Classes/ChatMessage+CoreDataProperties.swift
@@ -1,0 +1,24 @@
+//
+//  ChatMessage+CoreDataProperties.swift
+//  ConversationAI
+//
+//  Created by Gumdal, Raj Pawan on 14/03/19.
+//  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension ChatMessage {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ChatMessage> {
+        return NSFetchRequest<ChatMessage>(entityName: "ChatMessage")
+    }
+
+    @NSManaged public var chatMessageID: String?
+    @NSManaged public var chatMessageSentDate: NSDate?
+    @NSManaged public var chatMessageKind: ChatMessageKind?
+    @NSManaged public var chatMessageSender: ChatSender?
+}

--- a/Sources/Coredata/Model Classes/ChatMessage+MessageStructureWrapper.swift
+++ b/Sources/Coredata/Model Classes/ChatMessage+MessageStructureWrapper.swift
@@ -1,0 +1,57 @@
+//
+//  ChatMessage+MessageStructureWrapper.swift
+//  ConversationAI
+//
+//  Created by Gumdal, Raj Pawan on 15/03/19.
+//  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.
+//
+
+import Foundation
+import MessageKit
+
+extension ChatMessage : MessageType{
+    public var sender: Sender {
+        get {
+            var aSender:Sender? = nil
+            if ((chatMessageSender) != nil) {
+                aSender = chatMessageSender?.sender
+            }
+            return aSender!
+        }
+    }
+    public var messageId: String {
+        get {
+            return chatMessageID!
+        }
+    }
+    
+    public var sentDate: Date {
+        get {
+            return chatMessageSentDate! as Date
+        }
+    }
+    
+    public var kind: MessageKind {
+        get {
+            return (chatMessageKind?.kind)!
+        }
+    }
+    
+    /*var chatMessageType: MessageType {
+        get {
+//            return Sender(id: self.senderID!, displayName: self.displayName!)
+            let messType:MessageType = MessageType
+            messType.kind = self.kind
+            messType.sender = sender
+            self.messageId = messageId
+            self.sentDate = date
+
+            return MessageType
+        }
+        set {
+            self.senderID = newValue.id
+            self.displayName = newValue.displayName
+        }
+    }*/
+}
+

--- a/Sources/Coredata/Model Classes/ChatMessage+MessageStructureWrapper.swift
+++ b/Sources/Coredata/Model Classes/ChatMessage+MessageStructureWrapper.swift
@@ -1,6 +1,6 @@
 //
 //  ChatMessage+MessageStructureWrapper.swift
-//  ConversationAI
+//  MessageKit
 //
 //  Created by Gumdal, Raj Pawan on 15/03/19.
 //  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.

--- a/Sources/Coredata/Model Classes/ChatMessageKind+CoreDataClass.swift
+++ b/Sources/Coredata/Model Classes/ChatMessageKind+CoreDataClass.swift
@@ -1,0 +1,16 @@
+//
+//  ChatMessageKind+CoreDataClass.swift
+//  ConversationAI
+//
+//  Created by Gumdal, Raj Pawan on 14/03/19.
+//  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(ChatMessageKind)
+public class ChatMessageKind: NSManagedObject {
+
+}

--- a/Sources/Coredata/Model Classes/ChatMessageKind+CoreDataClass.swift
+++ b/Sources/Coredata/Model Classes/ChatMessageKind+CoreDataClass.swift
@@ -1,6 +1,6 @@
 //
 //  ChatMessageKind+CoreDataClass.swift
-//  ConversationAI
+//  MessageKit
 //
 //  Created by Gumdal, Raj Pawan on 14/03/19.
 //  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.

--- a/Sources/Coredata/Model Classes/ChatMessageKind+CoreDataProperties.swift
+++ b/Sources/Coredata/Model Classes/ChatMessageKind+CoreDataProperties.swift
@@ -1,0 +1,22 @@
+//
+//  ChatMessageKind+CoreDataProperties.swift
+//  ConversationAI
+//
+//  Created by Gumdal, Raj Pawan on 14/03/19.
+//  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension ChatMessageKind {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ChatMessageKind> {
+        return NSFetchRequest<ChatMessageKind>(entityName: "ChatMessageKind")
+    }
+
+    @NSManaged public var text: String?
+
+}

--- a/Sources/Coredata/Model Classes/ChatMessageKind+CoreDataProperties.swift
+++ b/Sources/Coredata/Model Classes/ChatMessageKind+CoreDataProperties.swift
@@ -1,6 +1,6 @@
 //
 //  ChatMessageKind+CoreDataProperties.swift
-//  ConversationAI
+//  MessageKit
 //
 //  Created by Gumdal, Raj Pawan on 14/03/19.
 //  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.

--- a/Sources/Coredata/Model Classes/ChatMessageKind+KindStructureWrapper.swift
+++ b/Sources/Coredata/Model Classes/ChatMessageKind+KindStructureWrapper.swift
@@ -1,0 +1,28 @@
+//
+//  MessageKind+KindStructureWrapper.swift
+//  ConversationAI
+//
+//  Created by Gumdal, Raj Pawan on 14/03/19.
+//  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.
+//
+
+import Foundation
+import MessageKit
+
+extension ChatMessageKind {
+    // From: https://stackoverflow.com/a/37877297/260665
+    var kind: MessageKind {
+        get {
+            return .text(self.text ?? "s")
+        }
+        set {
+            // From: https://stackoverflow.com/a/25355800/260665
+            switch newValue {
+            case .text(let textValue):
+                self.text = textValue
+            default:
+                self.text = ""
+            }
+        }
+    }
+}

--- a/Sources/Coredata/Model Classes/ChatMessageKind+KindStructureWrapper.swift
+++ b/Sources/Coredata/Model Classes/ChatMessageKind+KindStructureWrapper.swift
@@ -1,6 +1,6 @@
 //
 //  MessageKind+KindStructureWrapper.swift
-//  ConversationAI
+//  MessageKit
 //
 //  Created by Gumdal, Raj Pawan on 14/03/19.
 //  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.
@@ -11,7 +11,7 @@ import MessageKit
 
 extension ChatMessageKind {
     // From: https://stackoverflow.com/a/37877297/260665
-    var kind: MessageKind {
+    public var kind: MessageKind {
         get {
             return .text(self.text ?? "s")
         }

--- a/Sources/Coredata/Model Classes/ChatSender+CoreDataClass.swift
+++ b/Sources/Coredata/Model Classes/ChatSender+CoreDataClass.swift
@@ -1,6 +1,6 @@
 //
 //  ChatSender+CoreDataClass.swift
-//  ConversationAI
+//  MessageKit
 //
 //  Created by Gumdal, Raj Pawan on 14/03/19.
 //  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.

--- a/Sources/Coredata/Model Classes/ChatSender+CoreDataClass.swift
+++ b/Sources/Coredata/Model Classes/ChatSender+CoreDataClass.swift
@@ -1,0 +1,16 @@
+//
+//  ChatSender+CoreDataClass.swift
+//  ConversationAI
+//
+//  Created by Gumdal, Raj Pawan on 14/03/19.
+//  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(ChatSender)
+public class ChatSender: NSManagedObject {
+
+}

--- a/Sources/Coredata/Model Classes/ChatSender+CoreDataProperties.swift
+++ b/Sources/Coredata/Model Classes/ChatSender+CoreDataProperties.swift
@@ -1,6 +1,6 @@
 //
 //  ChatSender+CoreDataProperties.swift
-//  ConversationAI
+//  MessageKit
 //
 //  Created by Gumdal, Raj Pawan on 14/03/19.
 //  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.

--- a/Sources/Coredata/Model Classes/ChatSender+CoreDataProperties.swift
+++ b/Sources/Coredata/Model Classes/ChatSender+CoreDataProperties.swift
@@ -1,0 +1,23 @@
+//
+//  ChatSender+CoreDataProperties.swift
+//  ConversationAI
+//
+//  Created by Gumdal, Raj Pawan on 14/03/19.
+//  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension ChatSender {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ChatSender> {
+        return NSFetchRequest<ChatSender>(entityName: "ChatSender")
+    }
+
+    @NSManaged public var senderID: String?
+    @NSManaged public var displayName: String?
+
+}

--- a/Sources/Coredata/Model Classes/ChatSender+SenderStructureWrapper.swift
+++ b/Sources/Coredata/Model Classes/ChatSender+SenderStructureWrapper.swift
@@ -1,6 +1,6 @@
 //
 //  ChatSender+SenderStructureWrapper.swift
-//  ConversationAI
+//  MessageKit
 //
 //  Created by Gumdal, Raj Pawan on 14/03/19.
 //  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.
@@ -11,7 +11,7 @@ import MessageKit
 
 extension ChatSender {
     // From: https://stackoverflow.com/a/37877297/260665
-    var sender: Sender {
+    public var sender: Sender {
         get {
             return Sender(id: self.senderID!, displayName: self.displayName!)
         }

--- a/Sources/Coredata/Model Classes/ChatSender+SenderStructureWrapper.swift
+++ b/Sources/Coredata/Model Classes/ChatSender+SenderStructureWrapper.swift
@@ -1,0 +1,23 @@
+//
+//  ChatSender+SenderStructureWrapper.swift
+//  ConversationAI
+//
+//  Created by Gumdal, Raj Pawan on 14/03/19.
+//  Copyright © 2019 Gumdal, Raj Pawan. All rights reserved.
+//
+
+import Foundation
+import MessageKit
+
+extension ChatSender {
+    // From: https://stackoverflow.com/a/37877297/260665
+    var sender: Sender {
+        get {
+            return Sender(id: self.senderID!, displayName: self.displayName!)
+        }
+        set {
+            self.senderID = newValue.id
+            self.displayName = newValue.displayName
+        }
+    }
+}

--- a/Sources/Coredata/NSPersistentContainer+Bundle.swift
+++ b/Sources/Coredata/NSPersistentContainer+Bundle.swift
@@ -1,0 +1,24 @@
+//
+//  NSPersistentContainer+Bundle.swift
+//  MessageKit
+//
+//  Created by Gumdal, Raj Pawan on 20/03/19.
+//
+
+import Foundation
+import CoreData
+
+// https://gist.github.com/brennanMKE/45c2e809960b1715b29d83e560be8029
+extension NSPersistentContainer {
+    
+    public convenience init(name: String, bundle: Bundle) {
+        guard let modelURL = bundle.url(forResource: name, withExtension: "momd"),
+            let mom = NSManagedObjectModel(contentsOf: modelURL)
+            else {
+                fatalError("Unable to located Core Data model")
+        }
+        
+        self.init(name: name, managedObjectModel: mom)
+    }
+    
+}


### PR DESCRIPTION
👻- I have read the Contributing guidelines :)

What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request provides coredata wrapper classes for the model classes of MessageKit with which the objects can be persisted and loaded back.

Does this close any currently open issues?
------------------------------------------
No - none that I know of, I have searched if there is a feature request for coredata but did not find it.


Any relevant logs, error output, etc?
-------------------------------------
No relevant logs.

Any other comments?
-------------------
Had to upgrade the deployment SDK from 9.0 to 10.0 to support newer APIs in Coredata. I hope this should be fine?

I have tested it thoroughly as I need this for a demo. There is scope for further extension but I have built it for my requirement and documented enough for community to take it forward.

Where has this been tested?
---------------------------
**Devices/Simulators:** - Simulator

**iOS Version:** - iOS 12

**Swift Version:** - 4.2

**MessageKit Version:** - Latest from development branch