### PR TITLE
Added missing property assignments in layoutCellTopLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ### Added
 
+- Add missing textAlignment and textInsets assignments to layoutCellTopLabel method in MessageContentCell. [#1117](https://github.com/MessageKit/MessageKit/pull/1117) by [@mdescalzo](https://github.com/mdescalzo)
+
 - Add loading indicator to AudioMessageCell. [#1084](https://github.com/MessageKit/MessageKit/pull/1084) by [@marcetcheverry](https://github.com/marcetcheverry)
 
 - Lazily initialize the MessageInputBar on MessagesViewController. [#1092](https://github.com/MessageKit/MessageKit/pull/1092) by [@marcetcheverry](https://github.com/marcetcheverry)

--- a/Sources/Views/Cells/MessageContentCell.swift
+++ b/Sources/Views/Cells/MessageContentCell.swift
@@ -267,6 +267,9 @@ open class MessageContentCell: MessageCollectionViewCell {
     /// Positions the cell's top label.
     /// - attributes: The `MessagesCollectionViewLayoutAttributes` for the cell.
     open func layoutCellTopLabel(with attributes: MessagesCollectionViewLayoutAttributes) {
+        cellTopLabel.textAlignment = attributes.cellTopLabelAlignment.textAlignment
+        cellTopLabel.textInsets = attributes.cellTopLabelAlignment.textInsets
+
         cellTopLabel.frame = CGRect(origin: .zero, size: attributes.cellTopLabelSize)
     }
     


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Missing attribute assignments in the cellTopLabel.  Added the two missing assignments.

Does this close any currently open issues?
------------------------------------------
#1116  


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …
iPad sim, iPhone Xs

**iOS Version:** …
12.2

**Swift Version:** …
4.2

**MessageKit Version:** …
3.0.0

