### PR TITLE
Fixes support for custom inputAccessoryView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - Lazily initialize the MessageInputBar on MessagesViewController. [#1092](https://github.com/MessageKit/MessageKit/pull/1092) by [@marcetcheverry](https://github.com/marcetcheverry)
 
+- Improved support for custom input accessory views. [#1140](https://github.com/MessageKit/MessageKit/pull/1140) by [@marcetcheverry](https://github.com/marcetcheverry)
+
 ## 3.0.0
 
 ### Dependency Changes

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -46,7 +46,7 @@ internal extension MessagesViewController {
     @objc
     private func handleTextViewDidBeginEditing(_ notification: Notification) {
         if scrollsToBottomOnKeyboardBeginsEditing {
-            guard let inputTextView = notification.object as? InputTextView, inputTextView === messageInputBar.inputTextView else { return }
+            guard let textView = notification.object as? UITextView, inputTextView === textView else { return }
             messagesCollectionView.scrollToBottom(animated: true)
         }
     }

--- a/Sources/Controllers/MessagesViewController+Menu.swift
+++ b/Sources/Controllers/MessagesViewController+Menu.swift
@@ -58,9 +58,10 @@ internal extension MessagesViewController {
         guard let selectedCell = messagesCollectionView.cellForItem(at: selectedIndexPath) as? MessageContentCell else { return }
         let selectedCellMessageBubbleFrame = selectedCell.convert(selectedCell.messageContainerView.frame, to: view)
 
-        var messageInputBarFrame: CGRect = .zero
-        if let messageInputBarSuperview = messageInputBar.superview {
-            messageInputBarFrame = view.convert(messageInputBar.frame, from: messageInputBarSuperview)
+        var inputAccessoryViewFrame: CGRect = .zero
+        if let inputAccessoryView = inputAccessoryView,
+            let messageInputBarSuperview = inputAccessoryView.superview {
+            inputAccessoryViewFrame = view.convert(inputAccessoryView.frame, from: messageInputBarSuperview)
         }
 
         var topNavigationBarFrame: CGRect = navigationBarFrame
@@ -76,8 +77,8 @@ internal extension MessagesViewController {
         currentMenuController.arrowDirection = .default
 
         /// Message bubble intersects with navigationBar and keyboard
-        if selectedCellMessageBubblePlusMenuFrame.intersects(topNavigationBarFrame) && selectedCellMessageBubblePlusMenuFrame.intersects(messageInputBarFrame) {
-            let centerY = (selectedCellMessageBubblePlusMenuFrame.intersection(messageInputBarFrame).minY + selectedCellMessageBubblePlusMenuFrame.intersection(topNavigationBarFrame).maxY) / 2
+        if selectedCellMessageBubblePlusMenuFrame.intersects(topNavigationBarFrame) && selectedCellMessageBubblePlusMenuFrame.intersects(inputAccessoryViewFrame) {
+            let centerY = (selectedCellMessageBubblePlusMenuFrame.intersection(inputAccessoryViewFrame).minY + selectedCellMessageBubblePlusMenuFrame.intersection(topNavigationBarFrame).maxY) / 2
             targetRect = CGRect(selectedCellMessageBubblePlusMenuFrame.midX, centerY, 1, 1)
         } /// Message bubble only intersects with navigationBar
         else if selectedCellMessageBubblePlusMenuFrame.intersects(topNavigationBarFrame) {

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -33,7 +33,8 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
     /// The `MessagesCollectionView` managed by the messages view controller object.
     open var messagesCollectionView = MessagesCollectionView()
 
-    /// The `InputBarAccessoryView` used as the `inputAccessoryView` in the view controller.
+    /// The lazily created `InputBarAccessoryView` used as the `inputAccessoryView` in the view controller.
+    /// See `inputAccessoryView` and `inputTextView` which reference this.
     open lazy var messageInputBar = InputBarAccessoryView()
 
     /// A Boolean value that determines whether the `MessagesCollectionView` scrolls to the
@@ -52,8 +53,15 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
         return true
     }
 
+    /// You should override `inputTextView` if you override this.
     open override var inputAccessoryView: UIView? {
         return messageInputBar
+    }
+
+    /// The default textView responsible for `scrollsToBottomOnKeyboardBeginsEditing`.
+    /// Override this property if you override `inputAccessoryView`.
+    open var inputTextView: UITextView? {
+        return messageInputBar.inputTextView
     }
 
     open override var shouldAutorotate: Bool {


### PR DESCRIPTION
If you provide a custom `inputAccessoryView`, `MessagesViewController+Keyboard` would assume that you were still using the default `messageInputBar` and it would create that lazy var.

This PR provides a facility for specifying your `inputTextView` for keyboard notifications, and also removes unnecessary direct references to `messageInputBar` in the keyboard and menu extensions.

There are no breaking changes in this PR. Documentation is improved.