### PR TITLE
[Hotfix] - Fix keyboard notifications on iOS 13+

### DIFF
--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -63,6 +63,11 @@ internal extension MessagesViewController {
             return
         }
         
+        guard self.presentedViewController == nil else {
+            // This is important to skip notifications from child modal controllers in iOS >= 13.0
+            return
+        }
+      
         // Note that the check above does not exclude all notifications from an undocked keyboard, only the weird ones.
         //
         // We've tried following Apple's recommended approach of tracking UIKeyboardWillShow / UIKeyboardDidHide and ignoring frame


### PR DESCRIPTION
We are receiving keyboard notifications from child modal view controllers, this
is a fix to ensure that this doesn't happen. 

This was causing issues where messages were clipped by the input accessory view, because the bottom offset was incorrect.

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Stops the keyboard handling when it comes back from a modal view controller on iOS 13

Does this close any currently open issues?
------------------------------------------
Not that I know of.


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
I can provide a video/screenshot of the fix if you want.

Where has this been tested?
---------------------------
**Devices/Simulators:** Devices + Simulator

**iOS Version:** 13

**Swift Version:** 5.0

**MessageKit Version:** 3.0.0


