### PR TITLE
Lazily initialize the MessageInputBar on MessagesViewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The changelog for `MessageKit`. Also see the [releases](https://github.com/MessageKit/MessageKit/releases) on GitHub.
 
+## Upcoming Release
+
+### Added
+- Lazily initialize the MessageInputBar on MessagesViewController. [#1092](https://github.com/MessageKit/MessageKit/pull/1092) by [@marcetcheverry](https://github.com/marcetcheverry)
+
 ## 3.0.0
 
 ### Dependency Changes

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -34,7 +34,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
     open var messagesCollectionView = MessagesCollectionView()
 
     /// The `InputBarAccessoryView` used as the `inputAccessoryView` in the view controller.
-    open var messageInputBar = InputBarAccessoryView()
+    open lazy var messageInputBar = InputBarAccessoryView()
 
     /// A Boolean value that determines whether the `MessagesCollectionView` scrolls to the
     /// bottom whenever the `InputTextView` begins editing.


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
—————————————————————————
It lazily initializes the `MessageInputBar` on `MessagesViewController`. Subclasses can override to avoid any references to it, and there won't be any useless initialization in that case. Not all use cases require an input bar created by default, but most cases probably want to subclass from `MessagesViewController`.

Any other comments?
-------------------
Not sure which branch to submit too, but I am using Swift 5.

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone XS

**iOS Version:** 12.2

**Swift Version:** Swift 5

**MessageKit Version:** 3.0.0-swif5

 👻