### PR TITLE
docs(CustomCells): Creating custom cells 📱

### DIFF
--- a/Documentation/CustomCells.md
+++ b/Documentation/CustomCells.md
@@ -5,7 +5,46 @@
 To make a custom cell, you have to make a cell that inherit from `UICollectionViewCell`.
 
 ```
+import UIKit
+import MessageKit
 
+open class CustomCell: UICollectionViewCell {
+    
+    let label = UILabel()
+    
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupSubviews()
+    }
+    
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setupSubviews()
+    }
+    
+    open func setupSubviews() {
+        contentView.addSubview(label)
+        label.textAlignment = .center
+        label.font = UIFont.italicSystemFont(ofSize: 13)
+    }
+    
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        label.frame = contentView.bounds
+    }
+    
+    open func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
+        // Do stuff
+        switch message.kind {
+        case .custom(let data):
+            guard let systemMessage = data as? String else { return }
+            label.text = systemMessage
+        default:
+            break
+        }
+    }
+    
+}
 ```
 
 Once you have your cell, you need to tell the size of your cell. How can to do that ?

--- a/Documentation/CustomCells.md
+++ b/Documentation/CustomCells.md
@@ -1,0 +1,90 @@
+# Custom cells 
+
+## Creating a cell based on MessageBubble with MessageKit
+
+To make a custom cell, you have to make a cell that inherit from `UICollectionViewCell`.
+
+```
+
+```
+
+Once you have your cell, you need to tell the size of your cell. How can to do that ?
+
+You have to make a class that inherit from `MessageSizeCalculator` or `CellSizeCalculator` to make a custom cell size calculator
+
+You have to make a class that inherit from `MessagesCollectionViewFlowLayout` and add you custom size calculator that will calcul the size of your cell.
+
+You must override two method to achieve that:
+
+- `messageSizeCalculators()` to add your custom cell size calculator
+- `cellSizeCalculatorForItem(at indexPath: IndexPath)` to choose with which cell you will use your custom cell calculator
+
+
+You can see this example from the master branch:
+
+```
+open class CustomMessagesFlowLayout: MessagesCollectionViewFlowLayout {
+    
+    open lazy var customMessageSizeCalculator = CustomMessageSizeCalculator(layout: self)
+    
+    open override func cellSizeCalculatorForItem(at indexPath: IndexPath) -> CellSizeCalculator {
+        let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
+        if case .custom = message.kind {
+            return customMessageSizeCalculator
+        }
+        return super.cellSizeCalculatorForItem(at: indexPath)
+    }
+    
+    open override func messageSizeCalculators() -> [MessageSizeCalculator] {
+        var superCalculators = super.messageSizeCalculators()
+        // Append any of your custom `MessageSizeCalculator` if you wish for the convenience
+        // functions to work such as `setMessageIncoming...` or `setMessageOutgoing...`
+        superCalculators.append(customMessageSizeCalculator)
+        return superCalculators
+    }
+}
+
+open class CustomMessageSizeCalculator: MessageSizeCalculator {
+    
+    public override init(layout: MessagesCollectionViewFlowLayout? = nil) {
+        super.init()
+        self.layout = layout
+    }
+    
+    open override func sizeForItem(at indexPath: IndexPath) -> CGSize {
+        guard let layout = layout else { return .zero }
+        let collectionViewWidth = layout.collectionView?.bounds.width ?? 0
+        let contentInset = layout.collectionView?.contentInset ?? .zero
+        let inset = layout.sectionInset.left + layout.sectionInset.right + contentInset.left + contentInset.right
+        return CGSize(width: collectionViewWidth - inset, height: 44)
+    }
+  
+}
+
+```
+
+## Creating a cell based on MessageBubble with MessageKit
+
+[MessageContentCell](https://github.com/MessageKit/MessageKit/blob/master/Sources/Views/Cells/MessageContentCell.swift) is the class used by [MessageKit](https://github.com/MessageKit/MessageKit) to display your message in a chat bubble
+You can create a cell by just extending this class: 
+
+```
+import MessageKit
+import UIKit
+
+open class CustomCell: MessageContentCell {
+
+     open override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
+         super.configure(with: message, at: indexPath, and: messagesCollectionView)
+
+
+      }
+
+     override open func layoutAccessoryView(with attributes: MessagesCollectionViewLayoutAttributes) {
+         // Accessory view is always on the opposite side of avatar
+     }
+  
+  }
+```
+
+If you want to extend other [Cells](https://github.com/MessageKit/MessageKit/blob/master/Sources/Views/Cells)

--- a/Documentation/CustomCells.md
+++ b/Documentation/CustomCells.md
@@ -4,7 +4,7 @@
 
 To make a custom cell, you have to make a cell that inherit from `UICollectionViewCell`.
 
-```
+```swift
 import UIKit
 import MessageKit
 
@@ -61,7 +61,7 @@ You must override two method to achieve that:
 
 You can see this example from the master branch:
 
-```
+```swift
 open class CustomMessagesFlowLayout: MessagesCollectionViewFlowLayout {
     
     open lazy var customMessageSizeCalculator = CustomMessageSizeCalculator(layout: self)
@@ -107,7 +107,7 @@ open class CustomMessageSizeCalculator: MessageSizeCalculator {
 [MessageContentCell](https://github.com/MessageKit/MessageKit/blob/master/Sources/Views/Cells/MessageContentCell.swift) is the class used by [MessageKit](https://github.com/MessageKit/MessageKit) to display your message in a chat bubble
 You can create a cell by just extending this class: 
 
-```
+```swift
 import MessageKit
 import UIKit
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Please have a look at the [Quick Start guide](https://github.com/MessageKit/Mess
 
 We recommend you start by looking at the [Example](https://github.com/MessageKit/MessageKit/tree/master/Example) project or write a question with the "messagekit" tag on [Stack Overflow](https://stackoverflow.com/questions/tagged/messagekit). You can also look at previous issues here on GitHib with the **"Question"** tag.
 
+You can also take a look at the [Custom cells guide](https://github.com/MessageKit/MessageKit/blob/master/Documentation/CustomCells.md)
+
 For more on how to use the MessageInputBar, see the dependency it is based on [InputBarAccessoryView](https://github.com/nathantannar4/InputBarAccessoryView). You can also see this [short guide]([https://github.com/MessageKit/MessageKit/blob/master/Documentation/MessageInputBar.md) 
 
 ## Default Cells


### PR DESCRIPTION
# Documentation: Creating custom cells 📱

Turn issue from https://stackoverflow.com/questions/56958482/how-to-create-custom-cell-with-messagekit/57165876#57165876 into a documentation file

What does this implement/fix? Explain your changes.
---------------------------------------------------

Creating documentation file for custom cells 

Does this close any currently open issues?
------------------------------------------

We have some issue that are question about that topic such as: 

- https://github.com/MessageKit/MessageKit/issues/945 
- https://github.com/MessageKit/MessageKit/issues/948
- https://github.com/MessageKit/MessageKit/issues/947
- https://github.com/MessageKit/MessageKit/issues/934
- https://github.com/MessageKit/MessageKit/issues/1085
- https://github.com/MessageKit/MessageKit/issues/1033
- https://github.com/MessageKit/MessageKit/issues/1128

