### PR TITLE
Pass back MessageLabel reference in MessageLabelDelegate methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `MessageKit`. Also see the [releases](https://github.com/MessageKit/MessageKit/releases) on GitHub.
 
+## Upcoming Release
+
+### Added
+
+- **Breaking Change** Pass back MessageLabel reference in MessageLabelDelegate methods. [#1082](https://github.com/MessageKit/MessageKit/pull/1082) by [@marcetcheverry](https://github.com/marcetcheverry)
+
 ## 3.0.0
 
 ### Dependency Changes

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -258,35 +258,35 @@ extension ChatViewController: MessageCellDelegate {
 
 extension ChatViewController: MessageLabelDelegate {
     
-    func didSelectAddress(_ addressComponents: [String: String], in messageLabel: MessageLabel) {
+    func didSelectAddress(_ addressComponents: [String: String], in messageLabel: MessageLabel, touchLocation: CGPoint) {
         print("Address Selected: \(addressComponents)")
     }
     
-    func didSelectDate(_ date: Date, in messageLabel: MessageLabel) {
+    func didSelectDate(_ date: Date, in messageLabel: MessageLabel, touchLocation: CGPoint) {
         print("Date Selected: \(date)")
     }
     
-    func didSelectPhoneNumber(_ phoneNumber: String, in messageLabel: MessageLabel) {
+    func didSelectPhoneNumber(_ phoneNumber: String, in messageLabel: MessageLabel, touchLocation: CGPoint) {
         print("Phone Number Selected: \(phoneNumber)")
     }
     
-    func didSelectURL(_ url: URL, in messageLabel: MessageLabel) {
+    func didSelectURL(_ url: URL, in messageLabel: MessageLabel, touchLocation: CGPoint) {
         print("URL Selected: \(url)")
     }
     
-    func didSelectTransitInformation(_ transitInformation: [String: String], in messageLabel: MessageLabel) {
+    func didSelectTransitInformation(_ transitInformation: [String: String], in messageLabel: MessageLabel, touchLocation: CGPoint) {
         print("TransitInformation Selected: \(transitInformation)")
     }
 
-    func didSelectHashtag(_ hashtag: String, in messageLabel: MessageLabel) {
+    func didSelectHashtag(_ hashtag: String, in messageLabel: MessageLabel, touchLocation: CGPoint) {
         print("Hashtag selected: \(hashtag)")
     }
 
-    func didSelectMention(_ mention: String, in messageLabel: MessageLabel) {
+    func didSelectMention(_ mention: String, in messageLabel: MessageLabel, touchLocation: CGPoint) {
         print("Mention selected: \(mention)")
     }
 
-    func didSelectCustom(_ pattern: String, match: String?, in messageLabel: MessageLabel) {
+    func didSelectCustom(_ pattern: String, match: String?, in messageLabel: MessageLabel, touchLocation: CGPoint) {
         print("Custom data detector patter selected: \(pattern)")
     }
 

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -258,35 +258,35 @@ extension ChatViewController: MessageCellDelegate {
 
 extension ChatViewController: MessageLabelDelegate {
     
-    func didSelectAddress(_ addressComponents: [String: String]) {
+    func didSelectAddress(_ addressComponents: [String: String], in messageLabel: MessageLabel) {
         print("Address Selected: \(addressComponents)")
     }
     
-    func didSelectDate(_ date: Date) {
+    func didSelectDate(_ date: Date, in messageLabel: MessageLabel) {
         print("Date Selected: \(date)")
     }
     
-    func didSelectPhoneNumber(_ phoneNumber: String) {
+    func didSelectPhoneNumber(_ phoneNumber: String, in messageLabel: MessageLabel) {
         print("Phone Number Selected: \(phoneNumber)")
     }
     
-    func didSelectURL(_ url: URL) {
+    func didSelectURL(_ url: URL, in messageLabel: MessageLabel) {
         print("URL Selected: \(url)")
     }
     
-    func didSelectTransitInformation(_ transitInformation: [String: String]) {
+    func didSelectTransitInformation(_ transitInformation: [String: String], in messageLabel: MessageLabel) {
         print("TransitInformation Selected: \(transitInformation)")
     }
 
-    func didSelectHashtag(_ hashtag: String) {
+    func didSelectHashtag(_ hashtag: String, in messageLabel: MessageLabel) {
         print("Hashtag selected: \(hashtag)")
     }
 
-    func didSelectMention(_ mention: String) {
+    func didSelectMention(_ mention: String, in messageLabel: MessageLabel) {
         print("Mention selected: \(mention)")
     }
 
-    func didSelectCustom(_ pattern: String, match: String?) {
+    func didSelectCustom(_ pattern: String, match: String?, in messageLabel: MessageLabel) {
         print("Custom data detector patter selected: \(pattern)")
     }
 

--- a/Sources/Protocols/MessageLabelDelegate.swift
+++ b/Sources/Protocols/MessageLabelDelegate.swift
@@ -35,6 +35,9 @@ public protocol MessageLabelDelegate: AnyObject {
     ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectAddress(_ addressComponents: [String: String], in messageLabel: MessageLabel, touchLocation: CGPoint)
 
+    @available(*, unavailable, renamed: "didSelectAddress(_:in:touchLocation:)")
+    func didSelectAddress(_ addressComponents: String)
+
     /// Triggered when a tap occurs on a detected date.
     ///
     /// - Parameters:
@@ -42,6 +45,9 @@ public protocol MessageLabelDelegate: AnyObject {
     ///   - messageLabel: The `MessageLabel` in which the tap happened.
     ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectDate(_ date: Date, in messageLabel: MessageLabel, touchLocation: CGPoint)
+
+    @available(*, unavailable, renamed: "didSelectDate(_:in:touchLocation:)")
+    func didSelectDate(_ date: String)
 
     /// Triggered when a tap occurs on a detected phone number.
     ///
@@ -51,6 +57,9 @@ public protocol MessageLabelDelegate: AnyObject {
     ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectPhoneNumber(_ phoneNumber: String, in messageLabel: MessageLabel, touchLocation: CGPoint)
 
+    @available(*, unavailable, renamed: "didSelectPhoneNumber(_:in:touchLocation:)")
+    func didSelectPhoneNumber(_ phoneNumber: String)
+
     /// Triggered when a tap occurs on a detected URL.
     ///
     /// - Parameters:
@@ -58,6 +67,9 @@ public protocol MessageLabelDelegate: AnyObject {
     ///   - messageLabel: The `MessageLabel` in which the tap happened.
     ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectURL(_ url: URL, in messageLabel: MessageLabel, touchLocation: CGPoint)
+
+    @available(*, unavailable, renamed: "didSelectURL(_:in:touchLocation:)")
+    func didSelectURL(_ url: String)
 
     /// Triggered when a tap occurs on detected transit information.
     ///
@@ -67,6 +79,9 @@ public protocol MessageLabelDelegate: AnyObject {
     ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectTransitInformation(_ transitInformation: [String: String], in messageLabel: MessageLabel, touchLocation: CGPoint)
 
+    @available(*, unavailable, renamed: "didSelectTransitInformation(_:in:touchLocation:)")
+    func didSelectTransitInformation(_ transitInformation: String)
+
     /// Triggered when a tap occurs on a mention
     ///
     /// - Parameters:
@@ -75,6 +90,9 @@ public protocol MessageLabelDelegate: AnyObject {
     ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectMention(_ mention: String, in messageLabel: MessageLabel, touchLocation: CGPoint)
 
+    @available(*, unavailable, renamed: "didSelectMention(_:in:touchLocation:)")
+    func didSelectMention(_ mention: String)
+
     /// Triggered when a tap occurs on a hashtag
     ///
     /// - Parameters:
@@ -82,6 +100,9 @@ public protocol MessageLabelDelegate: AnyObject {
     ///   - messageLabel: The `MessageLabel` in which the tap happened.
     ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectHashtag(_ hashtag: String, in messageLabel: MessageLabel, touchLocation: CGPoint)
+
+    @available(*, unavailable, renamed: "didSelectHashtag(_:in:touchLocation:)")
+    func didSelectHashtag(_ hashtag: String)
 
     /// Triggered when a tap occurs on a custom regular expression
     ///
@@ -92,6 +113,8 @@ public protocol MessageLabelDelegate: AnyObject {
     ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectCustom(_ pattern: String, match: String?, in messageLabel: MessageLabel, touchLocation: CGPoint)
 
+    @available(*, unavailable, renamed: "didSelectCustom(_:match:in:touchLocation:)")
+    func didSelectCustom(_ pattern: String)
 }
 
 public extension MessageLabelDelegate {

--- a/Sources/Protocols/MessageLabelDelegate.swift
+++ b/Sources/Protocols/MessageLabelDelegate.swift
@@ -31,49 +31,65 @@ public protocol MessageLabelDelegate: AnyObject {
     ///
     /// - Parameters:
     ///   - addressComponents: The components of the selected address.
+    ///   - messageLabel: The `MessageLabel` in which the tap happened.
+    ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectAddress(_ addressComponents: [String: String], in messageLabel: MessageLabel, touchLocation: CGPoint)
 
     /// Triggered when a tap occurs on a detected date.
     ///
     /// - Parameters:
     ///   - date: The selected date.
+    ///   - messageLabel: The `MessageLabel` in which the tap happened.
+    ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectDate(_ date: Date, in messageLabel: MessageLabel, touchLocation: CGPoint)
 
     /// Triggered when a tap occurs on a detected phone number.
     ///
     /// - Parameters:
     ///   - phoneNumber: The selected phone number.
+    ///   - messageLabel: The `MessageLabel` in which the tap happened.
+    ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectPhoneNumber(_ phoneNumber: String, in messageLabel: MessageLabel, touchLocation: CGPoint)
 
     /// Triggered when a tap occurs on a detected URL.
     ///
     /// - Parameters:
     ///   - url: The selected URL.
+    ///   - messageLabel: The `MessageLabel` in which the tap happened.
+    ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectURL(_ url: URL, in messageLabel: MessageLabel, touchLocation: CGPoint)
 
     /// Triggered when a tap occurs on detected transit information.
     ///
     /// - Parameters:
     ///   - transitInformation: The selected transit information.
+    ///   - messageLabel: The `MessageLabel` in which the tap happened.
+    ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectTransitInformation(_ transitInformation: [String: String], in messageLabel: MessageLabel, touchLocation: CGPoint)
 
     /// Triggered when a tap occurs on a mention
     ///
     /// - Parameters:
-    ///   - mention: The selected mention
+    ///   - mention: The selected mention.
+    ///   - messageLabel: The `MessageLabel` in which the tap happened.
+    ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectMention(_ mention: String, in messageLabel: MessageLabel, touchLocation: CGPoint)
 
     /// Triggered when a tap occurs on a hashtag
     ///
     /// - Parameters:
-    ///   - mention: The selected hashtag
+    ///   - mention: The selected hashtag.
+    ///   - messageLabel: The `MessageLabel` in which the tap happened.
+    ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectHashtag(_ hashtag: String, in messageLabel: MessageLabel, touchLocation: CGPoint)
 
     /// Triggered when a tap occurs on a custom regular expression
     ///
     /// - Parameters:
-    ///   - pattern: the pattern of the regular expression
-    ///   - match: part that match with the regular expression
+    ///   - pattern: the pattern of the regular expression.
+    ///   - match: part that match with the regular expression.
+    ///   - messageLabel: The `MessageLabel` in which the tap happened.
+    ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
     func didSelectCustom(_ pattern: String, match: String?, in messageLabel: MessageLabel, touchLocation: CGPoint)
 
 }

--- a/Sources/Protocols/MessageLabelDelegate.swift
+++ b/Sources/Protocols/MessageLabelDelegate.swift
@@ -31,69 +31,69 @@ public protocol MessageLabelDelegate: AnyObject {
     ///
     /// - Parameters:
     ///   - addressComponents: The components of the selected address.
-    func didSelectAddress(_ addressComponents: [String: String])
+    func didSelectAddress(_ addressComponents: [String: String], in messageLabel: MessageLabel)
 
     /// Triggered when a tap occurs on a detected date.
     ///
     /// - Parameters:
     ///   - date: The selected date.
-    func didSelectDate(_ date: Date)
+    func didSelectDate(_ date: Date, in messageLabel: MessageLabel)
 
     /// Triggered when a tap occurs on a detected phone number.
     ///
     /// - Parameters:
     ///   - phoneNumber: The selected phone number.
-    func didSelectPhoneNumber(_ phoneNumber: String)
+    func didSelectPhoneNumber(_ phoneNumber: String, in messageLabel: MessageLabel)
 
     /// Triggered when a tap occurs on a detected URL.
     ///
     /// - Parameters:
     ///   - url: The selected URL.
-    func didSelectURL(_ url: URL)
+    func didSelectURL(_ url: URL, in messageLabel: MessageLabel)
 
     /// Triggered when a tap occurs on detected transit information.
     ///
     /// - Parameters:
     ///   - transitInformation: The selected transit information.
-    func didSelectTransitInformation(_ transitInformation: [String: String])
+    func didSelectTransitInformation(_ transitInformation: [String: String], in messageLabel: MessageLabel)
     
     /// Triggered when a tap occurs on a mention
     ///
     /// - Parameters:
     ///   - mention: The selected mention
-    func didSelectMention(_ mention: String)
+    func didSelectMention(_ mention: String, in messageLabel: MessageLabel)
     
     /// Triggered when a tap occurs on a hashtag
     ///
     /// - Parameters:
     ///   - mention: The selected hashtag
-    func didSelectHashtag(_ hashtag: String)
+    func didSelectHashtag(_ hashtag: String, in messageLabel: MessageLabel)
 
     /// Triggered when a tap occurs on a custom regular expression
     ///
     /// - Parameters:
     ///   - pattern: the pattern of the regular expression
     ///   - match: part that match with the regular expression
-    func didSelectCustom(_ pattern: String, match: String?)
+    func didSelectCustom(_ pattern: String, match: String?, in messageLabel: MessageLabel)
 
 }
 
 public extension MessageLabelDelegate {
 
-    func didSelectAddress(_ addressComponents: [String: String]) {}
+    func didSelectAddress(_ addressComponents: [String: String], in messageLabel: MessageLabel) {}
 
-    func didSelectDate(_ date: Date) {}
+    func didSelectDate(_ date: Date, in messageLabel: MessageLabel) {}
 
-    func didSelectPhoneNumber(_ phoneNumber: String) {}
+    func didSelectPhoneNumber(_ phoneNumber: String, in messageLabel: MessageLabel) {}
 
-    func didSelectURL(_ url: URL) {}
+    func didSelectURL(_ url: URL, in messageLabel: MessageLabel) {}
     
-    func didSelectTransitInformation(_ transitInformation: [String: String]) {}
+    func didSelectTransitInformation(_ transitInformation: [String: String], in messageLabel: MessageLabel) {}
 
-    func didSelectMention(_ mention: String) {}
+    func didSelectMention(_ mention: String, in messageLabel: MessageLabel) {}
 
-    func didSelectHashtag(_ hashtag: String) {}
+    func didSelectHashtag(_ hashtag: String, in messageLabel: MessageLabel) {}
 
-    func didSelectCustom(_ pattern: String, match: String?) {}
+    func didSelectCustom(_ pattern: String, match: String?, in messageLabel: MessageLabel) {}
 
 }

--- a/Sources/Protocols/MessageLabelDelegate.swift
+++ b/Sources/Protocols/MessageLabelDelegate.swift
@@ -31,69 +31,69 @@ public protocol MessageLabelDelegate: AnyObject {
     ///
     /// - Parameters:
     ///   - addressComponents: The components of the selected address.
-    func didSelectAddress(_ addressComponents: [String: String], in messageLabel: MessageLabel)
+    func didSelectAddress(_ addressComponents: [String: String], in messageLabel: MessageLabel, touchLocation: CGPoint)
 
     /// Triggered when a tap occurs on a detected date.
     ///
     /// - Parameters:
     ///   - date: The selected date.
-    func didSelectDate(_ date: Date, in messageLabel: MessageLabel)
+    func didSelectDate(_ date: Date, in messageLabel: MessageLabel, touchLocation: CGPoint)
 
     /// Triggered when a tap occurs on a detected phone number.
     ///
     /// - Parameters:
     ///   - phoneNumber: The selected phone number.
-    func didSelectPhoneNumber(_ phoneNumber: String, in messageLabel: MessageLabel)
+    func didSelectPhoneNumber(_ phoneNumber: String, in messageLabel: MessageLabel, touchLocation: CGPoint)
 
     /// Triggered when a tap occurs on a detected URL.
     ///
     /// - Parameters:
     ///   - url: The selected URL.
-    func didSelectURL(_ url: URL, in messageLabel: MessageLabel)
+    func didSelectURL(_ url: URL, in messageLabel: MessageLabel, touchLocation: CGPoint)
 
     /// Triggered when a tap occurs on detected transit information.
     ///
     /// - Parameters:
     ///   - transitInformation: The selected transit information.
-    func didSelectTransitInformation(_ transitInformation: [String: String], in messageLabel: MessageLabel)
-    
+    func didSelectTransitInformation(_ transitInformation: [String: String], in messageLabel: MessageLabel, touchLocation: CGPoint)
+
     /// Triggered when a tap occurs on a mention
     ///
     /// - Parameters:
     ///   - mention: The selected mention
-    func didSelectMention(_ mention: String, in messageLabel: MessageLabel)
-    
+    func didSelectMention(_ mention: String, in messageLabel: MessageLabel, touchLocation: CGPoint)
+
     /// Triggered when a tap occurs on a hashtag
     ///
     /// - Parameters:
     ///   - mention: The selected hashtag
-    func didSelectHashtag(_ hashtag: String, in messageLabel: MessageLabel)
+    func didSelectHashtag(_ hashtag: String, in messageLabel: MessageLabel, touchLocation: CGPoint)
 
     /// Triggered when a tap occurs on a custom regular expression
     ///
     /// - Parameters:
     ///   - pattern: the pattern of the regular expression
     ///   - match: part that match with the regular expression
-    func didSelectCustom(_ pattern: String, match: String?, in messageLabel: MessageLabel)
+    func didSelectCustom(_ pattern: String, match: String?, in messageLabel: MessageLabel, touchLocation: CGPoint)
 
 }
 
 public extension MessageLabelDelegate {
 
-    func didSelectAddress(_ addressComponents: [String: String], in messageLabel: MessageLabel) {}
+    func didSelectAddress(_ addressComponents: [String: String], in messageLabel: MessageLabel, touchLocation: CGPoint) {}
 
-    func didSelectDate(_ date: Date, in messageLabel: MessageLabel) {}
+    func didSelectDate(_ date: Date, in messageLabel: MessageLabel, touchLocation: CGPoint) {}
 
-    func didSelectPhoneNumber(_ phoneNumber: String, in messageLabel: MessageLabel) {}
+    func didSelectPhoneNumber(_ phoneNumber: String, in messageLabel: MessageLabel, touchLocation: CGPoint) {}
 
-    func didSelectURL(_ url: URL, in messageLabel: MessageLabel) {}
-    
-    func didSelectTransitInformation(_ transitInformation: [String: String], in messageLabel: MessageLabel) {}
+    func didSelectURL(_ url: URL, in messageLabel: MessageLabel, touchLocation: CGPoint) {}
 
-    func didSelectMention(_ mention: String, in messageLabel: MessageLabel) {}
+    func didSelectTransitInformation(_ transitInformation: [String: String], in messageLabel: MessageLabel, touchLocation: CGPoint) {}
 
-    func didSelectHashtag(_ hashtag: String, in messageLabel: MessageLabel) {}
+    func didSelectMention(_ mention: String, in messageLabel: MessageLabel, touchLocation: CGPoint) {}
 
-    func didSelectCustom(_ pattern: String, match: String?, in messageLabel: MessageLabel) {}
+    func didSelectHashtag(_ hashtag: String, in messageLabel: MessageLabel, touchLocation: CGPoint) {}
+
+    func didSelectCustom(_ pattern: String, match: String?, in messageLabel: MessageLabel, touchLocation: CGPoint) {}
 
 }

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -503,35 +503,35 @@ open class MessageLabel: UILabel {
     // swiftlint:enable cyclomatic_complexity
     
     private func handleAddress(_ addressComponents: [String: String]) {
-        delegate?.didSelectAddress(addressComponents)
+        delegate?.didSelectAddress(addressComponents, in: self)
     }
     
     private func handleDate(_ date: Date) {
-        delegate?.didSelectDate(date)
+        delegate?.didSelectDate(date, in: self)
     }
     
     private func handleURL(_ url: URL) {
-        delegate?.didSelectURL(url)
+        delegate?.didSelectURL(url, in: self)
     }
     
     private func handlePhoneNumber(_ phoneNumber: String) {
-        delegate?.didSelectPhoneNumber(phoneNumber)
+        delegate?.didSelectPhoneNumber(phoneNumber, in: self)
     }
     
     private func handleTransitInformation(_ components: [String: String]) {
-        delegate?.didSelectTransitInformation(components)
+        delegate?.didSelectTransitInformation(components, in: self)
     }
 
     private func handleHashtag(_ hashtag: String) {
-        delegate?.didSelectHashtag(hashtag)
+        delegate?.didSelectHashtag(hashtag, in: self)
     }
 
     private func handleMention(_ mention: String) {
-        delegate?.didSelectMention(mention)
+        delegate?.didSelectMention(mention, in: self)
     }
 
     private func handleCustom(_ pattern: String, match: String) {
-        delegate?.didSelectCustom(pattern, match: match)
+        delegate?.didSelectCustom(pattern, match: match, in: self)
     }
 
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
—————————————————————————

It adds a reference to the `MessageLabel` in all `MessageLabelDelegate` methods. This is useful if you want to present a popover based on a data detector tap, you need a reference to a UIView's `frame`.

I think there can be improvements elsewhere for this style of passing back a reference, but for now I just need this.

Any other comments?
-------------------
Not sure which branch to submit too, but I am using Swift 5.

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone XS

**iOS Version:** 12.2

**Swift Version:** Swift 5

**MessageKit Version:** 3.0.0-swif5

 👻