### PR TITLE
Fix image view tap gesture handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
  
  - Fixed `requiredInitialScrollViewBottomInset` when `inputAccessoryView` is `nil` [#1218](https://github.com/MessageKit/MessageKit/pull/1218) by [@aabosh](https://github.com/aabosh) 
 
+ - Fixed `MessagesCollectionView.scrollToBottom(animated:)` method to properly handle calls made early in the view lifecycle. [#1110](https://github.com/MessageKit/MessageKit/pull/1110) by [@marcetcheverry](https://github.com/marcetcheverry)
+
 ### Added
 
 - Add missing textAlignment and textInsets assignments to layoutCellTopLabel method in MessageContentCell. [#1117](https://github.com/MessageKit/MessageKit/pull/1117) by [@mdescalzo](https://github.com/mdescalzo)
@@ -18,24 +20,27 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - Add loading indicator to AudioMessageCell. [#1084](https://github.com/MessageKit/MessageKit/pull/1084) by [@marcetcheverry](https://github.com/marcetcheverry)
 
-- Lazily initialize the MessageInputBar on MessagesViewController. [#1092](https://github.com/MessageKit/MessageKit/pull/1092) by [@marcetcheverry](https://github.com/marcetcheverry)
-
 - Add support for Dark Mode [#1189](https://github.com/MessageKit/MessageKit/pull/1189) by [@Vlada31R](https://github.com/Vlada31R)
 
-- Add support for `scrollToLastItem` and `scrollsToLastItemOnKeyboardBeginsEditing` [#1247](https://github.com/MessageKit/MessageKit/pull/1247) by [@youuu](https://github.com/youuu)
+- Add support for `scrollToLastItem` and `scrollsToLastItemOnKeyboardBeginsEditing` [#1247](https://github.com/MessageKit/MessageKit/pull/1247) by [@hyouuu](https://github.com/hyouuu)
+
+- Added `MessageCellDelegate.didTapImage(in cell: MessageCollectionViewCell)` [#1166](https://github.com/MessageKit/MessageKit/pull/1166) by [@domeniconicoli](https://github.com/domeniconicoli), [#1278](https://github.com/MessageKit/MessageKit/pull/1278) by [@bguidolim](https://github.com/bguidolim), [1285](https://github.com/MessageKit/MessageKit/pull/1285) by [@austinwright](https://github.com/austinwright)
+
+- Added missing cellTopLabelAlignment to MessageSizeCalculator. [#1113](https://github.com/MessageKit/MessageKit/pull/1113) by [@marcetcheverry](https://github.com/marcetcheverry)
 
 ### Changed
 
 - **Breaking Change** Updated to Swift 5.0 [#1039](https://github.com/MessageKit/MessageKit/pull/1039) by [@nathantannar4](https://github.com/nathantannar4)
 
-- Fixes scrollToBottom method to properly handle calls made early in the view lifecycle. [#1110](https://github.com/MessageKit/MessageKit/pull/1110) by [@marcetcheverry](https://github.com/marcetcheverry)
+- Lazily initialize the MessageInputBar on MessagesViewController. [#1092](https://github.com/MessageKit/MessageKit/pull/1092) by [@marcetcheverry](https://github.com/marcetcheverry)
 
-- Add missing cellTopLabelAlignment to MessageSizeCalculator. [#1113](https://github.com/MessageKit/MessageKit/pull/1113) by [@marcetcheverry](https://github.com/marcetcheverry)
+### Deprecated
 
-- **Breaking Change** `MessageInputBar`, and `MessageInputBarDelegate` have been obsoleted. Use`InputBarAccessoryView` and `InputBarAccessoryViewDelegate` respectively. This change was previously meant for 3.0.0 but was implemented erroneously. [#1201](https://github.com/MessageKit/MessageKit/pull/1201) by [@kinoroy](https://github.com/kinoroy)
+- Deprecated `SenderType.id` in favour of `SenderType.senderId`. This change was previously meant for 3.0.0. [#1201](https://github.com/MessageKit/MessageKit/pull/1201) by [@kinoroy](https://github.com/kinoroy)
 
-- Deprecated `SenderType.id` in favour of `SenderType.senderId`. This change was previously meant for 3.0.0 but
-  was implemented erroneously. [#1201](https://github.com/MessageKit/MessageKit/pull/1201) by [@kinoroy](https://github.com/kinoroy)
+### Removed
+
+- **Breaking Change** `MessageInputBar`, and `MessageInputBarDelegate` have been obsoleted. Use `InputBarAccessoryView` and `InputBarAccessoryViewDelegate` respectively. This change was previously meant for 3.0.0. [#1201](https://github.com/MessageKit/MessageKit/pull/1201) by [@kinoroy](https://github.com/kinoroy)
 
 ## 3.0.0
 

--- a/CHANGELOG_GUIDELINES.md
+++ b/CHANGELOG_GUIDELINES.md
@@ -12,7 +12,6 @@ Here you can find the general guidelines for maintaining the Changelog (or addin
 - Mention whether you follow Semantic Versioning.
 
 ... with MessageKit-specific additions:
-- Keep an unreleased section at the top.
 - Add PR number and a GitHub tag at the end of each entry.
 - Each breaking change entry should have **Breaking Change** label at the beginning of this entry.
 - **Breaking Change** entries should be placed at the top of the section it's in.

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - InputBarAccessoryView (4.3.1):
-    - InputBarAccessoryView/Core (= 4.3.1)
-  - InputBarAccessoryView/Core (4.3.1)
+  - InputBarAccessoryView (4.3.2):
+    - InputBarAccessoryView/Core (= 4.3.2)
+  - InputBarAccessoryView/Core (4.3.2)
   - MessageKit (3.1.0-beta.1):
     - InputBarAccessoryView (~> 4.3.0)
 
@@ -17,9 +17,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  InputBarAccessoryView: 58a348be7ea2736c7eec60e5c315511c2dbb39fd
+  InputBarAccessoryView: 7985d418040a05fe894bd4b8328dd43ab35517c3
   MessageKit: 6b809a162328346e0727dbcd040b5f9fd5f5ba15
 
 PODFILE CHECKSUM: 90bd12ca685503630d7fe716609f4974660ed5ee
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.0

--- a/Sources/Views/Cells/MediaMessageCell.swift
+++ b/Sources/Views/Cells/MediaMessageCell.swift
@@ -84,14 +84,13 @@ open class MediaMessageCell: MessageContentCell {
     
     /// Handle tap gesture on contentView and its subviews.
     open override func handleTapGesture(_ gesture: UIGestureRecognizer) {
-        let touchLocation = gesture.location(in: imageView)
-        
-        switch true {
-        case imageView.frame.contains(touchLocation):
-            delegate?.didTapImage(in: self)
-        default:
-            break
+        let touchLocation: CGPoint = convert(gesture.location(in: self), to: imageView)
+
+        guard imageView.bounds.contains(touchLocation) else {
+            super.handleTapGesture(gesture)
+            return
         }
+        delegate?.didTapImage(in: self)
     }
     
 }

--- a/Sources/Views/Cells/MediaMessageCell.swift
+++ b/Sources/Views/Cells/MediaMessageCell.swift
@@ -84,9 +84,9 @@ open class MediaMessageCell: MessageContentCell {
     
     /// Handle tap gesture on contentView and its subviews.
     open override func handleTapGesture(_ gesture: UIGestureRecognizer) {
-        let touchLocation: CGPoint = convert(gesture.location(in: self), to: imageView)
+        let touchLocation = gesture.location(in: imageView)
 
-        guard imageView.bounds.contains(touchLocation) else {
+        guard imageView.frame.contains(touchLocation) else {
             super.handleTapGesture(gesture)
             return
         }

--- a/Sources/Views/Cells/MediaMessageCell.swift
+++ b/Sources/Views/Cells/MediaMessageCell.swift
@@ -84,7 +84,7 @@ open class MediaMessageCell: MessageContentCell {
     
     /// Handle tap gesture on contentView and its subviews.
     open override func handleTapGesture(_ gesture: UIGestureRecognizer) {
-        let touchLocation = gesture.location(in: self)
+        let touchLocation = gesture.location(in: imageView)
         
         switch true {
         case imageView.frame.contains(touchLocation):


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
👻 🍕 Revise #1278.

Does this close any currently open issues?
------------------------------------------
No, but I confirmed this was a bug with the implementation of the new delegate API method `didTapImage`.


Any relevant logs, error output, etc?
-------------------------------------
I had plenty, but they are gone now. Easily reproducible if you are so inclined.

Any other comments?
-------------------
N/A

Where has this been tested?
---------------------------
**Devices/Simulators:** Simulator - iPhone 11 Pro Max

**iOS Version:** iOS 13

**Swift Version:** 5.0

**MessageKit Version:** 3.1.0-beta.1


