### PR TITLE
Added delegate method for image tap action

### DIFF
--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -195,6 +195,10 @@ extension ChatViewController: MessageCellDelegate {
         print("Message tapped")
     }
     
+    func didTapImage(in cell: MessageCollectionViewCell) {
+        print("Image tapped")
+    }
+    
     func didTapCellTopLabel(in cell: MessageCollectionViewCell) {
         print("Top cell label tapped")
     }

--- a/Sources/Protocols/MessageCellDelegate.swift
+++ b/Sources/Protocols/MessageCellDelegate.swift
@@ -109,6 +109,16 @@ public protocol MessageCellDelegate: MessageLabelDelegate {
     /// method `messageForItem(at:indexPath:messagesCollectionView)`.
     func didTapAccessoryView(in cell: MessageCollectionViewCell)
 
+    /// Triggered when a tap occurs on the image.
+    ///
+    /// - Parameters:
+    ///   - cell: The image where the touch occurred.
+    ///
+    /// You can get a reference to the `MessageType` for the cell by using `UICollectionView`'s
+    /// `indexPath(for: cell)` method. Then using the returned `IndexPath` with the `MessagesDataSource`
+    /// method `messageForItem(at:indexPath:messagesCollectionView)`.
+    func didTapImage(in cell: MessageCollectionViewCell)
+
     /// Triggered when a tap occurs on the play button from audio cell.
     ///
     /// - Parameters:
@@ -164,6 +174,8 @@ public extension MessageCellDelegate {
     func didTapCellBottomLabel(in cell: MessageCollectionViewCell) {}
 
     func didTapMessageTopLabel(in cell: MessageCollectionViewCell) {}
+    
+    func didTapImage(in cell: MessageCollectionViewCell) {}
 
     func didTapPlayButton(in cell: AudioMessageCell) {}
 

--- a/Sources/Views/Cells/MediaMessageCell.swift
+++ b/Sources/Views/Cells/MediaMessageCell.swift
@@ -81,4 +81,17 @@ open class MediaMessageCell: MessageContentCell {
 
         displayDelegate.configureMediaMessageImageView(imageView, for: message, at: indexPath, in: messagesCollectionView)
     }
+    
+    /// Handle tap gesture on contentView and its subviews.
+    open override func handleTapGesture(_ gesture: UIGestureRecognizer) {
+        let touchLocation = gesture.location(in: self)
+        
+        switch true {
+        case imageView.frame.contains(touchLocation):
+            delegate?.didTapImage(in: self)
+        default:
+            break
+        }
+    }
+    
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
👻 Added delegate for image tap action.

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Devices:** 
iPhone X
**iOS Version:** 
12.4
**Swift Version:** 
4.2
**MessageKit Version:** 
3.0.0
