### PR TITLE
Removed the redundant access modifiers

### DIFF
--- a/Example/Sources/Data Generation/Lorem.swift
+++ b/Example/Sources/Data Generation/Lorem.swift
@@ -222,7 +222,7 @@ public extension Array {
     /**
      Shuffle the array in-place using the Fisher-Yates algorithm.
      */
-    public mutating func shuffle() {
+    mutating func shuffle() {
         for i in 0..<(count - 1) {
             let j = Int(arc4random_uniform(UInt32(count - i))) + i
             if j != i {
@@ -237,7 +237,7 @@ public extension Array {
      
      - returns: Returns a shuffled version of the array.
      */
-    public func shuffled() -> [Element] {
+    func shuffled() -> [Element] {
         var list = self
         list.shuffle()
         
@@ -249,7 +249,7 @@ public extension Array {
      - returns: Returns a random element from the array or `nil` if the
      array is empty.
      */
-    public func random() -> Element? {
+    func random() -> Element? {
         return (count > 0) ? self.shuffled()[0] : nil
     }
     
@@ -257,7 +257,7 @@ public extension Array {
      Return a random subset of `cnt` elements from the array.
      - returns: Returns a random subset of `cnt` elements from the array.
      */
-    public func random(_ count: Int = 1) -> [Element] {
+    func random(_ count: Int = 1) -> [Element] {
         let result = shuffled()
         
         return (count > result.count) ? result : Array(result[0..<count])

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -29,13 +29,13 @@ internal extension MessagesViewController {
 
     // MARK: - Register / Unregister Observers
 
-    internal func addKeyboardObservers() {
+    func addKeyboardObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(MessagesViewController.handleKeyboardDidChangeState(_:)), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(MessagesViewController.handleTextViewDidBeginEditing(_:)), name: UITextView.textDidBeginEditingNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(MessagesViewController.adjustScrollViewTopInset), name: UIDevice.orientationDidChangeNotification, object: nil)
     }
 
-    internal func removeKeyboardObservers() {
+    func removeKeyboardObservers() {
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UITextView.textDidBeginEditingNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
@@ -95,7 +95,7 @@ internal extension MessagesViewController {
     // MARK: - Inset Computation
 
     @objc
-    internal func adjustScrollViewTopInset() {
+    func adjustScrollViewTopInset() {
         if #available(iOS 11.0, *) {
             // No need to add to the top contentInset
         } else {
@@ -121,7 +121,7 @@ internal extension MessagesViewController {
         }
     }
 
-    internal func requiredInitialScrollViewBottomInset() -> CGFloat {
+    func requiredInitialScrollViewBottomInset() -> CGFloat {
         guard let inputAccessoryView = inputAccessoryView else { return 0 }
         return max(0, inputAccessoryView.frame.height + additionalBottomInset - automaticallyAddedBottomInset)
     }

--- a/Sources/Controllers/MessagesViewController+Menu.swift
+++ b/Sources/Controllers/MessagesViewController+Menu.swift
@@ -28,11 +28,11 @@ internal extension MessagesViewController {
 
     // MARK: - Register / Unregister Observers
 
-    internal func addMenuControllerObservers() {
+    func addMenuControllerObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(MessagesViewController.menuControllerWillShow(_:)), name: UIMenuController.willShowMenuNotification, object: nil)
     }
 
-    internal func removeMenuControllerObservers() {
+    func removeMenuControllerObservers() {
         NotificationCenter.default.removeObserver(self, name: UIMenuController.willShowMenuNotification, object: nil)
     }
 

--- a/Sources/Extensions/UIImage+Extension.swift
+++ b/Sources/Extensions/UIImage+Extension.swift
@@ -33,7 +33,7 @@ import UIKit
 /// This extension provide a way to access image resources with in framework
 public extension UIImage {
     
-    public class func messageKitImageWith(type: ImageType) -> UIImage? {
+    class func messageKitImageWith(type: ImageType) -> UIImage? {
         let assetBundle = Bundle.messageKitAssetBundle()
         let imagePath = assetBundle.path(forResource: type.rawValue, ofType: "png", inDirectory: "Images")
         let image = UIImage(contentsOfFile: imagePath ?? "")

--- a/Sources/Extensions/UIView+Extensions.swift
+++ b/Sources/Extensions/UIView+Extensions.swift
@@ -67,7 +67,7 @@ internal extension UIView {
     }
 
     @discardableResult
-    internal func addConstraints(_ top: NSLayoutYAxisAnchor? = nil, left: NSLayoutXAxisAnchor? = nil, bottom: NSLayoutYAxisAnchor? = nil, right: NSLayoutXAxisAnchor? = nil, centerY: NSLayoutYAxisAnchor? = nil, centerX: NSLayoutXAxisAnchor? = nil, topConstant: CGFloat = 0, leftConstant: CGFloat = 0, bottomConstant: CGFloat = 0, rightConstant: CGFloat = 0, centerYConstant: CGFloat = 0, centerXConstant: CGFloat = 0, widthConstant: CGFloat = 0, heightConstant: CGFloat = 0) -> [NSLayoutConstraint] {
+    func addConstraints(_ top: NSLayoutYAxisAnchor? = nil, left: NSLayoutXAxisAnchor? = nil, bottom: NSLayoutYAxisAnchor? = nil, right: NSLayoutXAxisAnchor? = nil, centerY: NSLayoutYAxisAnchor? = nil, centerX: NSLayoutXAxisAnchor? = nil, topConstant: CGFloat = 0, leftConstant: CGFloat = 0, bottomConstant: CGFloat = 0, rightConstant: CGFloat = 0, centerYConstant: CGFloat = 0, centerXConstant: CGFloat = 0, widthConstant: CGFloat = 0, heightConstant: CGFloat = 0) -> [NSLayoutConstraint] {
         
         if self.superview == nil {
             return []

--- a/Sources/Models/HorizontalEdgeInsets.swift
+++ b/Sources/Models/HorizontalEdgeInsets.swift
@@ -49,7 +49,7 @@ public extension HorizontalEdgeInsets {
 
 internal extension HorizontalEdgeInsets {
 
-    internal var horizontal: CGFloat {
+    var horizontal: CGFloat {
         return left + right
     }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Removed the Redundant access modifiers warnings. 
Most of the methods were inside an `Extension` with the modifier. 


Does this close any currently open issues?
------------------------------------------
no


Any relevant logs, error output, etc?
-------------------------------------
nop

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**iOS Version:** …

**Swift Version:** …

**MessageKit Version:** …


