### PR TITLE
Support overriding multiple paragraph styles in MessageLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - Lazily initialize the MessageInputBar on MessagesViewController. [#1092](https://github.com/MessageKit/MessageKit/pull/1092) by [@marcetcheverry](https://github.com/marcetcheverry)
 
+- Improve handling of attributed strings with multiple paragraph styles. [#1097](https://github.com/MessageKit/MessageKit/pull/1097) by [@marcetcheverry](https://github.com/marcetcheverry)
+
 ## 3.0.0
 
 ### Dependency Changes

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -223,12 +223,28 @@ open class MessageLabel: UILabel {
             return
         }
         
-        let style = paragraphStyle(for: newText)
         let range = NSRange(location: 0, length: newText.length)
         
         let mutableText = NSMutableAttributedString(attributedString: newText)
-        mutableText.addAttribute(.paragraphStyle, value: style, range: range)
         
+        var paragraphStyleFound = false
+        mutableText.enumerateAttribute(.paragraphStyle,
+                                       in: range,
+                                       options: []) { (style, attributeRange, _) in
+                                        if let style = style as? NSMutableParagraphStyle {
+                                            paragraphStyleFound = true
+                                            style.lineBreakMode = lineBreakMode
+                                            style.alignment = textAlignment
+                                        }
+        }
+
+        if !paragraphStyleFound {
+            let style = NSMutableParagraphStyle()
+            style.lineBreakMode = lineBreakMode
+            style.alignment = textAlignment
+            mutableText.addAttribute(.paragraphStyle, value: style, range: range)
+        }
+
         if shouldParse {
             rangesForDetectors.removeAll()
             let results = parse(text: mutableText)
@@ -251,19 +267,6 @@ open class MessageLabel: UILabel {
 
     }
     
-    private func paragraphStyle(for text: NSAttributedString) -> NSParagraphStyle {
-        guard text.length > 0 else { return NSParagraphStyle() }
-        
-        var range = NSRange(location: 0, length: text.length)
-        let existingStyle = text.attribute(.paragraphStyle, at: 0, effectiveRange: &range) as? NSMutableParagraphStyle
-        let style = existingStyle ?? NSMutableParagraphStyle()
-        
-        style.lineBreakMode = lineBreakMode
-        style.alignment = textAlignment
-        
-        return style
-    }
-
     private func updateAttributes(for detectors: [DetectorType]) {
 
         guard let attributedText = attributedText, attributedText.length > 0 else { return }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
—————————————————————————

This updates the override code for `MessageLabel`s handling of `NSParagraphStyle` to handle attributed strings which may have multiple paragraph styles. The current implementation does not detect that you may have different paragraph styles in a string, and just overrides it entirely. This basically enumerates all the paragraph styles and overrides their styles.

I am unsure if `NSParagraphStyle` (as a non mutable ever shows up in practice), but in case anyone needs that they can submit a PR to support `mutableCopy`. This continues the existing codebase tradition of assuming `NSMutableParagraphStyle`

Any other comments?
-------------------
Not sure which branch to submit too, but I am using Swift 5.

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone XS

**iOS Version:** 12.2

**Swift Version:** Swift 5

**MessageKit Version:** 3.0.0-swif5

 👻