### PR TITLE
Support for tapping NSTextAttachments in MessageLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## 3.0.0
 
+## Upcoming Release
+
+### Added
+- Support for tapping NSTextAttachments in MessageLabel. [#1090](https://github.com/MessageKit/MessageKit/pull/1090) by [@marcetcheverry](https://github.com/marcetcheverry)
+
 ### Dependency Changes
 
 - **Breaking Change** The dependency `MessageInputBar` was replaced with `InputBarAccessoryView`. As `MessageInputBar` was previously a fork this means no functionality has been lost but improvements and bug fixes will be present. `InputBarAccessoryView` has more of a following outside of `MessageKit` making its development faster than `MessageInputBar`. Maintaining two versions only increased the workload. You can find the changelog for `InputBarAccessoryView` [here](https://github.com/nathantannar4/InputBarAccessoryView/blob/master/CHANGELOG.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 The changelog for `MessageKit`. Also see the [releases](https://github.com/MessageKit/MessageKit/releases) on GitHub.
 
-## 3.0.0
-
 ## Upcoming Release
 
 ### Added
 - Support for tapping NSTextAttachments in MessageLabel. [#1090](https://github.com/MessageKit/MessageKit/pull/1090) by [@marcetcheverry](https://github.com/marcetcheverry)
+
+## 3.0.0
 
 ### Dependency Changes
 

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -290,6 +290,9 @@ extension ChatViewController: MessageLabelDelegate {
         print("Custom data detector patter selected: \(pattern)")
     }
 
+    func didSelectTextAttachment(_ textAttachment: NSTextAttachment, characterIndex: Int, in messageLabel: MessageLabel, touchLocation: CGPoint) {
+        print("Text attachment selected: \(textAttachment)")
+    }
 }
 
 // MARK: - MessageInputBarDelegate

--- a/Sources/Protocols/MessageLabelDelegate.swift
+++ b/Sources/Protocols/MessageLabelDelegate.swift
@@ -76,6 +76,14 @@ public protocol MessageLabelDelegate: AnyObject {
     ///   - match: part that match with the regular expression
     func didSelectCustom(_ pattern: String, match: String?)
 
+    /// Triggered when a tap occurs on a NSTextAttachment
+    ///
+    /// - Parameters:
+    ///   - textAttachment: the `NSTextAttachment` tapped.
+    ///   - characterIndex: the index of the character in the `MessageLabel`'s string
+    ///   - messageLabel: The `MessageLabel` in which the tap happened.
+    ///   - touchLocation: The location in the `MessageLabel` in which the tap happened.
+    func didSelectTextAttachment(_ textAttachment: NSTextAttachment, characterIndex: Int, in messageLabel: MessageLabel, touchLocation: CGPoint)
 }
 
 public extension MessageLabelDelegate {

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -459,12 +459,10 @@ open class MessageLabel: UILabel {
             }
         }
 
-        if NSTextAttachment.character == (textStorage.string as NSString).character(at: index) {
-            let attributes = textStorage.attributes(at: index, effectiveRange: nil)
-            if let attachment = attributes[NSAttributedString.Key.attachment] as? NSTextAttachment {
-                delegate?.didSelectTextAttachment(attachment, characterIndex: index, in: self, touchLocation: touchLocation)
-                return true
-            }
+        let attributes = textStorage.attributes(at: index, effectiveRange: nil)
+        if let attachment = attributes[NSAttributedString.Key.attachment] as? NSTextAttachment {
+            delegate?.didSelectTextAttachment(attachment, characterIndex: index, in: self, touchLocation: touchLocation)
+            return true
         }
 
         return false

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -446,7 +446,7 @@ open class MessageLabel: UILabel {
 
     }
 
-  open func handleGesture(_ touchLocation: CGPoint) -> Bool {
+    open func handleGesture(_ touchLocation: CGPoint) -> Bool {
 
         guard let index = stringIndex(at: touchLocation) else { return false }
 
@@ -458,6 +458,15 @@ open class MessageLabel: UILabel {
                 }
             }
         }
+
+        if NSTextAttachment.character == (textStorage.string as NSString).character(at: index) {
+            let attributes = textStorage.attributes(at: index, effectiveRange: nil)
+            if let attachment = attributes[NSAttributedString.Key.attachment] as? NSTextAttachment {
+                delegate?.didSelectTextAttachment(attachment, characterIndex: index, in: self, touchLocation: touchLocation)
+                return true
+            }
+        }
+
         return false
     }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
—————————————————————————

In the case of a `MessageLabel` backed by an `NSAttributedString` this allows you to embed an `NSTextAttachment` (or a subclass) and to receive tap events from it.

A real life use case of this is adding file attachments to a text message. The screenshot below (pixelated some identifying information) shows an example of embedding an image based `NSTextAttachment` which can be tapped.

<img width="350" alt="Screen Shot 2019-06-11 at 10 07 27" src="https://user-images.githubusercontent.com/229094/59292123-3c08b300-8c31-11e9-96fe-1375f3b93846.png">

Any other comments?
-------------------
Not sure which branch to submit too, but I am using Swift 5.

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone XS

**iOS Version:** 12.2

**Swift Version:** Swift 5

**MessageKit Version:** 3.0.0-swif5

 👻