### PR TITLE
Added delegate method for image tap action

### DIFF
--- a/Documentation/QuickStart.md
+++ b/Documentation/QuickStart.md
@@ -32,35 +32,28 @@ Second, each message must have its own `messageId` which is a unique `String` id
 Third, each message must have a `sentDate` which represents the `Date` that each message was sent.
 
 Fourth, each message must specify what kind of message it is through the `kind: MessageKind` property:
-### MessageKind
+### [MessageKind](https://github.com/MessageKit/MessageKit#default-cells)
 
-```Swift
-public enum MessageKind {
-    case text(String)
-    case attributedText(NSAttributedString)
-    case emoji(String)
-    case photo(MediaItem)
-    case video(MediaItem)
-    case location(LocationItem)
-    case custom(Any?)
-}
-```
-`MessageData` has 7 different cases representing the types of messages that **MessageKit** can display.
+`MessageData` has 8 different cases representing the types of messages that **MessageKit** can display.
 
 - `text(String)` - Use this case if you just want to display a normal text message without any attributes.
-- **NOTE**: You must also specify the `UIFont` you want to use for this text by setting the `messageLabelFont` property of the `textMessageSizeCalculator` in `MessagesCollectionViewFlowLayout`.
-
-- `emoji(String)` - Use this case to display a message that only contains emoji.
-- **NOTE**: You must also specify the `UIFont` you want to use for this text by setting the `messageLabelFont` property of the `emojiMessageSizeCalculator` in `MessagesCollectionViewFlowLayout`.
+  - **NOTE**: You must also specify the `UIFont` you want to use for this text by setting the `messageLabelFont` property of the `textMessageSizeCalculator` in `MessagesCollectionViewFlowLayout`.
 
 - `attributedText(NSAttributedString)` - Use this case if you want to display a text message with attributes.
-- **NOTE**: It is recommended that you use `attributedText` for text messages.
+  - **NOTE**: It is recommended that you use `attributedText` for text messages.
+
+- `emoji(String)` - Use this case to display a message that only contains emoji.
+  - **NOTE**: You must also specify the `UIFont` you want to use for this text by setting the `messageLabelFont` property of the `emojiMessageSizeCalculator` in `MessagesCollectionViewFlowLayout`.
 
 - `photo(MediaItem)` - Use this case to display a photo message.
 
 - `video(MediaItem)` - Use this case to display a video message.
 
 - `location(LocationItem)` - Use this case to display a location message.
+
+- `audio(AudioItem)` - Use this case to display an audio message.
+
+- `contact(ContactItem)` - Use this case to display a contact message.
 
 # MessagesViewController
 

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -195,6 +195,10 @@ extension ChatViewController: MessageCellDelegate {
         print("Message tapped")
     }
     
+    func didTapImage(in cell: MessageCollectionViewCell) {
+        print("Image tapped")
+    }
+    
     func didTapCellTopLabel(in cell: MessageCollectionViewCell) {
         print("Top cell label tapped")
     }

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Add your app to the list of apps using this library and make a pull request.
 - [WiseEyes](https://itunes.apple.com/us/app/wiseeyes/id1391408511?mt=8)
 - [SwiftHub](https://github.com/khoren93/SwiftHub)
 - [Studievenn](https://studievenn.no)
+- [SmooveText](https://apps.apple.com/np/app/smoove-text/id1362792811)
 
 *Please provide attribution, it is greatly appreciated.*
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Add your app to the list of apps using this library and make a pull request.
 - [RappresentaMe](https://itunes.apple.com/it/app/rappresentame/id1330914443)
 - [WiseEyes](https://itunes.apple.com/us/app/wiseeyes/id1391408511?mt=8)
 - [SwiftHub](https://github.com/khoren93/SwiftHub)
+- [Studievenn](https://studievenn.no)
 
 *Please provide attribution, it is greatly appreciated.*
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ public enum MessageKind {
 
 If you choose to use the `.custom` kind you are responsible for all of the cells layout. Any `UICollectionViewCell` can be returned for custom cells which means any of the styling you provide from the `MessageDisplayDelegate` will not effect your custom cell. Even if you subclass your cell from `MessageContentCell`.
 
+[Read more about the cases on the Quick Start guide.](https://github.com/MessageKit/MessageKit/blob/whoyawn-documentation-update/Documentation/QuickStart.md#messagekind)
 
 ## Contributing
 

--- a/Sources/Protocols/MessageCellDelegate.swift
+++ b/Sources/Protocols/MessageCellDelegate.swift
@@ -109,6 +109,16 @@ public protocol MessageCellDelegate: MessageLabelDelegate {
     /// method `messageForItem(at:indexPath:messagesCollectionView)`.
     func didTapAccessoryView(in cell: MessageCollectionViewCell)
 
+    /// Triggered when a tap occurs on the image.
+    ///
+    /// - Parameters:
+    ///   - cell: The image where the touch occurred.
+    ///
+    /// You can get a reference to the `MessageType` for the cell by using `UICollectionView`'s
+    /// `indexPath(for: cell)` method. Then using the returned `IndexPath` with the `MessagesDataSource`
+    /// method `messageForItem(at:indexPath:messagesCollectionView)`.
+    func didTapImage(in cell: MessageCollectionViewCell)
+
     /// Triggered when a tap occurs on the play button from audio cell.
     ///
     /// - Parameters:
@@ -164,6 +174,8 @@ public extension MessageCellDelegate {
     func didTapCellBottomLabel(in cell: MessageCollectionViewCell) {}
 
     func didTapMessageTopLabel(in cell: MessageCollectionViewCell) {}
+    
+    func didTapImage(in cell: MessageCollectionViewCell) {}
 
     func didTapPlayButton(in cell: AudioMessageCell) {}
 

--- a/Sources/Views/Cells/MediaMessageCell.swift
+++ b/Sources/Views/Cells/MediaMessageCell.swift
@@ -81,4 +81,17 @@ open class MediaMessageCell: MessageContentCell {
 
         displayDelegate.configureMediaMessageImageView(imageView, for: message, at: indexPath, in: messagesCollectionView)
     }
+    
+    /// Handle tap gesture on contentView and its subviews.
+    open override func handleTapGesture(_ gesture: UIGestureRecognizer) {
+        let touchLocation = gesture.location(in: self)
+        
+        switch true {
+        case imageView.frame.contains(touchLocation):
+            delegate?.didTapImage(in: self)
+        default:
+            break
+        }
+    }
+    
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Added delegate for image tap action.

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Devices:** 
iPhone X
**iOS Version:**
12.4
**Swift Version:**
4.2
**MessageKit Version:**
3.0.0

