### PR TITLE
Add 3 new categorized issue templates #trivial

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,0 +1,49 @@
+---
+name: "\U0001F41B Bug report"
+about: Create a report to help us improve
+title: ''
+labels: bug?
+assignees: ''
+
+---
+
+<!--
+Hi, thanks so much for opening an issue! 🤗
+
+To better pinpoint (and solve) the issue you're experiencing, we could use some information on your behalf.
+-->
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps/code to reproduce the behavior:
+<!-- 
+If the bug can be reproduced in the MessageKit example app, this is really helpful to us!
+
+In some cases it can be really helpful to provide a short example of your code.
+If so, please wrap these code blocks in backticks, like this:
+
+```swift
+*your code goes here*
+```
+
+Please, *do not* submit screenshots of code, instead copy and paste it as above.
+ -->
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment**
+- What version of MessageKit are you using?
+- What version of iOS are you running on?
+- What version of Swift are you running on?
+- What device(s) are you testing on? Are these simulators?
+- Is the issue you're experiencing reproducible in the example app?
+
+**Additional context**
+Add any other context about the problem here.
+<!-- When referencing a dependency manager-related issue (think CocoaPods, Carthage, SwiftPM), please add its configuration file and version here. -->

--- a/.github/ISSUE_TEMPLATE/--feature-request.md
+++ b/.github/ISSUE_TEMPLATE/--feature-request.md
@@ -1,0 +1,22 @@
+---
+name: "\U0001F4A1Feature request"
+about: Suggest an idea for this project
+title: ''
+labels: feature request
+assignees: ''
+
+---
+
+<!-- Hey! Thanks so much for wanting to help improve MessageKit 😃 We always welcome PRs. If you would also be interested in implementing your feature request, please let us know! -->
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/--question-support.md
+++ b/.github/ISSUE_TEMPLATE/--question-support.md
@@ -1,0 +1,30 @@
+---
+name: "❓ Question/Support"
+about: Ask a question about how to use MessageKit
+title: ''
+labels: question
+assignees: ''
+
+---
+
+<!--
+🛑 Read this 🛑
+Before you open an issue. Please check the quick start guide, the FAQ, and the example project to see if your question is answered there (links in the README). Please also search through previous issues to see if your question was previously answered. 
+Also consider posting(/crossposting) your question to StackOverflow (with the tag 'messagekit').
+
+⚠️ If you need to include code, please wrap it in backticks so it will get Swift highlighting like this:
+```swift
+*your code goes here*
+```
+Please, do not upload screenshots of code.
+
+If relevant, please let us know the following things:
+
+- What version of MessageKit are you using?
+- What version of iOS are you running on?
+- What version of Swift are you running on?
+- What device(s) are you testing on? Are these simulators?
+- Is the issue you're experiencing reproducable in the example app?
+
+Please make sure your title describes your issue well. We will try our best to answer your question in a timely manner. Remember that this project is run by helpful volunteers, and we can't make any guarantees on turnaround time.
+-->

--- a/.github/ISSUE_TEMPLATE/--question-support.md
+++ b/.github/ISSUE_TEMPLATE/--question-support.md
@@ -9,7 +9,11 @@ assignees: ''
 
 <!--
 🛑 Read this 🛑
-Before you open an issue. Please check the quick start guide, the FAQ, and the example project to see if your question is answered there (links in the README). Please also search through previous issues to see if your question was previously answered. 
+Before you open an issue. Please check the following to see if your question is answered there: 
+  - The quick start guide: https://github.com/MessageKit/MessageKit/blob/master/Documentation/QuickStart.md 
+  - The FAQ: https://github.com/MessageKit/MessageKit/blob/master/Documentation/FAQs.md 
+  - The example project: https://github.com/MessageKit/MessageKit/tree/master/Example 
+Please also search through previous issues to see if your question was previously addressed. 
 Also consider posting(/crossposting) your question to StackOverflow (with the tag 'messagekit').
 
 ⚠️ If you need to include code, please wrap it in backticks so it will get Swift highlighting like this:


### PR DESCRIPTION
Our current issue template is a one-size-fits-all approach that could be improved by addressing the different needs of the 3 typical types of issues being: 

1. Bug reports (this is the type of issue that the current template is most designed for)
2. Feature requests 
3. Questions/Support

This PR creates 3 separate issue templates, allowing the user to select the template they would like to use when opening up their issue. By selecting the correct template, Github will also tag the issue with the appropriate label (‘bug?’, ‘feature request’, or ‘question’). This will help us sort through new issues with less triage. 