### PR TITLE
Fixes scrollToBottom method to properly handle calls made early in the view lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - Lazily initialize the MessageInputBar on MessagesViewController. [#1092](https://github.com/MessageKit/MessageKit/pull/1092) by [@marcetcheverry](https://github.com/marcetcheverry)
 
+### Changed
+
+- Fixes scrollToBottom method to properly handle calls made early in the view lifecycle. [#1110](https://github.com/MessageKit/MessageKit/pull/1110) by [@marcetcheverry](https://github.com/marcetcheverry)
+
 ## 3.0.0
 
 ### Dependency Changes

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -101,9 +101,8 @@ open class MessagesCollectionView: UICollectionView {
     }
 
     public func scrollToBottom(animated: Bool = false) {
-        let collectionViewContentHeight = collectionViewLayout.collectionViewContentSize.height
-
         performBatchUpdates(nil) { _ in
+            let collectionViewContentHeight = self.collectionViewLayout.collectionViewContentSize.height
             self.scrollRectToVisible(CGRect(0.0, collectionViewContentHeight - 1.0, 1.0, 1.0), animated: animated)
         }
     }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
—————————————————————————
Wanting to implement a default "scrolled to bottom" appearance I did something like this

```
    private var hasAppearedOnce = false
    
    override func viewWillAppear(_ animated: Bool) {
        super.viewWillAppear(animated)

        if !hasAppearedOnce {
            messagesCollectionView.scrollToBottom()
            hasAppearedOnce = true
        }
    }
```

(Let me know if there is a better way to do this)

However, I found that `collectionViewContentHeight` was often `0` in `scrollToBottom`, leading to this code not working unless it was called twice.

This was the old implementation:

````   
    public func scrollToBottom(animated: Bool = false) {
        let collectionViewContentHeight = collectionViewLayout.collectionViewContentSize.height

        performBatchUpdates(nil) { _ in
            self.scrollRectToVisible(CGRect(0.0, collectionViewContentHeight - 1.0, 1.0, 1.0), animated: animated)
        }
    }
````

The documentation for `performBatchUpdates` states:

```If the collection view's layout is not up to date before you call this method, a reload may occur.```

Therefore, moving the capturing of the collection view height to inside the block fixes the issue, as performBatchUpdates will ensure all basic layout is done and we have accurate data to work off.

Whatever you think of the implementation of the automatic scroll to bottom on first appearance, the fix for this issue is still valid, as calling this method before the first `reloadData` right now does not work, and this PR fixes that.

Any other comments?
-------------------
Not sure which branch to submit too, but I am using Swift 5.

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone XS

**iOS Version:** 12.2

**Swift Version:** Swift 5

**MessageKit Version:** 3.0.0-swif5

 👻