### PR TITLE
Fix for issue 1265

### DIFF
--- a/Sources/Views/TypingIndicator.swift
+++ b/Sources/Views/TypingIndicator.swift
@@ -33,7 +33,7 @@ open class TypingIndicator: UIView {
     public var bounceOffset: CGFloat = 2.5
     
     /// A convenience accessor for the `backgroundColor` of each dot
-    open var dotColor: UIColor = UIColor.lightGrayColor {
+    open var dotColor: UIColor = UIColor.darkTextColor {
         didSet {
             dots.forEach { $0.backgroundColor = dotColor }
         }


### PR DESCRIPTION
Change bubble circles to be same color as text

https://github.com/MessageKit/MessageKit/issues/1265

I don't understand why this problem is new, perhaps the bubbles were a lighter shade before.

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Dots don't show in typing indicator

Does this close any currently open issues?
------------------------------------------
Yes: https://github.com/MessageKit/MessageKit/issues/1265

Any relevant logs, error output, etc?
-------------------------------------

![Simulator Screen Shot - iPhone 11 - 2020-03-04 at 10 56 50](https://user-images.githubusercontent.com/1905433/75873093-42663d00-5e07-11ea-8144-e3e630928943.png)

Any other comments?
-------------------
Thanks for the great project!

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 11 

**iOS Version:** iOS 13.4

**Swift Version:** 5

**MessageKit Version:** 3.1.0-beta.1


