### PR TITLE
Update Circle CI PR tests to include cache for pods

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
 #          command: curl -sS https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash
       - run:
           name: Update Pods
-              command: cd Example && pod install
+          command: cd Example && pod install
       - save_cache:
           name: Save Pods cache
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,13 @@
-# .circleci/config.yml
-
-# Specify the config version - version 2 is latest.
+# Specify the config version
 version: 2.1
 
-# Define the jobs for the current project.
+# Define the jobs for the current project
 jobs:
-  build-and-test:
-
+  build_tests:
+    macos:
+      xcode: 11.3.1
     environment:
       - DESTINATION: "platform=iOS Simulator,name=iPhone 11 Pro"
-
-    # Specify the Xcode version to use.
-    macos:
-      xcode: "11.3.1"
-
     # Define the steps required to build the project.
     steps:
       # Get the code from the VCS provider.
@@ -71,6 +65,6 @@ jobs:
       #    destination: scan-logs
 
 workflows:
-  build-and-deploy:
-    jobs:
-      - build-and-test
+    build_and_tests:
+        jobs:
+            - build_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,25 +30,22 @@ jobs:
       - run:
           name: Build and run tests
           command: xcodebuild test -project MessageKit.xcodeproj -scheme MessageKitTests -destination "$DESTINATION" CODE_SIGNING_REQUIRED=NO | xcpretty -c
-      - run:
-          name: Open Example
-          command: cd Example
       - restore_cache:
           name: Restore Pods cache
           keys:
-              - v1-pods-cache-{{ arch }}-{{ checksum "Podfile.lock" }}
+              - v1-pods-cache-{{ arch }}-{{ checksum "Example/Podfile.lock" }}
               - v1-pods-cache-{{ arch }}-
 #      - run:
 #          name: Fetch CocoaPods Specs
 #          command: curl -sS https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash
       - run:
           name: Update Pods
-          command: pod install
+              command: cd Example && pod install
       - save_cache:
           name: Save Pods cache
           paths:
               - Pods
-          key: v1-pods-cache-{{ arch }}-{{ checksum "Podfile.lock" }}
+          key: v1-pods-cache-{{ arch }}-{{ checksum "Example/Podfile.lock" }}
       - run:
           name: Build and analyze Example
           command: xcodebuild build analyze -workspace Example/ChatExample.xcworkspace -scheme ChatExample -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | xcpretty -c

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,11 @@ jobs:
           name: Update Homebrew
           command: brew update
       - run:
-          name: Pre-start simulator
-          command: xcrun instruments -w "iPhone 11 Pro (13.3) [" || true
-      - run:
           name: Bootstrap Carthage
           command: carthage bootstrap --platform ios
+      - run:
+          name: Pre-start simulator
+          command: xcrun instruments -w "iPhone 11 Pro (13.3) [" || true
       - run:
           name: Build framework
           command: xcodebuild build -project MessageKit.xcodeproj -scheme MessageKit -destination "$DESTINATION" CODE_SIGNING_REQUIRED=NO | xcpretty -c

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # .circleci/config.yml
 
 # Specify the config version - version 2 is latest.
-version: 2
+version: 2.1
 
 # Define the jobs for the current project.
 jobs:
@@ -16,7 +16,6 @@ jobs:
 
     # Define the steps required to build the project.
     steps:
-
       # Get the code from the VCS provider.
       - checkout
       - run:
@@ -31,12 +30,25 @@ jobs:
       - run:
           name: Build and run tests
           command: xcodebuild test -project MessageKit.xcodeproj -scheme MessageKitTests -destination "$DESTINATION" CODE_SIGNING_REQUIRED=NO | xcpretty -c
-      - run: 
-          name: Fetch CocoaPods Specs
-          command: curl -sS https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash
+      - run:
+          name: Open Example
+          command: cd Example
+      - restore_cache:
+          name: Restore Pods cache
+          keys:
+              - v1-pods-cache-{{ arch }}-{{ checksum "Podfile.lock" }}
+              - v1-pods-cache-{{ arch }}-
+#      - run:
+#          name: Fetch CocoaPods Specs
+#          command: curl -sS https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash
       - run:
           name: Update Pods
-          command: cd Example && pod install
+          command: pod install
+      - save_cache:
+          name: Save Pods cache
+          paths:
+              - Pods
+          key: v1-pods-cache-{{ arch }}-{{ checksum "Podfile.lock" }}
       - run:
           name: Build and analyze Example
           command: xcodebuild build analyze -workspace Example/ChatExample.xcworkspace -scheme ChatExample -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | xcpretty -c
@@ -62,7 +74,6 @@ jobs:
       #    destination: scan-logs
 
 workflows:
-  version: 2
   build-and-deploy:
     jobs:
       - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
           name: Bootstrap Carthage
           command: carthage bootstrap --platform ios
       - run:
+          # More info about pre-start of the simulator at https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator
           name: Pre-start simulator
           command: xcrun instruments -w "iPhone 11 Pro (13.3) [" || true
       - run:
@@ -30,8 +31,8 @@ jobs:
       - restore_cache:
           name: Restore Pods cache
           keys:
-              - v1-pods-cache-{{ arch }}-{{ checksum "Example/Podfile.lock" }}
-              - v1-pods-cache-{{ arch }}-
+              - v1-pods-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Example/Podfile.lock" }}
+              - v1-pods-cache-{{ arch }}-{{ .Branch }}-
 #      - run:
 #          name: Fetch CocoaPods Specs
 #          command: curl -sS https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash
@@ -42,7 +43,7 @@ jobs:
           name: Save Pods cache
           paths:
               - Pods
-          key: v1-pods-cache-{{ arch }}-{{ checksum "Example/Podfile.lock" }}
+          key: v1-pods-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Example/Podfile.lock" }}
       - run:
           name: Build and analyze Example
           command: xcodebuild build analyze -workspace Example/ChatExample.xcworkspace -scheme ChatExample -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | xcpretty -c
@@ -68,6 +69,6 @@ jobs:
       #    destination: scan-logs
 
 workflows:
-    build_and_tests:
-        jobs:
-            - build_tests
+  build_and_tests:
+    jobs:
+      - build_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
           name: Update Homebrew
           command: brew update
       - run:
+          name: Pre-start simulator
+          command: xcrun instruments -w "iPhone 11 Pro (13.3) [" || true
+      - run:
           name: Bootstrap Carthage
           command: carthage bootstrap --platform ios
       - run:

--- a/MessageKit.podspec
+++ b/MessageKit.podspec
@@ -11,16 +11,10 @@ Pod::Spec.new do |s|
    s.source = { :git => 'https://github.com/MessageKit/MessageKit.git', :tag => s.version }
    s.source_files = 'Sources/**/*.swift'
 
-   s.pod_target_xcconfig = {
-      "SWIFT_VERSION" => "5.0",
-   }
-
    s.swift_version = '5.0'
 
    s.ios.deployment_target = '9.0'
    s.ios.resource_bundle = { 'MessageKitAssets' => 'Assets/MessageKitAssets.bundle/Images' }
-
-   s.requires_arc = true
 
    s.dependency 'InputBarAccessoryView', '~> 4.3.0'
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Change example build to use cache for pods, without fetching specs.

Does this close any currently open issues?
------------------------------------------
No


