### PR TITLE
Adding property status to MessageType protocol

### DIFF
--- a/MessageKit.xcodeproj/project.pbxproj
+++ b/MessageKit.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		50FF34572237FE6A0004DCD7 /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FF34562237FE6A0004DCD7 /* UIImage+Extension.swift */; };
 		50FF34592237FE850004DCD7 /* ContactMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FF34582237FE840004DCD7 /* ContactMessageCell.swift */; };
 		50FF345B2237FE9C0004DCD7 /* ContactMessageSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FF345A2237FE9C0004DCD7 /* ContactMessageSizeCalculator.swift */; };
+		79661AA922E8AFEB00EF0087 /* MessageStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79661AA822E8AFEB00EF0087 /* MessageStatus.swift */; };
 		88916B2D1CF0DF2F00469F91 /* MessageKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88916B221CF0DF2F00469F91 /* MessageKit.framework */; };
 		8962AC8A1F87AB7D0030B058 /* MessagesCollectionViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8962AC831F87AB230030B058 /* MessagesCollectionViewTests.swift */; };
 		8962AC8C1F87AB7D0030B058 /* AvatarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8962AC851F87AB230030B058 /* AvatarViewTests.swift */; };
@@ -166,6 +167,7 @@
 		50FF34562237FE6A0004DCD7 /* UIImage+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
 		50FF34582237FE840004DCD7 /* ContactMessageCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactMessageCell.swift; sourceTree = "<group>"; };
 		50FF345A2237FE9C0004DCD7 /* ContactMessageSizeCalculator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactMessageSizeCalculator.swift; sourceTree = "<group>"; };
+		79661AA822E8AFEB00EF0087 /* MessageStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageStatus.swift; sourceTree = "<group>"; };
 		88916B221CF0DF2F00469F91 /* MessageKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MessageKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		88916B2C1CF0DF2F00469F91 /* MessageKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MessageKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8962AC741F87AB230030B058 /* MessageKitDateFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageKitDateFormatterTests.swift; sourceTree = "<group>"; };
@@ -421,6 +423,7 @@
 				B7A03F221F866895006AEF79 /* LabelAlignment.swift */,
 				B7A03F1D1F866895006AEF79 /* LocationMessageSnapshotOptions.swift */,
 				B7A03F231F866895006AEF79 /* MessageKind.swift */,
+				79661AA822E8AFEB00EF0087 /* MessageStatus.swift */,
 				B7A03F1B1F866895006AEF79 /* MessageKitDateFormatter.swift */,
 				1FF377A320087C82004FD648 /* MessageKitError.swift */,
 				B7A03F1F1F866895006AEF79 /* MessageStyle.swift */,
@@ -635,6 +638,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				382C794221705D2000F4FAF5 /* HorizontalEdgeInsets.swift in Sources */,
+				79661AA922E8AFEB00EF0087 /* MessageStatus.swift in Sources */,
 				B7A03F3C1F866946006AEF79 /* LocationMessageCell.swift in Sources */,
 				1FF377AA20087D78004FD648 /* MessagesViewController+Menu.swift in Sources */,
 				B7A03F5B1F8669CA006AEF79 /* MessageType.swift in Sources */,

--- a/Sources/Models/MessageStatus.swift
+++ b/Sources/Models/MessageStatus.swift
@@ -1,0 +1,15 @@
+//
+//  MessageStatus.swift
+//  MessageKit
+//
+//  Created by Vlada Radchenko on 7/24/19.
+//  Copyright © 2019 MessageKit. All rights reserved.
+//
+
+import Foundation
+
+public enum MessageStatus: String, Codable {
+
+    case delivered
+    case read
+}

--- a/Sources/Protocols/MessageType.swift
+++ b/Sources/Protocols/MessageType.swift
@@ -40,4 +40,6 @@ public protocol MessageType {
     /// The kind of message and its underlying kind.
     var kind: MessageKind { get }
 
+    /// The message status delivered/read
+    var status: [String: MessageStatus] { get }
 }


### PR DESCRIPTION
There is necessity to track message status. In future cases "sending", "error" could be added to MessageStatus model.