### PR TITLE
Disable Danger for development branch #trivial

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,6 +1,9 @@
 name: PR Danger
 
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   danger:


### PR DESCRIPTION
Danger right now doesn't work for forks, I'll spend some time debugging it this week, but for now failing PRs don't look good.