### PR TITLE
Fix image view tap gesture handler.

### DIFF
--- a/Sources/Views/Cells/MediaMessageCell.swift
+++ b/Sources/Views/Cells/MediaMessageCell.swift
@@ -84,14 +84,13 @@ open class MediaMessageCell: MessageContentCell {
     
     /// Handle tap gesture on contentView and its subviews.
     open override func handleTapGesture(_ gesture: UIGestureRecognizer) {
-        let touchLocation = gesture.location(in: imageView)
-        
-        switch true {
-        case imageView.frame.contains(touchLocation):
-            delegate?.didTapImage(in: self)
-        default:
-            break
+        let touchLocation: CGPoint = convert(gesture.location(in: self), to: imageView)
+
+        guard imageView.bounds.contains(touchLocation) else {
+            super.handleTapGesture(gesture)
+            return
         }
+        delegate?.didTapImage(in: self)
     }
     
 }

--- a/Sources/Views/Cells/MediaMessageCell.swift
+++ b/Sources/Views/Cells/MediaMessageCell.swift
@@ -84,7 +84,7 @@ open class MediaMessageCell: MessageContentCell {
     
     /// Handle tap gesture on contentView and its subviews.
     open override func handleTapGesture(_ gesture: UIGestureRecognizer) {
-        let touchLocation = gesture.location(in: self)
+        let touchLocation = gesture.location(in: imageView)
         
         switch true {
         case imageView.frame.contains(touchLocation):


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The touchLocation set before is a wrong calculation if you want to compare it with ImageView's frame. Tapping in the middle of the image usually works, but if you tap in the edges, one of them won't work, especially if you have an image with very different width and height.

Does this close any currently open issues?
------------------------------------------
I don't think so.


Where has this been tested?
---------------------------
**Devices/Simulators:** Simulator - iPhone 11 Pro

**iOS Version:** iOS 13

**Swift Version:** 5

**MessageKit Version:** 3.1.0-beta.1


