### PR TITLE
Fix compilation warnings

### DIFF
--- a/MessageKit.xcodeproj/project.pbxproj
+++ b/MessageKit.xcodeproj/project.pbxproj
@@ -577,11 +577,11 @@
 			};
 			buildConfigurationList = 88916B1C1CF0DF2F00469F91 /* Build configuration list for PBXProject "MessageKit" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
+				Base,
 			);
 			mainGroup = 88916B181CF0DF2F00469F91;
 			productRefGroup = 88916B231CF0DF2F00469F91 /* Products */;

--- a/Sources/Models/Sender.swift
+++ b/Sources/Models/Sender.swift
@@ -28,7 +28,7 @@ import Foundation
 @available(*, deprecated, message: "`Sender` has been replaced with the `SenderType` protocol in 3.0.0")
 public struct Sender: SenderType {
 
-    /// MARK: - Properties
+    // MARK: - Properties
 
     /// The unique String identifier for the sender.
     ///


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Apply 2 auto-fixits about recommended Xcode project settings (regarding localization), and fixes 1 warning about an improperly formatted MARK comment.

No source code changes.

Does this close any currently open issues?
------------------------------------------
No


Where has this been tested?
---------------------------
**Devices/Simulators:** … iPhone 11 Pro Simulator

**iOS Version:** … iOS 13

**Swift Version:** … 5

**MessageKit Version:** … 3.0.0


