### PR TITLE
Add loading indicator to AudioMessageCell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `MessageKit`. Also see the [releases](https://github.com/MessageKit/MessageKit/releases) on GitHub.
 
+## Upcoming Release
+
+### Added
+
+- Add loading indicator to AudioMessageCell. [#1084](hub.com/MessageKit/MessageKit/pull/1084) by [@marcetcheverry](https://github.com/marcetcheverry))
+
 ## 3.0.0
 
 ### Dependency Changes

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - InputBarAccessoryView (4.3.0)
-  - MessageKit (3.0.0-beta-swift5):
+  - MessageKit (3.1.0):
     - InputBarAccessoryView (~> 4.3.0)
 
 DEPENDENCIES:
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   InputBarAccessoryView: 28dca73f28df7822fe5377f83cfc4547e22f90ff
-  MessageKit: 96420f1fe84d037451cc7b11800a559189f40c25
+  MessageKit: 72add24fcba6c6ca1e09385285f6f66757340769
 
 PODFILE CHECKSUM: cecdb7bc8129cf99f66de9f68eea3256fec30c3d
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.7.0

--- a/Sources/Views/Cells/AudioMessageCell.swift
+++ b/Sources/Views/Cells/AudioMessageCell.swift
@@ -83,7 +83,6 @@ open class AudioMessageCell: MessageContentCell {
     open func setupConstraints() {
         playButton.constraint(equalTo: CGSize(width: 25, height: 25))
         playButton.addConstraints(left: messageContainerView.leftAnchor, centerY: messageContainerView.centerYAnchor, leftConstant: 10)
-        activityIndicatorView.constraint(equalTo: CGSize(width: 25, height: 25))
         activityIndicatorView.addConstraints(centerY: playButton.centerYAnchor, centerX: playButton.centerXAnchor)
         durationLabel.addConstraints(right: messageContainerView.rightAnchor, centerY: messageContainerView.centerYAnchor, rightConstant: 15)
         progressView.addConstraints(left: playButton.rightAnchor, right: durationLabel.leftAnchor, centerY: messageContainerView.centerYAnchor, leftConstant: 5, rightConstant: 5)

--- a/Sources/Views/Cells/AudioMessageCell.swift
+++ b/Sources/Views/Cells/AudioMessageCell.swift
@@ -47,7 +47,7 @@ open class AudioMessageCell: MessageContentCell {
         return durationLabel
     }()
 
-    private lazy var activityIndicatorView: UIActivityIndicatorView = {
+    public lazy var activityIndicatorView: UIActivityIndicatorView = {
         let activityIndicatorView = UIActivityIndicatorView(style: .gray)
         activityIndicatorView.hidesWhenStopped = true
         activityIndicatorView.isHidden = true
@@ -59,30 +59,13 @@ open class AudioMessageCell: MessageContentCell {
         progressView.progress = 0.0
         return progressView
     }()
-
-    public var isLoadingIndicatorVisible: Bool {
-        get {
-            return activityIndicatorView.isHidden
-        }
-        set {
-            if newValue {
-                activityIndicatorView.isHidden = false
-                playButton.isHidden = true
-                activityIndicatorView.startAnimating()
-            }
-            else {
-                playButton.isHidden = false
-                activityIndicatorView.stopAnimating()
-            }
-        }
-    }
     
     // MARK: - Methods
 
     /// Responsible for setting up the constraints of the cell's subviews.
     open func setupConstraints() {
         playButton.constraint(equalTo: CGSize(width: 25, height: 25))
-        playButton.addConstraints(left: messageContainerView.leftAnchor, centerY: messageContainerView.centerYAnchor, leftConstant: 10)
+        playButton.addConstraints(left: messageContainerView.leftAnchor, centerY: messageContainerView.centerYAnchor, leftConstant: 5)
         activityIndicatorView.addConstraints(centerY: playButton.centerYAnchor, centerX: playButton.centerXAnchor)
         durationLabel.addConstraints(right: messageContainerView.rightAnchor, centerY: messageContainerView.centerYAnchor, rightConstant: 15)
         progressView.addConstraints(left: playButton.rightAnchor, right: durationLabel.leftAnchor, centerY: messageContainerView.centerYAnchor, leftConstant: 5, rightConstant: 5)

--- a/Sources/Views/Cells/AudioMessageCell.swift
+++ b/Sources/Views/Cells/AudioMessageCell.swift
@@ -47,18 +47,44 @@ open class AudioMessageCell: MessageContentCell {
         return durationLabel
     }()
 
+    private lazy var activityIndicatorView: UIActivityIndicatorView = {
+        let activityIndicatorView = UIActivityIndicatorView(style: .gray)
+        activityIndicatorView.hidesWhenStopped = true
+        activityIndicatorView.isHidden = true
+        return activityIndicatorView
+    }()
+
     public lazy var progressView: UIProgressView = {
         let progressView = UIProgressView(progressViewStyle: .default)
         progressView.progress = 0.0
         return progressView
     }()
 
+    public var isLoadingIndicatorVisible: Bool {
+        get {
+            return activityIndicatorView.isHidden
+        }
+        set {
+            if newValue {
+                activityIndicatorView.isHidden = false
+                playButton.isHidden = true
+                activityIndicatorView.startAnimating()
+            }
+            else {
+                playButton.isHidden = false
+                activityIndicatorView.stopAnimating()
+            }
+        }
+    }
+    
     // MARK: - Methods
 
     /// Responsible for setting up the constraints of the cell's subviews.
     open func setupConstraints() {
         playButton.constraint(equalTo: CGSize(width: 25, height: 25))
-        playButton.addConstraints(left: messageContainerView.leftAnchor, centerY: messageContainerView.centerYAnchor, leftConstant: 5)
+        playButton.addConstraints(left: messageContainerView.leftAnchor, centerY: messageContainerView.centerYAnchor, leftConstant: 10)
+        activityIndicatorView.constraint(equalTo: CGSize(width: 25, height: 25))
+        activityIndicatorView.addConstraints(centerY: playButton.centerYAnchor, centerX: playButton.centerXAnchor)
         durationLabel.addConstraints(right: messageContainerView.rightAnchor, centerY: messageContainerView.centerYAnchor, rightConstant: 15)
         progressView.addConstraints(left: playButton.rightAnchor, right: durationLabel.leftAnchor, centerY: messageContainerView.centerYAnchor, leftConstant: 5, rightConstant: 5)
     }
@@ -66,6 +92,7 @@ open class AudioMessageCell: MessageContentCell {
     open override func setupSubviews() {
         super.setupSubviews()
         messageContainerView.addSubview(playButton)
+        messageContainerView.addSubview(activityIndicatorView)
         messageContainerView.addSubview(durationLabel)
         messageContainerView.addSubview(progressView)
         setupConstraints()
@@ -75,6 +102,8 @@ open class AudioMessageCell: MessageContentCell {
         super.prepareForReuse()
         progressView.progress = 0
         playButton.isSelected = false
+        activityIndicatorView.stopAnimating()
+        playButton.isHidden = false
         durationLabel.text = "0:00"
     }
 


### PR DESCRIPTION
This adds a loading indicator to the audio cell that hides the play/pause button when made visible. This is what WhatsApp does for audio messages. **It is unlikely that in a real world app you would have local files ready to go for `AVAudioPlayer` as per the example implementation audio controller, these need to be loaded from the server as they are tapped.**

Of course you can override and return a custom cell for audio messages, but I think `AudioMessageCell` is decent enough, and the example audio controller can be updated to add a single `NSURLSessionDownloadTask`.

Sadly `AVAudioPlayer` is local only, and `AVPlayer` is quite a departure (see the ridiculous use of KVO and all the logic needed to handle buffering, been there, done that), so this PR can include in the future an updated BasicAudioController to handle remote audio files.

The only drawback to this PR is that if you do truly have local audio files only, `AudioMessageCell` creates an activity indicator for nothing, but that is a drawback of how cells are architected in `MessageKit`: `setupSubviews` is called without any context as to what type of message you are setting up for, and whether the audio URL is a `file:///` url or a remote asset.

Where has this been tested?

Devices/Simulators: iPhone XS

iOS Version: 12.2

Swift Version: Swift 5

MessageKit Version: 3.0.0-swif5

👻