### PR TITLE
Resolve issue with scrolling to bottom

### DIFF
--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -101,9 +101,10 @@ open class MessagesCollectionView: UICollectionView {
     }
 
     public func scrollToBottom(animated: Bool = false) {
-        let collectionViewContentHeight = collectionViewLayout.collectionViewContentSize.height
 
-        performBatchUpdates(nil) { _ in
+        performBatchUpdates(nil) { [weak self] _ in
+            guard let self = self else { return }
+            let collectionViewContentHeight = collectionViewLayout.collectionViewContentSize.height
             self.scrollRectToVisible(CGRect(0.0, collectionViewContentHeight - 1.0, 1.0, 1.0), animated: animated)
         }
     }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

The content size is 0 when reading before performBatchUpdates is called
The content size is correct inside performBatchUpdates
Calling reloadData() before doesn't help.

Where has this been tested?
---------------------------
**Devices/Simulators:**

Tested on iOS 13 

**Swift Version:** …

Swift 5.1

**MessageKit Version:** …

3.0

