### PR TITLE
Fix implementation of sizeThatFits and improve implementation of intrinsicContentSize in MessageLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - Fix implementation of sizeThatFits and improve implementation of intrinsicContentSize in MessageLabel. [#1137](https://github.com/MessageKit/MessageKit/pull/1137) by [@marcetcheverry](https://github.com/marcetcheverry)
 
-
 ## 3.0.0
 
 ### Dependency Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - Lazily initialize the MessageInputBar on MessagesViewController. [#1092](https://github.com/MessageKit/MessageKit/pull/1092) by [@marcetcheverry](https://github.com/marcetcheverry)
 
+### Changed
+
+- Fix implementation of sizeThatFits and improve implementation of intrinsicContentSize in MessageLabel. [#1137](https://github.com/MessageKit/MessageKit/pull/1137) by [@marcetcheverry](https://github.com/marcetcheverry)
+
+
 ## 3.0.0
 
 ### Dependency Changes

--- a/MessageKit.xcodeproj/project.pbxproj
+++ b/MessageKit.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		50FF34572237FE6A0004DCD7 /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FF34562237FE6A0004DCD7 /* UIImage+Extension.swift */; };
 		50FF34592237FE850004DCD7 /* ContactMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FF34582237FE840004DCD7 /* ContactMessageCell.swift */; };
 		50FF345B2237FE9C0004DCD7 /* ContactMessageSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FF345A2237FE9C0004DCD7 /* ContactMessageSizeCalculator.swift */; };
+		8859074322D699FC001AC7D3 /* CGFloat+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8859074222D699FC001AC7D3 /* CGFloat+Extensions.swift */; };
 		88916B2D1CF0DF2F00469F91 /* MessageKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88916B221CF0DF2F00469F91 /* MessageKit.framework */; };
 		8962AC8A1F87AB7D0030B058 /* MessagesCollectionViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8962AC831F87AB230030B058 /* MessagesCollectionViewTests.swift */; };
 		8962AC8C1F87AB7D0030B058 /* AvatarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8962AC851F87AB230030B058 /* AvatarViewTests.swift */; };
@@ -166,6 +167,7 @@
 		50FF34562237FE6A0004DCD7 /* UIImage+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
 		50FF34582237FE840004DCD7 /* ContactMessageCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactMessageCell.swift; sourceTree = "<group>"; };
 		50FF345A2237FE9C0004DCD7 /* ContactMessageSizeCalculator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactMessageSizeCalculator.swift; sourceTree = "<group>"; };
+		8859074222D699FC001AC7D3 /* CGFloat+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CGFloat+Extensions.swift"; sourceTree = "<group>"; };
 		88916B221CF0DF2F00469F91 /* MessageKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MessageKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		88916B2C1CF0DF2F00469F91 /* MessageKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MessageKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8962AC741F87AB230030B058 /* MessageKitDateFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageKitDateFormatterTests.swift; sourceTree = "<group>"; };
@@ -401,6 +403,7 @@
 			children = (
 				50FF34562237FE6A0004DCD7 /* UIImage+Extension.swift */,
 				0EE91E651FDEC887005420A2 /* CGRect+Extensions.swift */,
+				8859074222D699FC001AC7D3 /* CGFloat+Extensions.swift */,
 				B7A03F671F8669EB006AEF79 /* Bundle+Extensions.swift */,
 				B7A03F681F8669EB006AEF79 /* NSAttributedString+Extensions.swift */,
 				B7A03F651F8669EB006AEF79 /* UIColor+Extensions.swift */,
@@ -635,6 +638,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				382C794221705D2000F4FAF5 /* HorizontalEdgeInsets.swift in Sources */,
+				8859074322D699FC001AC7D3 /* CGFloat+Extensions.swift in Sources */,
 				B7A03F3C1F866946006AEF79 /* LocationMessageCell.swift in Sources */,
 				1FF377AA20087D78004FD648 /* MessagesViewController+Menu.swift in Sources */,
 				B7A03F5B1F8669CA006AEF79 /* MessageType.swift in Sources */,

--- a/Sources/Extensions/CGFloat+Extensions.swift
+++ b/Sources/Extensions/CGFloat+Extensions.swift
@@ -1,0 +1,43 @@
+/*
+ MIT License
+ 
+ Copyright (c) 2017-2019 MessageKit
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+import Foundation
+
+internal extension CGFloat {
+
+    // This checks against the sentinel values used for unconstrained layout in one direction
+    var isGreatestFiniteMagnitude : Bool {
+        if self == CGFloat.greatestFiniteMagnitude {
+            return true
+        }
+
+        // The frameworks (and this method in particular) sometimes wrongly use the 32-bit version even if CGFLOAT_IS_DOUBLE is 1
+        if self == CGFloat(Float.greatestFiniteMagnitude) {
+            return true
+        }
+
+        return false
+    }
+
+}

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -50,7 +50,7 @@ open class MessageLabel: UILabel {
     }()
 
     internal lazy var rangesForDetectors: [DetectorType: [(NSRange, MessageTextCheckingType)]] = [:]
-
+    
     private var isConfiguring: Bool = false
 
     // MARK: - Public Properties
@@ -135,11 +135,11 @@ open class MessageLabel: UILabel {
     open internal(set) var phoneNumberAttributes: [NSAttributedString.Key: Any] = defaultAttributes
 
     open internal(set) var urlAttributes: [NSAttributedString.Key: Any] = defaultAttributes
-
+    
     open internal(set) var transitInformationAttributes: [NSAttributedString.Key: Any] = defaultAttributes
-
+    
     open internal(set) var hashtagAttributes: [NSAttributedString.Key: Any] = defaultAttributes
-
+    
     open internal(set) var mentionAttributes: [NSAttributedString.Key: Any] = defaultAttributes
 
     open internal(set) var customAttributes: [NSRegularExpression: [NSAttributedString.Key: Any]] = [:]
@@ -198,6 +198,7 @@ open class MessageLabel: UILabel {
 
     // This enables proper calculation of intrinsicContentSize and sizeThatFits
     open override func textRect(forBounds bounds: CGRect, limitedToNumberOfLines numberOfLines: Int) -> CGRect {
+        
         // UIKit often uses MAX values for 2 dimensional constraint based layout of text, we don't want to adjust those values
         var insetBounds = bounds
         if !insetBounds.size.width.isGreatestFiniteMagnitude {
@@ -218,7 +219,7 @@ open class MessageLabel: UILabel {
     }
 
     // MARK: - Public Methods
-
+    
     public func configure(block: () -> Void) {
         isConfiguring = true
         block()
@@ -239,19 +240,19 @@ open class MessageLabel: UILabel {
             setNeedsDisplay()
             return
         }
-
+        
         let style = paragraphStyle(for: newText)
         let range = NSRange(location: 0, length: newText.length)
-
+        
         let mutableText = NSMutableAttributedString(attributedString: newText)
         mutableText.addAttribute(.paragraphStyle, value: style, range: range)
-
+        
         if shouldParse {
             rangesForDetectors.removeAll()
             let results = parse(text: mutableText)
             setRangesForDetectors(in: results)
         }
-
+        
         for (detector, rangeTuples) in rangesForDetectors {
             if enabledDetectors.contains(detector) {
                 let attributes = detectorAttributes(for: detector)
@@ -267,7 +268,7 @@ open class MessageLabel: UILabel {
         if !isConfiguring { setNeedsDisplay() }
 
     }
-
+    
     private func paragraphStyle(for text: NSAttributedString) -> NSParagraphStyle {
         guard text.length > 0 else { return NSParagraphStyle() }
         
@@ -338,7 +339,7 @@ open class MessageLabel: UILabel {
             fatalError(MessageKitError.unrecognizedCheckingResult)
         }
     }
-
+    
     private func setupView() {
         numberOfLines = 0
         lineBreakMode = .byWordWrapping
@@ -395,7 +396,7 @@ open class MessageLabel: UILabel {
     private func setRangesForDetectors(in checkingResults: [NSTextCheckingResult]) {
 
         guard checkingResults.isEmpty == false else { return }
-
+        
         for result in checkingResults {
 
             switch result.resultType {
@@ -452,18 +453,18 @@ open class MessageLabel: UILabel {
         let index = layoutManager.glyphIndex(for: location, in: textContainer)
 
         let lineRect = layoutManager.lineFragmentUsedRect(forGlyphAt: index, effectiveRange: nil)
-
+        
         var characterIndex: Int?
-
+        
         if lineRect.contains(location) {
             characterIndex = layoutManager.characterIndexForGlyph(at: index)
         }
-
+        
         return characterIndex
 
     }
 
-    open func handleGesture(_ touchLocation: CGPoint) -> Bool {
+  open func handleGesture(_ touchLocation: CGPoint) -> Bool {
 
         guard let index = stringIndex(at: touchLocation) else { return false }
 
@@ -480,7 +481,7 @@ open class MessageLabel: UILabel {
 
     // swiftlint:disable cyclomatic_complexity
     private func handleGesture(for detectorType: DetectorType, value: MessageTextCheckingType) {
-
+        
         switch value {
         case let .addressComponents(addressComponents):
             var transformedAddressComponents = [String: String]()
@@ -518,23 +519,23 @@ open class MessageLabel: UILabel {
         }
     }
     // swiftlint:enable cyclomatic_complexity
-
+    
     private func handleAddress(_ addressComponents: [String: String]) {
         delegate?.didSelectAddress(addressComponents)
     }
-
+    
     private func handleDate(_ date: Date) {
         delegate?.didSelectDate(date)
     }
-
+    
     private func handleURL(_ url: URL) {
         delegate?.didSelectURL(url)
     }
-
+    
     private func handlePhoneNumber(_ phoneNumber: String) {
         delegate?.didSelectPhoneNumber(phoneNumber)
     }
-
+    
     private func handleTransitInformation(_ components: [String: String]) {
         delegate?.didSelectTransitInformation(components)
     }

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -50,7 +50,7 @@ open class MessageLabel: UILabel {
     }()
 
     internal lazy var rangesForDetectors: [DetectorType: [(NSRange, MessageTextCheckingType)]] = [:]
-    
+
     private var isConfiguring: Bool = false
 
     // MARK: - Public Properties
@@ -109,17 +109,13 @@ open class MessageLabel: UILabel {
 
     open var textInsets: UIEdgeInsets = .zero {
         didSet {
-            if !isConfiguring { setNeedsDisplay() }
+            if !isConfiguring {
+                invalidateIntrinsicContentSize()
+                setNeedsDisplay()
+            }
         }
     }
 
-    open override var intrinsicContentSize: CGSize {
-        var size = super.intrinsicContentSize
-        size.width += textInsets.horizontal
-        size.height += textInsets.vertical
-        return size
-    }
-    
     internal var messageLabelFont: UIFont?
 
     private var attributesNeedUpdate = false
@@ -139,11 +135,11 @@ open class MessageLabel: UILabel {
     open internal(set) var phoneNumberAttributes: [NSAttributedString.Key: Any] = defaultAttributes
 
     open internal(set) var urlAttributes: [NSAttributedString.Key: Any] = defaultAttributes
-    
+
     open internal(set) var transitInformationAttributes: [NSAttributedString.Key: Any] = defaultAttributes
-    
+
     open internal(set) var hashtagAttributes: [NSAttributedString.Key: Any] = defaultAttributes
-    
+
     open internal(set) var mentionAttributes: [NSAttributedString.Key: Any] = defaultAttributes
 
     open internal(set) var customAttributes: [NSRegularExpression: [NSAttributedString.Key: Any]] = [:]
@@ -200,8 +196,29 @@ open class MessageLabel: UILabel {
         layoutManager.drawGlyphs(forGlyphRange: range, at: origin)
     }
 
+    // This enables proper calculation of intrinsicContentSize and sizeThatFits
+    open override func textRect(forBounds bounds: CGRect, limitedToNumberOfLines numberOfLines: Int) -> CGRect {
+        // UIKit often uses MAX values for 2 dimensional constraint based layout of text, we don't want to adjust those values
+        var insetBounds = bounds
+        if !insetBounds.size.width.isGreatestFiniteMagnitude {
+            insetBounds.size.width -= textInsets.horizontal
+        }
+
+        if !insetBounds.size.height.isGreatestFiniteMagnitude {
+            insetBounds.size.height -= textInsets.vertical
+        }
+
+        var actualTextRect = super.textRect(forBounds: insetBounds, limitedToNumberOfLines: numberOfLines)
+
+        // Add back the inset to what UILabel calculated
+        actualTextRect.size.width += textInsets.horizontal
+        actualTextRect.size.height += textInsets.vertical
+
+        return actualTextRect
+    }
+
     // MARK: - Public Methods
-    
+
     public func configure(block: () -> Void) {
         isConfiguring = true
         block()
@@ -222,19 +239,19 @@ open class MessageLabel: UILabel {
             setNeedsDisplay()
             return
         }
-        
+
         let style = paragraphStyle(for: newText)
         let range = NSRange(location: 0, length: newText.length)
-        
+
         let mutableText = NSMutableAttributedString(attributedString: newText)
         mutableText.addAttribute(.paragraphStyle, value: style, range: range)
-        
+
         if shouldParse {
             rangesForDetectors.removeAll()
             let results = parse(text: mutableText)
             setRangesForDetectors(in: results)
         }
-        
+
         for (detector, rangeTuples) in rangesForDetectors {
             if enabledDetectors.contains(detector) {
                 let attributes = detectorAttributes(for: detector)
@@ -250,7 +267,7 @@ open class MessageLabel: UILabel {
         if !isConfiguring { setNeedsDisplay() }
 
     }
-    
+
     private func paragraphStyle(for text: NSAttributedString) -> NSParagraphStyle {
         guard text.length > 0 else { return NSParagraphStyle() }
         
@@ -321,7 +338,7 @@ open class MessageLabel: UILabel {
             fatalError(MessageKitError.unrecognizedCheckingResult)
         }
     }
-    
+
     private func setupView() {
         numberOfLines = 0
         lineBreakMode = .byWordWrapping
@@ -378,7 +395,7 @@ open class MessageLabel: UILabel {
     private func setRangesForDetectors(in checkingResults: [NSTextCheckingResult]) {
 
         guard checkingResults.isEmpty == false else { return }
-        
+
         for result in checkingResults {
 
             switch result.resultType {
@@ -435,18 +452,18 @@ open class MessageLabel: UILabel {
         let index = layoutManager.glyphIndex(for: location, in: textContainer)
 
         let lineRect = layoutManager.lineFragmentUsedRect(forGlyphAt: index, effectiveRange: nil)
-        
+
         var characterIndex: Int?
-        
+
         if lineRect.contains(location) {
             characterIndex = layoutManager.characterIndexForGlyph(at: index)
         }
-        
+
         return characterIndex
 
     }
 
-  open func handleGesture(_ touchLocation: CGPoint) -> Bool {
+    open func handleGesture(_ touchLocation: CGPoint) -> Bool {
 
         guard let index = stringIndex(at: touchLocation) else { return false }
 
@@ -463,7 +480,7 @@ open class MessageLabel: UILabel {
 
     // swiftlint:disable cyclomatic_complexity
     private func handleGesture(for detectorType: DetectorType, value: MessageTextCheckingType) {
-        
+
         switch value {
         case let .addressComponents(addressComponents):
             var transformedAddressComponents = [String: String]()
@@ -501,23 +518,23 @@ open class MessageLabel: UILabel {
         }
     }
     // swiftlint:enable cyclomatic_complexity
-    
+
     private func handleAddress(_ addressComponents: [String: String]) {
         delegate?.didSelectAddress(addressComponents)
     }
-    
+
     private func handleDate(_ date: Date) {
         delegate?.didSelectDate(date)
     }
-    
+
     private func handleURL(_ url: URL) {
         delegate?.didSelectURL(url)
     }
-    
+
     private func handlePhoneNumber(_ phoneNumber: String) {
         delegate?.didSelectPhoneNumber(phoneNumber)
     }
-    
+
     private func handleTransitInformation(_ components: [String: String]) {
         delegate?.didSelectTransitInformation(components)
     }


### PR DESCRIPTION
Overriding `intrinsicContentSize` is a not a proper implementation for `UILabel` subclasses that want to add insets.

Instead the `textRect` methods of `UILabel` should be overridden, since they are called by both `intrinsicContentSize` and the older `sizeThatFits`.

This PR also makes sure to call `invalidateIntrinsicContentSize` when `textInsets` is changed.

Purpose of this PR: use `MessageLabel` inside of a `UIStackView` and to improve the overall correctness of the implementation.

Note for third parties: you will need to set a `preferredMaxLayoutWidth` if you want to use auto sizing, otherwise `sizeToFit` will size to a single line regardless of `numberOfLines`