### PR TITLE
Make messageLabelInsets(for message: MessageType) open so it can be overriden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - Lazily initialize the MessageInputBar on MessagesViewController. [#1092](https://github.com/MessageKit/MessageKit/pull/1092) by [@marcetcheverry](https://github.com/marcetcheverry)
 
+- Make messageLabelInsets(for message: MessageType) open so it can be overriden in TextMessageSizeCalculator. [#1098](https://github.com/MessageKit/MessageKit/pull/1098) by [@marcetcheverry](https://github.com/marcetcheverry)
+
 ## 3.0.0
 
 ### Dependency Changes

--- a/Sources/Layout/TextMessageSizeCalculator.swift
+++ b/Sources/Layout/TextMessageSizeCalculator.swift
@@ -31,7 +31,7 @@ open class TextMessageSizeCalculator: MessageSizeCalculator {
 
     public var messageLabelFont = UIFont.preferredFont(forTextStyle: .body)
 
-    internal func messageLabelInsets(for message: MessageType) -> UIEdgeInsets {
+    open func messageLabelInsets(for message: MessageType) -> UIEdgeInsets {
         let dataSource = messagesLayout.messagesDataSource
         let isFromCurrentSender = dataSource.isFromCurrentSender(message: message)
         return isFromCurrentSender ? outgoingMessageLabelInsets : incomingMessageLabelInsets


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
—————————————————————————

This makes `messageLabelInsets(for message: MessageType)` an open function so subclasses of `TextMessageSizeCalculator` can override it.

While it is nice that the `incomingMessageLabelInsets` and `outgoingMessageLabelInsets` variables are open, sometimes you want to override insets beyond the basics based on a property of a `MessageType`. A real world use case is if you wanted to render an email message with different insets as opposed to a text message.

A sample implementation of this would involve subclassing this calculator to override the `messageLabelInsets(for message: MessageType)` function.

Any other comments?
-------------------
Not sure which branch to submit too, but I am using Swift 5.

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone XS

**iOS Version:** 12.2

**Swift Version:** Swift 5

**MessageKit Version:** 3.0.0-swif5

 👻