### PR TITLE
Update InputBarAccessoryView to 4.3.2, edit Cartfile to allow < v5.0.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "nathantannar4/InputBarAccessoryView" "4.3.0"
+github "nathantannar4/InputBarAccessoryView" ~> 4.3.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "v8.0.5"
 github "Quick/Quick" "v2.2.0"
-github "nathantannar4/InputBarAccessoryView" "4.3.0"
+github "nathantannar4/InputBarAccessoryView" "4.3.2"


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Removes the fixed version requirement of "4.3.0" for InputBarAccessoryView, and allows versions up to but not including version 5.0.0.
- Updates the dependency to the latest version (4.3.2) 

Does this close any currently open issues?
-----------------------------------------
No

Where has this been tested?
---------------------------
**Devices/Simulators:** … Simulator: iPhone 11 Pro

**iOS Version:** … 13.2

**Swift Version:** … 5.0

**MessageKit Version:** … N/A (unreleased)


