### PR TITLE
Fix text clipping caused by MessageSizeCalculator when textInsets are zero in MessageLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - Lazily initialize the MessageInputBar on MessagesViewController. [#1092](https://github.com/MessageKit/MessageKit/pull/1092) by [@marcetcheverry](https://github.com/marcetcheverry)
 
+### Changed
+
+- Fix text clipping caused by MessageSizeCalculator when textInsets are zero in MessageLabel. [#1136](https://github.com/MessageKit/MessageKit/pull/1136) by [@marcetcheverry](https://github.com/marcetcheverry)
+
 ## 3.0.0
 
 ### Dependency Changes

--- a/Sources/Layout/MessageSizeCalculator.swift
+++ b/Sources/Layout/MessageSizeCalculator.swift
@@ -278,7 +278,7 @@ open class MessageSizeCalculator: CellSizeCalculator {
 
     internal func labelSize(for attributedText: NSAttributedString, considering maxWidth: CGFloat) -> CGSize {
         let constraintBox = CGSize(width: maxWidth, height: .greatestFiniteMagnitude)
-        let rect = attributedText.boundingRect(with: constraintBox, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).integral
+        let rect = attributedText.boundingRect(with: constraintBox, options: [.usesLineFragmentOrigin, .usesFontLeading, .usesDeviceMetrics], context: nil).integral
 
         return rect.size
     }


### PR DESCRIPTION
I don't know which branch to target anymore, 3.0.0-swift5 or development, please clarify.

If you set `MessageLabel` insets to `.zero`, text size calculation will not work because it is often off by 1 point in large wrapped strings. Adding `usesDeviceMetrics` to use image bounds fixes this easily.

Notice in the before and after picture how "END" does not appear in the first case. I turned off bubble style to make it clearer (bubble style has no effect on this issue).

Before:
![before](https://user-images.githubusercontent.com/229094/61007949-0edc1d00-a323-11e9-971f-324264bb3367.png)

After:
![after](https://user-images.githubusercontent.com/229094/61007952-126fa400-a323-11e9-9ac0-169ec3314513.png)