### PR TITLE
Revive carthage compatibility

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" ~> 1.2.0
-github "Quick/Nimble" ~> 7.0.3
+github "Quick/Quick" ~> 2.0.0
+github "Quick/Nimble" ~> 8.0.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "MessageKit/MessageInputBar" "0.4.0"
-github "Quick/Nimble" "v7.3.1"
-github "Quick/Quick" "v1.3.2"
+github "Quick/Nimble" "v8.0.1"
+github "Quick/Quick" "v2.0.0"

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -25,7 +25,7 @@
 import Foundation
 import MessageInputBar
 
-extension MessagesViewController {
+extension MessagesViewController { // swiftlint:disable:this explicit_acl explicit_top_level_acl
 
     // MARK: - Register / Unregister Observers
 

--- a/Sources/Controllers/MessagesViewController+Menu.swift
+++ b/Sources/Controllers/MessagesViewController+Menu.swift
@@ -25,7 +25,7 @@
 import Foundation
 import MessageInputBar
 
-extension MessagesViewController {
+extension MessagesViewController { // swiftlint:disable:this explicit_acl explicit_top_level_acl
 
     // MARK: - Register / Unregister Observers
 

--- a/Sources/Extensions/Bundle+Extensions.swift
+++ b/Sources/Extensions/Bundle+Extensions.swift
@@ -24,9 +24,9 @@
 
 import Foundation
 
-extension Bundle {
+internal extension Bundle {
 
-    internal static func messageKitAssetBundle() -> Bundle {
+    static func messageKitAssetBundle() -> Bundle { // swiftlint:disable:this explicit_acl
         let podBundle = Bundle(for: MessagesViewController.self)
         
         guard let resourceBundleUrl = podBundle.url(forResource: "MessageKitAssets", withExtension: "bundle") else {

--- a/Sources/Extensions/CGRect+Extensions.swift
+++ b/Sources/Extensions/CGRect+Extensions.swift
@@ -24,9 +24,9 @@
 
 import Foundation
 
-extension CGRect {
+internal extension CGRect {
     
-    internal init(_ x: CGFloat, _ y: CGFloat, _ w: CGFloat, _ h: CGFloat) {
+    init(_ x: CGFloat, _ y: CGFloat, _ w: CGFloat, _ h: CGFloat) { // swiftlint:disable:this explicit_acl
         self.init(x: x, y: y, width: w, height: h)
     }
 

--- a/Sources/Extensions/NSAttributedString+Extensions.swift
+++ b/Sources/Extensions/NSAttributedString+Extensions.swift
@@ -24,9 +24,9 @@
 
 import Foundation
 
-extension NSAttributedString {
+internal extension NSAttributedString {
 
-    internal func width(considering height: CGFloat) -> CGFloat {
+    func width(considering height: CGFloat) -> CGFloat { // swiftlint:disable:this explicit_acl
 
         let constraintBox = CGSize(width: .greatestFiniteMagnitude, height: height)
         let rect = self.boundingRect(with: constraintBox, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)

--- a/Sources/Extensions/UIColor+Extensions.swift
+++ b/Sources/Extensions/UIColor+Extensions.swift
@@ -24,16 +24,18 @@
 
 import Foundation
 
-extension UIColor {
+// swiftlint:disable explicit_acl
 
-    internal static let incomingGray = UIColor(red: 230/255, green: 230/255, blue: 235/255, alpha: 1.0)
+internal extension UIColor {
 
-    internal static let outgoingGreen = UIColor(red: 69/255, green: 214/255, blue: 93/255, alpha: 1.0)
+    static let incomingGray = UIColor(red: 230/255, green: 230/255, blue: 235/255, alpha: 1.0)
 
-    internal static let inputBarGray = UIColor(red: 247/255, green: 247/255, blue: 247/255, alpha: 1.0)
+    static let outgoingGreen = UIColor(red: 69/255, green: 214/255, blue: 93/255, alpha: 1.0)
 
-    internal static let playButtonLightGray = UIColor(red: 230/255, green: 230/255, blue: 230/255, alpha: 1.0)
+    static let inputBarGray = UIColor(red: 247/255, green: 247/255, blue: 247/255, alpha: 1.0)
 
-    internal static let sendButtonBlue = UIColor(red: 15/255, green: 135/255, blue: 255/255, alpha: 1.0)
+    static let playButtonLightGray = UIColor(red: 230/255, green: 230/255, blue: 230/255, alpha: 1.0)
+
+    static let sendButtonBlue = UIColor(red: 15/255, green: 135/255, blue: 255/255, alpha: 1.0)
 
 }

--- a/Sources/Extensions/UIEdgeInsets+Extensions.swift
+++ b/Sources/Extensions/UIEdgeInsets+Extensions.swift
@@ -24,13 +24,15 @@
 
 import Foundation
 
-extension UIEdgeInsets {
+// swiftlint:disable explicit_acl
 
-    internal var vertical: CGFloat {
+internal extension UIEdgeInsets {
+
+    var vertical: CGFloat {
         return top + bottom
     }
 
-    internal var horizontal: CGFloat {
+    var horizontal: CGFloat {
         return left + right
     }
 

--- a/Sources/Extensions/UIView+Extensions.swift
+++ b/Sources/Extensions/UIView+Extensions.swift
@@ -24,9 +24,11 @@
 
 import UIKit
 
-extension UIView {
+// swiftlint:disable explicit_acl
+
+internal extension UIView {
     
-    internal func fillSuperview() {
+    func fillSuperview() {
         guard let superview = self.superview else {
             return
         }
@@ -41,7 +43,7 @@ extension UIView {
 	    NSLayoutConstraint.activate(constraints)
     }
 
-    internal func centerInSuperview() {
+    func centerInSuperview() {
         guard let superview = self.superview else {
             return
         }
@@ -53,7 +55,7 @@ extension UIView {
         NSLayoutConstraint.activate(constraints)
     }
     
-    internal func constraint(equalTo size: CGSize) {
+    func constraint(equalTo size: CGSize) {
         guard superview != nil else { return }
         translatesAutoresizingMaskIntoConstraints = false
         let constraints: [NSLayoutConstraint] = [
@@ -65,7 +67,7 @@ extension UIView {
     }
 
     @discardableResult
-    internal func addConstraints(_ top: NSLayoutYAxisAnchor? = nil, left: NSLayoutXAxisAnchor? = nil, bottom: NSLayoutYAxisAnchor? = nil, right: NSLayoutXAxisAnchor? = nil, topConstant: CGFloat = 0, leftConstant: CGFloat = 0, bottomConstant: CGFloat = 0, rightConstant: CGFloat = 0, widthConstant: CGFloat = 0, heightConstant: CGFloat = 0) -> [NSLayoutConstraint] {
+    func addConstraints(_ top: NSLayoutYAxisAnchor? = nil, left: NSLayoutXAxisAnchor? = nil, bottom: NSLayoutYAxisAnchor? = nil, right: NSLayoutXAxisAnchor? = nil, topConstant: CGFloat = 0, leftConstant: CGFloat = 0, bottomConstant: CGFloat = 0, rightConstant: CGFloat = 0, widthConstant: CGFloat = 0, heightConstant: CGFloat = 0) -> [NSLayoutConstraint] {
         
         if self.superview == nil {
             return []

--- a/Sources/Models/AvatarPosition.swift
+++ b/Sources/Models/AvatarPosition.swift
@@ -89,7 +89,7 @@ public struct AvatarPosition {
 
 // MARK: - Equatable Conformance
 
-extension AvatarPosition: Equatable {
+extension AvatarPosition: Equatable { // swiftlint:disable:this explicit_acl explicit_top_level_acl
 
     public static func == (lhs: AvatarPosition, rhs: AvatarPosition) -> Bool {
         return lhs.vertical == rhs.vertical && lhs.horizontal == rhs.horizontal

--- a/Sources/Models/HorizontalEdgeInsets.swift
+++ b/Sources/Models/HorizontalEdgeInsets.swift
@@ -40,16 +40,16 @@ public struct HorizontalEdgeInsets {
     }
 }
 
-extension HorizontalEdgeInsets: Equatable {
+extension HorizontalEdgeInsets: Equatable { // swiftlint:disable:this explicit_acl explicit_top_level_acl
 
     public static func == (lhs: HorizontalEdgeInsets, rhs: HorizontalEdgeInsets) -> Bool {
         return lhs.left == rhs.left && lhs.right == rhs.right
     }
 }
 
-extension HorizontalEdgeInsets {
+internal extension HorizontalEdgeInsets {
 
-    internal var horizontal: CGFloat {
+    var horizontal: CGFloat { // swiftlint:disable:this explicit_acl
         return left + right
     }
 }

--- a/Sources/Models/LabelAlignment.swift
+++ b/Sources/Models/LabelAlignment.swift
@@ -38,7 +38,7 @@ public struct LabelAlignment {
 
 // MARK: - Equatable Conformance
 
-extension LabelAlignment: Equatable {
+extension LabelAlignment: Equatable { // swiftlint:disable:this explicit_acl explicit_top_level_acl
 
     public static func == (lhs: LabelAlignment, rhs: LabelAlignment) -> Bool {
         return lhs.textAlignment == rhs.textAlignment && lhs.textInsets == rhs.textInsets

--- a/Sources/Models/Sender.swift
+++ b/Sources/Models/Sender.swift
@@ -47,7 +47,7 @@ public struct Sender {
 
 // MARK: - Equatable Conformance
 
-extension Sender: Equatable {
+extension Sender: Equatable { // swiftlint:disable:this explicit_acl explicit_top_level_acl
 
     /// Two senders are considered equal if they have the same id.
     public static func == (left: Sender, right: Sender) -> Bool {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
It basically makes `master` compilable again.

In the case you never checked out MessageKit repository before, you have to run `carthage bootstrap`. This command fails because it cannot build _Nimble_ and _Quick_, so I just updated the versions of both. After that bootstrapping will succeed.

When you try to compile MessageKit using Xcode it will immediately fail because of two SwiftLint rules, 
`explicit_acl` and `explicit_top_level_acl` (SwiftLint version 0.31.0). Both are configured to _error_ in `.swiftlint.yml`. To respect the configuration, I just disabled them individually in code. There is no other way to fix them because Xcode is otherwise complaining about _redundancy_ or _protocol conformance_. And because Xcode/Swift feedback has always a higher priority than a linter, the most logical decision is to just disable the linting individually.

My recommendation however is to loosen the SwiftLint configuration for both rules because of the following reasons:

1. They are conflicting with Swift compiler warnings.
2. Configuring them to _error_ prevents compiling the project itself which can lead to Carthage incompatibility.
3. The `master` branch shows multiple occurrences of these linting errors and _no one cares_.

My second recommendation is to get rid of the two _avoidable_ dependencies **Nimble** and **Quick** to guarantee Carthage compatibility or you appoint a responsible person to take care of the dependencies.

Does this close any currently open issues?
------------------------------------------
Does not seem to be the case.

Where has this been tested?
---------------------------
**Devices/Simulators:** Xcode 10.2 Simulators

**iOS Version:** 12.2

**Swift Version:** 4.2

**MessageKit Version:** Seems to be 3.0.0-pre or something similar.


