### PR TITLE
Add support for styling NSLinkAttribute with existing urlAttributes in MessageLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## 3.0.0
 
+## Upcoming Release
+
+### Added
+
+- Add support for styling NSLinkAttribute with existing urlAttributes in MessageLabel. [#1091](https://github.com/MessageKit/MessageKit/pull/1091) by [@marcetcheverry](https://github.com/marcetcheverry)
+
+## Upcoming Release
 ### Dependency Changes
 
 - **Breaking Change** The dependency `MessageInputBar` was replaced with `InputBarAccessoryView`. As `MessageInputBar` was previously a fork this means no functionality has been lost but improvements and bug fixes will be present. `InputBarAccessoryView` has more of a following outside of `MessageKit` making its development faster than `MessageInputBar`. Maintaining two versions only increased the workload. You can find the changelog for `InputBarAccessoryView` [here](https://github.com/nathantannar4/InputBarAccessoryView/blob/master/CHANGELOG.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,14 @@
 
 The changelog for `MessageKit`. Also see the [releases](https://github.com/MessageKit/MessageKit/releases) on GitHub.
 
-## 3.0.0
-
 ## Upcoming Release
 
 ### Added
 
 - Add support for styling NSLinkAttribute with existing urlAttributes in MessageLabel. [#1091](https://github.com/MessageKit/MessageKit/pull/1091) by [@marcetcheverry](https://github.com/marcetcheverry)
 
-## Upcoming Release
+## 3.0.0
+
 ### Dependency Changes
 
 - **Breaking Change** The dependency `MessageInputBar` was replaced with `InputBarAccessoryView`. As `MessageInputBar` was previously a fork this means no functionality has been lost but improvements and bug fixes will be present. `InputBarAccessoryView` has more of a following outside of `MessageKit` making its development faster than `MessageInputBar`. Maintaining two versions only increased the workload. You can find the changelog for `InputBarAccessoryView` [here](https://github.com/nathantannar4/InputBarAccessoryView/blob/master/CHANGELOG.md).

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -273,6 +273,11 @@ open class MessageLabel: UILabel {
             guard let rangeTuples = rangesForDetectors[detector] else { continue }
 
             for (range, _)  in rangeTuples {
+                // This will enable us to attribute it with our own styles, since `UILabel` does not provide link attribute overrides like `UITextView` does
+                if detector.textCheckingType == .link {
+                    mutableAttributedString.removeAttribute(NSAttributedString.Key.link, range: range)
+                }
+
                 let attributes = detectorAttributes(for: detector)
                 mutableAttributedString.addAttributes(attributes, range: range)
             }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
—————————————————————————

Since `MessageLabel` supports handling `NSLinkAttribute` as tappable links, this add support for styling the links with the same styles as a URL data detector.

`UILabel` has no option to override the default styling that it applies to `NSLinkAttribute`, this faculty is reserved for `UITextView`'s `linkTextAttributes`.

The only way to imitate this behavior is to remove the `NSLinkAttribute` before drawing and to apply our own attributes (which have already been detected by the existing code in `MessageLabel`).

With the current behavior you just get a blue style which is the default `UILabel` style.

Below is a real world example of using `NSLinkAttribute` to highlight a filename which will open an url when tapped.

<img width="350" alt="Screen Shot 2019-06-11 at 10 07 27" src="https://user-images.githubusercontent.com/229094/59292831-abcb6d80-8c32-11e9-8f60-ba3748fb2c4f.png">

**A future PR may want to implement a highlight/touch down attributed style for these links**

Any other comments?
-------------------
Not sure which branch to submit too, but I am using Swift 5.

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone XS

**iOS Version:** 12.2

**Swift Version:** Swift 5

**MessageKit Version:** 3.0.0-swif5

 👻