### PR TITLE
Fix: unexpected animation when keyboard dismissing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ### Fixed
 
+- Fixes an incorrect animation of message cells while dragging to dismiss the keyboard by [@lhr000lhrmega](https://github.com/lhr000lhrmega)
+
 ### Added
 
 - Added option to use Photo messages with remote image URL in Example project [#1294](https://github.com/MessageKit/MessageKit/pull/1294) by [@martinpucik](https://github.com/martinpucik)
 - **Breaking Change** Added new `linkPreview` message type, which display a subclass of `TextMessageCell` with support to present title, teaser and a thumbnail image for a link [#1310](https://github.com/MessageKit/MessageKit/pull/1310) by [@bguidolim](https://github.com/bguidolim)
+
 ### Changed
 
 - **Breaking Change** Dropped support for iOS 9 and iOS 10 [#1261](https://github.com/MessageKit/MessageKit/pull/1261) by [@kaspik](https://github.com/kaspik)

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -100,7 +100,9 @@ internal extension MessagesViewController {
             messagesCollectionView.setContentOffset(contentOffset, animated: false)
         }
 
-        messageCollectionViewBottomInset = newBottomInset
+        UIView.performWithoutAnimation {
+            messageCollectionViewBottomInset = newBottomInset
+        }
     }
 
     // MARK: - Inset Computation


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
See #1406: Fixes incorrect animation of `messageCollectionViewBottomInset` when the keyboard is dismissed. Credit to @lhr000lhrmega for the idea for this fix.

Does this close any currently open issues?
------------------------------------------
Fixes #1406 

Where has this been tested?
---------------------------
**Devices/Simulators:** … iPhone 11 Pro Simulator

**iOS Version:** … iOS 13.6

**Swift Version:** … Swift 5

**MessageKit Version:** … 3.1.0

