### PR TITLE
Use messagesKey instead of string

### DIFF
--- a/Example/Sources/Settings+UserDefaults.swift
+++ b/Example/Sources/Settings+UserDefaults.swift
@@ -31,12 +31,12 @@ extension UserDefaults {
     // MARK: - Mock Messages
     
     func setMockMessages(count: Int) {
-        set(count, forKey: "mockMessages")
+        set(count, forKey: messagesKey)
         synchronize()
     }
     
     func mockMessagesCount() -> Int {
-        if let value = object(forKey: "mockMessages") as? Int {
+        if let value = object(forKey: messagesKey) as? Int {
             return value
         }
         return 20


### PR DESCRIPTION


<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
messagesKey was initialized but not used

Does this close any currently open issues?
------------------------------------------
no


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:**
all
**iOS Version:** …
all
**Swift Version:** …
all
**MessageKit Version:** …
all

