### PR TITLE
Fix: Content offset wrong after dismissing modal view controller

### DIFF
--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -103,6 +103,8 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         isMessagesControllerBeingDismissed = false
+        isFirstLayout = true
+        viewDidLayoutSubviews()
     }
     
     open override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Implement the fix via https://github.com/MessageKit/MessageKit/issues/993#issuecomment-479390478
- Force `isFirstLayout` to be true whenever the view appears and call `viewDidLayoutSubviews()`

Does this close any currently open issues?
------------------------------------------
#993 

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone XR Simulator + Device

**iOS Version:** 12.2, 12.3

**Swift Version:** 5

**MessageKit Version:** 3.0.0-swift5


