### PR TITLE
Display message time by swiping left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - Fixes missing insets for link preview messages [#1447](https://github.com/MessageKit/MessageKit/pull/1447) by [@bguidolim](https://github.com/bguidolim)
 
 ### Added
-- show message time by swiping left over the chat controller. [#718] by @amirpirzad
+- Show message time by swiping left over the chat controller. [#1444](https://github.com/MessageKit/MessageKit/pull/1444) by [@amirpirzad](https://github.com/amirpirzad)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - Fixes missing insets for link preview messages [#1447](https://github.com/MessageKit/MessageKit/pull/1447) by [@bguidolim](https://github.com/bguidolim)
 
 ### Added
+- show message time by swiping left over the chat controller. [#718] by @amirpirzad
 
 ### Changed
 

--- a/Example/Sources/View Controllers/AdvancedExampleViewController.swift
+++ b/Example/Sources/View Controllers/AdvancedExampleViewController.swift
@@ -279,6 +279,19 @@ final class AdvancedExampleViewController: ChatViewController {
         return nil
     }
 
+    override func messageTimestampLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
+          let sentDate = message.sentDate
+          let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
+          let timeLabelFont: UIFont = .boldSystemFont(ofSize: 10)
+          let timeLabelColor: UIColor
+          if #available(iOS 13, *) {
+              timeLabelColor = .systemGray
+          } else {
+              timeLabelColor = .darkGray
+          }
+          return NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont, NSAttributedString.Key.foregroundColor: timeLabelColor])
+      }
+
 }
 
 // MARK: - MessagesDisplayDelegate

--- a/Example/Sources/View Controllers/AdvancedExampleViewController.swift
+++ b/Example/Sources/View Controllers/AdvancedExampleViewController.swift
@@ -278,20 +278,6 @@ final class AdvancedExampleViewController: ChatViewController {
         }
         return nil
     }
-
-    override func messageTimestampLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
-          let sentDate = message.sentDate
-          let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
-          let timeLabelFont: UIFont = .boldSystemFont(ofSize: 10)
-          let timeLabelColor: UIColor
-          if #available(iOS 13, *) {
-              timeLabelColor = .systemGray
-          } else {
-              timeLabelColor = .darkGray
-          }
-          return NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont, NSAttributedString.Key.foregroundColor: timeLabelColor])
-      }
-
 }
 
 // MARK: - MessagesDisplayDelegate

--- a/Example/Sources/View Controllers/AutocompleteExampleViewController.swift
+++ b/Example/Sources/View Controllers/AutocompleteExampleViewController.swift
@@ -187,19 +187,6 @@ final class AutocompleteExampleViewController: ChatViewController {
         return nil
     }
 
-    override func messageTimestampLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
-        let sentDate = message.sentDate
-        let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
-        let timeLabelFont: UIFont = .boldSystemFont(ofSize: 10)
-        let timeLabelColor: UIColor
-        if #available(iOS 13, *) {
-            timeLabelColor = .systemGray
-        } else {
-            timeLabelColor = .darkGray
-        }
-        return NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont, NSAttributedString.Key.foregroundColor: timeLabelColor])
-    }
-
     // Async autocomplete requires the manager to reload
     func inputBar(_ inputBar: InputBarAccessoryView, textViewTextDidChangeTo text: String) {
         guard autocompleteManager.currentSession != nil, autocompleteManager.currentSession?.prefix == "#" else { return }

--- a/Example/Sources/View Controllers/AutocompleteExampleViewController.swift
+++ b/Example/Sources/View Controllers/AutocompleteExampleViewController.swift
@@ -187,6 +187,19 @@ final class AutocompleteExampleViewController: ChatViewController {
         return nil
     }
 
+    override func messageTimestampLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
+        let sentDate = message.sentDate
+        let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
+        let timeLabelFont: UIFont = .boldSystemFont(ofSize: 10)
+        let timeLabelColor: UIColor
+        if #available(iOS 13, *) {
+            timeLabelColor = .systemGray
+        } else {
+            timeLabelColor = .darkGray
+        }
+        return NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont, NSAttributedString.Key.foregroundColor: timeLabelColor])
+    }
+
     // Async autocomplete requires the manager to reload
     func inputBar(_ inputBar: InputBarAccessoryView, textViewTextDidChangeTo text: String) {
         guard autocompleteManager.currentSession != nil, autocompleteManager.currentSession?.prefix == "#" else { return }

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -112,6 +112,8 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
         
         scrollsToBottomOnKeyboardBeginsEditing = true // default false
         maintainPositionOnKeyboardFrameChanged = true // default false
+
+        displayTimeBySwipingLeft = true
         
         messagesCollectionView.refreshControl = refreshControl
     }

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -188,19 +188,6 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
         let dateString = formatter.string(from: message.sentDate)
         return NSAttributedString(string: dateString, attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .caption2)])
     }
-
-    func messageTimestampLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
-        let sentDate = message.sentDate
-        let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
-        let timeLabelFont: UIFont = .boldSystemFont(ofSize: 10)
-        let timeLabelColor: UIColor
-        if #available(iOS 13, *) {
-            timeLabelColor = .systemGray
-        } else {
-            timeLabelColor = .darkGray
-        }
-        return NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont, NSAttributedString.Key.foregroundColor: timeLabelColor])
-    }
 }
 
 // MARK: - MessageCellDelegate

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -113,7 +113,7 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
         scrollsToBottomOnKeyboardBeginsEditing = true // default false
         maintainPositionOnKeyboardFrameChanged = true // default false
 
-        displayTimeBySwipingLeft = true // default false
+        showMessageTimestampOnSwipeLeft = true // default false
         
         messagesCollectionView.refreshControl = refreshControl
     }
@@ -187,6 +187,19 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
     func messageBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
         let dateString = formatter.string(from: message.sentDate)
         return NSAttributedString(string: dateString, attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .caption2)])
+    }
+
+    func messageTimestampLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
+        let sentDate = message.sentDate
+        let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
+        let timeLabelFont: UIFont = .boldSystemFont(ofSize: 10)
+        let timeLabelColor: UIColor
+        if #available(iOS 13, *) {
+            timeLabelColor = .systemGray
+        } else {
+            timeLabelColor = .darkGray
+        }
+        return NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont, NSAttributedString.Key.foregroundColor: timeLabelColor])
     }
 }
 

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -113,7 +113,7 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
         scrollsToBottomOnKeyboardBeginsEditing = true // default false
         maintainPositionOnKeyboardFrameChanged = true // default false
 
-        displayTimeBySwipingLeft = true
+        displayTimeBySwipingLeft = true // default false
         
         messagesCollectionView.refreshControl = refreshControl
     }

--- a/Example/Sources/Views/SwiftUI/MessagesView.swift
+++ b/Example/Sources/Views/SwiftUI/MessagesView.swift
@@ -34,6 +34,7 @@ struct MessagesView: UIViewControllerRepresentable {
         messagesVC.messageInputBar.delegate = context.coordinator
         messagesVC.scrollsToBottomOnKeyboardBeginsEditing = true // default false
         messagesVC.maintainPositionOnKeyboardFrameChanged = true // default false
+        messagesVC.showMessageTimestampOnSwipeLeft = true // default false
         
         return messagesVC
     }
@@ -94,6 +95,14 @@ extension MessagesView.Coordinator: MessagesDataSource {
     func messageBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
         let dateString = formatter.string(from: message.sentDate)
         return NSAttributedString(string: dateString, attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .caption2)])
+    }
+
+    func messageTimestampLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
+        let sentDate = message.sentDate
+        let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
+        let timeLabelFont: UIFont = .boldSystemFont(ofSize: 10)
+        let timeLabelColor: UIColor = .systemGray
+        return NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont, NSAttributedString.Key.foregroundColor: timeLabelColor])
     }
 }
 

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -167,7 +167,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
         case .began, .changed:
             messagesCollectionView.showsVerticalScrollIndicator = false
             let translation = gesture.translation(in: view)
-            let minX = -(view.frame.size.width * 0.3)
+            let minX = -(view.frame.size.width * 0.4)
             let maxX: CGFloat = 0
             var offsetValue = translation.x
             offsetValue = max(offsetValue, minX)

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -60,6 +60,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
     /// The default value of this property is `false`.
     open var displayTimeBySwipingLeft: Bool = false {
         didSet {
+            messagesCollectionView.displayTimeBySwipingLeft = displayTimeBySwipingLeft
             if displayTimeBySwipingLeft {
                 addPanGesture()
             } else {

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -56,6 +56,14 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
     /// The default value of this property is `false`.
     open var maintainPositionOnKeyboardFrameChanged: Bool = false
 
+    /// Display the date of message by swiping left.
+    /// The default value of this property is `false`.
+    open var displayTimeBySwipingLeft: Bool = false {
+        didSet {
+            addPanGesture()
+        }
+    }
+
     open override var canBecomeFirstResponder: Bool {
         return true
     }
@@ -102,7 +110,6 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
         super.viewDidLoad()
         setupDefaults()
         setupSubviews()
-        addPanGesture()
         setupConstraints()
         setupDelegates()
         addMenuControllerObservers()
@@ -151,6 +158,9 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
 
     /// Display time of message by swiping the cell
     private func addPanGesture() {
+        guard displayTimeBySwipingLeft else {
+            return
+        }
         let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture(_:)))
         panGesture.delegate = self
         messagesCollectionView.addGestureRecognizer(panGesture)
@@ -167,7 +177,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
         case .began, .changed:
             messagesCollectionView.showsVerticalScrollIndicator = false
             let translation = gesture.translation(in: view)
-            let minX = -(view.frame.size.width * 0.4)
+            let minX = -(view.frame.size.width * 0.35)
             let maxX: CGFloat = 0
             var offsetValue = translation.x
             offsetValue = max(offsetValue, minX)

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -60,9 +60,16 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
     /// The default value of this property is `false`.
     open var displayTimeBySwipingLeft: Bool = false {
         didSet {
-            addPanGesture()
+            if displayTimeBySwipingLeft {
+                addPanGesture()
+            } else {
+                removePanGesture()
+            }
         }
     }
+
+    /// Pan gesture for display the date of message by swiping left.
+    private var panGesture: UIPanGestureRecognizer?
 
     open override var canBecomeFirstResponder: Bool {
         return true
@@ -158,13 +165,23 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
 
     /// Display time of message by swiping the cell
     private func addPanGesture() {
-        guard displayTimeBySwipingLeft else {
+        panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture(_:)))
+        guard let panGesture = panGesture else {
             return
         }
-        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture(_:)))
         panGesture.delegate = self
         messagesCollectionView.addGestureRecognizer(panGesture)
         messagesCollectionView.clipsToBounds = false
+    }
+
+    private func removePanGesture() {
+        guard let panGesture = panGesture else {
+            return
+        }
+        panGesture.delegate = nil
+        self.panGesture = nil
+        messagesCollectionView.removeGestureRecognizer(panGesture)
+        messagesCollectionView.clipsToBounds = true
     }
 
     @objc

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -28,7 +28,7 @@ import InputBarAccessoryView
 /// A subclass of `UIViewController` with a `MessagesCollectionView` object
 /// that is used to display conversation interfaces.
 open class MessagesViewController: UIViewController,
-UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
+UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecognizerDelegate {
 
     /// The `MessagesCollectionView` managed by the messages view controller object.
     open var messagesCollectionView = MessagesCollectionView()
@@ -152,6 +152,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
     /// Display time of message by swiping the cell
     private func addPanGesture() {
         let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture(_:)))
+        panGesture.delegate = self
         messagesCollectionView.addGestureRecognizer(panGesture)
         messagesCollectionView.clipsToBounds = false
     }
@@ -164,7 +165,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
 
         switch gesture.state {
         case .began, .changed:
-            // show time
+            messagesCollectionView.showsVerticalScrollIndicator = false
             let translation = gesture.translation(in: view)
             let minX = -(view.frame.size.width * 0.3)
             let maxX: CGFloat = 0
@@ -173,7 +174,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
             offsetValue = min(offsetValue, maxX)
             parentView.frame.origin.x = offsetValue
         case .ended:
-            // hide time
+            messagesCollectionView.showsVerticalScrollIndicator = true
             UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 0.8, options: .curveEaseOut, animations: {
                 parentView.frame.origin.x = 0
             }, completion: nil)
@@ -453,5 +454,16 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
     
     @objc private func clearMemoryCache() {
         MessageStyle.bubbleImageCache.removeAllObjects()
+    }
+
+    // MARK: - UIGestureRecognizerDelegate
+
+    /// check pan gesture direction
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard let panGesture = gestureRecognizer as? UIPanGestureRecognizer else {
+            return false
+        }
+        let velocity = panGesture.velocity(in: messagesCollectionView)
+        return abs(velocity.x) > abs(velocity.y)
     }
 }

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -102,6 +102,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
         super.viewDidLoad()
         setupDefaults()
         setupSubviews()
+        addPanGesture()
         setupConstraints()
         setupDelegates()
         addMenuControllerObservers()
@@ -147,6 +148,39 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
     }
 
     // MARK: - Methods [Private]
+
+    /// Display time of message by swiping the cell
+    private func addPanGesture() {
+        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture(_:)))
+        messagesCollectionView.addGestureRecognizer(panGesture)
+        messagesCollectionView.clipsToBounds = false
+    }
+
+    @objc
+    private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
+        guard let parentView = gesture.view else {
+            return
+        }
+
+        switch gesture.state {
+        case .began, .changed:
+            // show time
+            let translation = gesture.translation(in: view)
+            let minX = -(view.frame.size.width * 0.3)
+            let maxX: CGFloat = 0
+            var offsetValue = translation.x
+            offsetValue = max(offsetValue, minX)
+            offsetValue = min(offsetValue, maxX)
+            parentView.frame.origin.x = offsetValue
+        case .ended:
+            // hide time
+            UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 0.8, options: .curveEaseOut, animations: {
+                parentView.frame.origin.x = 0
+            }, completion: nil)
+        default:
+            break
+        }
+    }
 
     private func setupDefaults() {
         extendedLayoutIncludesOpaqueBars = true

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -58,10 +58,10 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
 
     /// Display the date of message by swiping left.
     /// The default value of this property is `false`.
-    open var displayTimeBySwipingLeft: Bool = false {
+    open var showMessageTimestampOnSwipeLeft: Bool = false {
         didSet {
-            messagesCollectionView.displayTimeBySwipingLeft = displayTimeBySwipingLeft
-            if displayTimeBySwipingLeft {
+            messagesCollectionView.showMessageTimestampOnSwipeLeft = showMessageTimestampOnSwipeLeft
+            if showMessageTimestampOnSwipeLeft {
                 addPanGesture()
             } else {
                 removePanGesture()

--- a/Sources/Layout/MessageSizeCalculator.swift
+++ b/Sources/Layout/MessageSizeCalculator.swift
@@ -202,12 +202,11 @@ open class MessageSizeCalculator: CellSizeCalculator {
     // MARK: - Message time label
 
     open func messageTimeLabelSize(for message: MessageType, at indexPath: IndexPath) -> CGSize {
-        let sentDate = message.sentDate
-        let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
-        let timeLabelFont : UIFont = .boldSystemFont(ofSize: 10)
-        let timeLabelText =
-            NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont])
-        let size = timeLabelText.size()
+        let dataSource = messagesLayout.messagesDataSource
+        guard let attributedText = dataSource.messageTimestampLabelAttributedText(for: message, at: indexPath) else {
+            return .zero
+        }
+        let size = attributedText.size()
         return CGSize(width: size.width, height: size.height)
     }
 

--- a/Sources/Layout/MessageSizeCalculator.swift
+++ b/Sources/Layout/MessageSizeCalculator.swift
@@ -81,6 +81,7 @@ open class MessageSizeCalculator: CellSizeCalculator {
         attributes.cellTopLabelSize = cellTopLabelSize(for: message, at: indexPath)
         attributes.cellTopLabelAlignment = cellTopLabelAlignment(for: message)
         attributes.cellBottomLabelSize = cellBottomLabelSize(for: message, at: indexPath)
+        attributes.messageTimeLabelSize = messageTimeLabelSize(for: message, at: indexPath)
         attributes.cellBottomLabelAlignment = cellBottomLabelAlignment(for: message)
         attributes.messageTopLabelSize = messageTopLabelSize(for: message, at: indexPath)
         attributes.messageTopLabelAlignment = messageTopLabelAlignment(for: message)
@@ -197,7 +198,20 @@ open class MessageSizeCalculator: CellSizeCalculator {
         let isFromCurrentSender = dataSource.isFromCurrentSender(message: message)
         return isFromCurrentSender ? outgoingMessageTopLabelAlignment : incomingMessageTopLabelAlignment
     }
-    
+
+    // MARK: - Message time label
+
+    open func messageTimeLabelSize(for message: MessageType, at indexPath: IndexPath) -> CGSize {
+        let sentDate = message.sentDate
+        let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
+        let timeLabelFont : UIFont = .boldSystemFont(ofSize: 10)
+        let timeLabelColor: UIColor = .darkGray
+        let timeLabelText =
+            NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont, NSAttributedString.Key.foregroundColor: timeLabelColor])
+        let size = timeLabelText.size()
+        return CGSize(width: size.width, height: size.height)
+    }
+
     // MARK: - Bottom cell Label
     
     open func cellBottomLabelSize(for message: MessageType, at indexPath: IndexPath) -> CGSize {

--- a/Sources/Layout/MessageSizeCalculator.swift
+++ b/Sources/Layout/MessageSizeCalculator.swift
@@ -205,9 +205,8 @@ open class MessageSizeCalculator: CellSizeCalculator {
         let sentDate = message.sentDate
         let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
         let timeLabelFont : UIFont = .boldSystemFont(ofSize: 10)
-        let timeLabelColor: UIColor = .darkGray
         let timeLabelText =
-            NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont, NSAttributedString.Key.foregroundColor: timeLabelColor])
+            NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont])
         let size = timeLabelText.size()
         return CGSize(width: size.width, height: size.height)
     }

--- a/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
+++ b/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
@@ -50,6 +50,8 @@ open class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttribu
     public var messageBottomLabelAlignment = LabelAlignment(textAlignment: .center, textInsets: .zero)
     public var messageBottomLabelSize: CGSize = .zero
 
+    public var messageTimeLabelSize: CGSize = .zero
+
     public var accessoryViewSize: CGSize = .zero
     public var accessoryViewPadding: HorizontalEdgeInsets = .zero
     public var accessoryViewPosition: AccessoryPosition = .messageCenter
@@ -74,6 +76,7 @@ open class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttribu
         copy.cellTopLabelSize = cellTopLabelSize
         copy.cellBottomLabelAlignment = cellBottomLabelAlignment
         copy.cellBottomLabelSize = cellBottomLabelSize
+        copy.messageTimeLabelSize = messageTimeLabelSize
         copy.messageTopLabelAlignment = messageTopLabelAlignment
         copy.messageTopLabelSize = messageTopLabelSize
         copy.messageBottomLabelAlignment = messageBottomLabelAlignment
@@ -100,6 +103,7 @@ open class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttribu
                 && attributes.cellTopLabelSize == cellTopLabelSize
                 && attributes.cellBottomLabelAlignment == cellBottomLabelAlignment
                 && attributes.cellBottomLabelSize == cellBottomLabelSize
+                && attributes.messageTimeLabelSize == messageTimeLabelSize
                 && attributes.messageTopLabelAlignment == messageTopLabelAlignment
                 && attributes.messageTopLabelSize == messageTopLabelSize
                 && attributes.messageBottomLabelAlignment == messageBottomLabelAlignment

--- a/Sources/Protocols/MessagesDataSource.swift
+++ b/Sources/Protocols/MessagesDataSource.swift
@@ -102,6 +102,17 @@ public protocol MessagesDataSource: AnyObject {
     ///
     /// The default value returned by this method is `nil`.
     func messageBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString?
+
+    /// The attributed text to be used for cell's timestamp label.
+    ///
+    /// - Parameters:
+    ///   - message: The `MessageType` that will be displayed by this cell.
+    ///   - indexPath: The `IndexPath` of the cell.
+    ///   - messagesCollectionView: The `MessagesCollectionView` in which this cell will be displayed.
+    ///
+    /// The default value returned by this method is `nil`.
+    func messageTimestampLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString?
+
     
     /// Custom collectionView cell for message with `custom` message type.
     ///

--- a/Sources/Protocols/MessagesDataSource.swift
+++ b/Sources/Protocols/MessagesDataSource.swift
@@ -104,6 +104,7 @@ public protocol MessagesDataSource: AnyObject {
     func messageBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString?
 
     /// The attributed text to be used for cell's timestamp label.
+    /// The timestamp label is shown when showMessageTimestampOnSwipeLeft is enabled by swiping left over the chat controller.
     ///
     /// - Parameters:
     ///   - message: The `MessageType` that will be displayed by this cell.

--- a/Sources/Protocols/MessagesDataSource.swift
+++ b/Sources/Protocols/MessagesDataSource.swift
@@ -159,7 +159,20 @@ public extension MessagesDataSource {
     func messageBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
         return nil
     }
-    
+
+    func messageTimestampLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
+        let sentDate = message.sentDate
+        let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
+        let timeLabelFont: UIFont = .boldSystemFont(ofSize: 10)
+        let timeLabelColor: UIColor
+        if #available(iOS 13, *) {
+            timeLabelColor = .systemGray
+        } else {
+            timeLabelColor = .darkGray
+        }
+        return NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont, NSAttributedString.Key.foregroundColor: timeLabelColor])
+    }
+
     func customCell(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UICollectionViewCell {
         fatalError(MessageKitError.customDataUnresolvedCell)
     }

--- a/Sources/Views/Cells/MessageContentCell.swift
+++ b/Sources/Views/Cells/MessageContentCell.swift
@@ -160,7 +160,10 @@ open class MessageContentCell: MessageCollectionViewCell {
         let sentDate = message.sentDate
         let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
         let timeLabelFont : UIFont = .boldSystemFont(ofSize: 10)
-        let timeLabelColor: UIColor = .darkGray
+        var timeLabelColor: UIColor = .darkGray
+        if #available(iOS 12.0, *), traitCollection.userInterfaceStyle == .dark {
+            timeLabelColor = .white
+        }
         let timeLabelText =
         NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont, NSAttributedString.Key.foregroundColor: timeLabelColor])
 

--- a/Sources/Views/Cells/MessageContentCell.swift
+++ b/Sources/Views/Cells/MessageContentCell.swift
@@ -371,7 +371,7 @@ open class MessageContentCell: MessageCollectionViewCell {
     /// - attributes: The `MessagesCollectionViewLayoutAttributes` for the cell.
     open func layoutTimeLabelView(with attributes: MessagesCollectionViewLayoutAttributes) {
         let paddingLeft: CGFloat = 10
-        let origin = CGPoint(x: contentView.frame.size.width + paddingLeft, y: 0)
+        let origin = CGPoint(x: contentView.frame.size.width + paddingLeft, y: contentView.frame.size.height * 0.5)
         let size = CGSize(width: attributes.messageTimeLabelSize.width, height: attributes.messageTimeLabelSize.height)
         timeLabel.frame = CGRect(origin: origin, size: size)
     }

--- a/Sources/Views/Cells/MessageContentCell.swift
+++ b/Sources/Views/Cells/MessageContentCell.swift
@@ -176,7 +176,7 @@ open class MessageContentCell: MessageCollectionViewCell {
         timeLabel.attributedText = timeLabelText
 
         messageBottomLabel.isHidden = messagesCollectionView.displayTimeBySwipingLeft
-        timeLabel.isHidden = !messageBottomLabel.isHidden
+        timeLabel.isHidden = !messagesCollectionView.displayTimeBySwipingLeft
     }
 
     /// Handle tap gesture on contentView and its subviews.

--- a/Sources/Views/Cells/MessageContentCell.swift
+++ b/Sources/Views/Cells/MessageContentCell.swift
@@ -169,6 +169,10 @@ open class MessageContentCell: MessageCollectionViewCell {
         messageTopLabel.attributedText = topMessageLabelText
         messageBottomLabel.attributedText = bottomMessageLabelText
         timeLabel.attributedText = timeLabelText
+
+        let displayTimeBySwipingLeft = messagesCollectionView.clipsToBounds == false
+        messageBottomLabel.isHidden = displayTimeBySwipingLeft
+        timeLabel.isHidden = !displayTimeBySwipingLeft
     }
 
     /// Handle tap gesture on contentView and its subviews.

--- a/Sources/Views/Cells/MessageContentCell.swift
+++ b/Sources/Views/Cells/MessageContentCell.swift
@@ -70,7 +70,7 @@ open class MessageContentCell: MessageCollectionViewCell {
     }()
 
     /// The time label of the messageBubble.
-    open var timeLabel: InsetLabel = InsetLabel()
+    open var messageTimestampLabel: InsetLabel = InsetLabel()
 
     // Should only add customized subviews - don't change accessoryView itself.
     open var accessoryView: UIView = UIView()
@@ -98,7 +98,7 @@ open class MessageContentCell: MessageCollectionViewCell {
         contentView.addSubview(cellBottomLabel)
         contentView.addSubview(messageContainerView)
         contentView.addSubview(avatarView)
-        contentView.addSubview(timeLabel)
+        contentView.addSubview(messageTimestampLabel)
     }
 
     open override func prepareForReuse() {
@@ -107,7 +107,7 @@ open class MessageContentCell: MessageCollectionViewCell {
         cellBottomLabel.text = nil
         messageTopLabel.text = nil
         messageBottomLabel.text = nil
-        timeLabel.attributedText = nil
+        messageTimestampLabel.attributedText = nil
     }
 
     // MARK: - Configuration
@@ -156,27 +156,13 @@ open class MessageContentCell: MessageCollectionViewCell {
         let bottomCellLabelText = dataSource.cellBottomLabelAttributedText(for: message, at: indexPath)
         let topMessageLabelText = dataSource.messageTopLabelAttributedText(for: message, at: indexPath)
         let bottomMessageLabelText = dataSource.messageBottomLabelAttributedText(for: message, at: indexPath)
-
-        let sentDate = message.sentDate
-        let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
-        let timeLabelFont : UIFont = .boldSystemFont(ofSize: 10)
-        let timeLabelColor: UIColor
-        if #available(iOS 13, *) {
-            timeLabelColor = .systemGray
-        } else {
-            timeLabelColor = .darkGray
-        }
-        let timeLabelText =
-        NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont, NSAttributedString.Key.foregroundColor: timeLabelColor])
-
+        let messageTimestampLabelText = dataSource.messageTimestampLabelAttributedText(for: message, at: indexPath)
         cellTopLabel.attributedText = topCellLabelText
         cellBottomLabel.attributedText = bottomCellLabelText
         messageTopLabel.attributedText = topMessageLabelText
         messageBottomLabel.attributedText = bottomMessageLabelText
-        timeLabel.attributedText = timeLabelText
-
-        messageBottomLabel.isHidden = messagesCollectionView.displayTimeBySwipingLeft
-        timeLabel.isHidden = !messagesCollectionView.displayTimeBySwipingLeft
+        messageTimestampLabel.attributedText = messageTimestampLabelText
+        messageTimestampLabel.isHidden = !messagesCollectionView.showMessageTimestampOnSwipeLeft
     }
 
     /// Handle tap gesture on contentView and its subviews.
@@ -373,6 +359,6 @@ open class MessageContentCell: MessageCollectionViewCell {
         let paddingLeft: CGFloat = 10
         let origin = CGPoint(x: contentView.frame.size.width + paddingLeft, y: contentView.frame.size.height * 0.5)
         let size = CGSize(width: attributes.messageTimeLabelSize.width, height: attributes.messageTimeLabelSize.height)
-        timeLabel.frame = CGRect(origin: origin, size: size)
+        messageTimestampLabel.frame = CGRect(origin: origin, size: size)
     }
 }

--- a/Sources/Views/Cells/MessageContentCell.swift
+++ b/Sources/Views/Cells/MessageContentCell.swift
@@ -173,9 +173,8 @@ open class MessageContentCell: MessageCollectionViewCell {
         messageBottomLabel.attributedText = bottomMessageLabelText
         timeLabel.attributedText = timeLabelText
 
-        let displayTimeBySwipingLeft = messagesCollectionView.clipsToBounds == false
-        messageBottomLabel.isHidden = displayTimeBySwipingLeft
-        timeLabel.isHidden = !displayTimeBySwipingLeft
+        messageBottomLabel.isHidden = messagesCollectionView.displayTimeBySwipingLeft
+        timeLabel.isHidden = !messageBottomLabel.isHidden
     }
 
     /// Handle tap gesture on contentView and its subviews.

--- a/Sources/Views/Cells/MessageContentCell.swift
+++ b/Sources/Views/Cells/MessageContentCell.swift
@@ -160,9 +160,11 @@ open class MessageContentCell: MessageCollectionViewCell {
         let sentDate = message.sentDate
         let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
         let timeLabelFont : UIFont = .boldSystemFont(ofSize: 10)
-        var timeLabelColor: UIColor = .darkGray
-        if #available(iOS 12.0, *), traitCollection.userInterfaceStyle == .dark {
-            timeLabelColor = .white
+        let timeLabelColor: UIColor
+        if #available(iOS 13, *) {
+            timeLabelColor = .systemGray
+        } else {
+            timeLabelColor = .darkGray
         }
         let timeLabelText =
         NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont, NSAttributedString.Key.foregroundColor: timeLabelColor])

--- a/Sources/Views/Cells/MessageContentCell.swift
+++ b/Sources/Views/Cells/MessageContentCell.swift
@@ -69,6 +69,9 @@ open class MessageContentCell: MessageCollectionViewCell {
         return label
     }()
 
+    /// The time label of the messageBubble.
+    open var timeLabel: InsetLabel = InsetLabel()
+
     // Should only add customized subviews - don't change accessoryView itself.
     open var accessoryView: UIView = UIView()
 
@@ -95,6 +98,7 @@ open class MessageContentCell: MessageCollectionViewCell {
         contentView.addSubview(cellBottomLabel)
         contentView.addSubview(messageContainerView)
         contentView.addSubview(avatarView)
+        contentView.addSubview(timeLabel)
     }
 
     open override func prepareForReuse() {
@@ -103,6 +107,7 @@ open class MessageContentCell: MessageCollectionViewCell {
         cellBottomLabel.text = nil
         messageTopLabel.text = nil
         messageBottomLabel.text = nil
+        timeLabel.attributedText = nil
     }
 
     // MARK: - Configuration
@@ -118,6 +123,7 @@ open class MessageContentCell: MessageCollectionViewCell {
         layoutMessageTopLabel(with: attributes)
         layoutAvatarView(with: attributes)
         layoutAccessoryView(with: attributes)
+        layoutTimeLabelView(with: attributes)
     }
 
     /// Used to configure the cell.
@@ -151,10 +157,18 @@ open class MessageContentCell: MessageCollectionViewCell {
         let topMessageLabelText = dataSource.messageTopLabelAttributedText(for: message, at: indexPath)
         let bottomMessageLabelText = dataSource.messageBottomLabelAttributedText(for: message, at: indexPath)
 
+        let sentDate = message.sentDate
+        let sentDateString = MessageKitDateFormatter.shared.string(from: sentDate)
+        let timeLabelFont : UIFont = .boldSystemFont(ofSize: 10)
+        let timeLabelColor: UIColor = .darkGray
+        let timeLabelText =
+        NSAttributedString(string: sentDateString, attributes: [NSAttributedString.Key.font: timeLabelFont, NSAttributedString.Key.foregroundColor: timeLabelColor])
+
         cellTopLabel.attributedText = topCellLabelText
         cellBottomLabel.attributedText = bottomCellLabelText
         messageTopLabel.attributedText = topMessageLabelText
         messageBottomLabel.attributedText = bottomMessageLabelText
+        timeLabel.attributedText = timeLabelText
     }
 
     /// Handle tap gesture on contentView and its subviews.
@@ -343,5 +357,14 @@ open class MessageContentCell: MessageCollectionViewCell {
         }
 
         accessoryView.frame = CGRect(origin: origin, size: attributes.accessoryViewSize)
+    }
+
+    ///  Positions the message bubble's time label.
+    /// - attributes: The `MessagesCollectionViewLayoutAttributes` for the cell.
+    open func layoutTimeLabelView(with attributes: MessagesCollectionViewLayoutAttributes) {
+        let paddingLeft: CGFloat = 10
+        let origin = CGPoint(x: contentView.frame.size.width + paddingLeft, y: 0)
+        let size = CGSize(width: attributes.messageTimeLabelSize.width, height: attributes.messageTimeLabelSize.height)
+        timeLabel.frame = CGRect(origin: origin, size: size)
     }
 }

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -43,7 +43,7 @@ open class MessagesCollectionView: UICollectionView {
 
     /// Display the date of message by swiping left.
     /// The default value of this property is `false`.
-    open var displayTimeBySwipingLeft: Bool = false
+    internal var showMessageTimestampOnSwipeLeft: Bool = false
 
     private var indexPathForLastItem: IndexPath? {
         let lastSection = numberOfSections - 1

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -41,6 +41,10 @@ open class MessagesCollectionView: UICollectionView {
         return messagesCollectionViewFlowLayout.isTypingIndicatorViewHidden
     }
 
+    /// Display the date of message by swiping left.
+    /// The default value of this property is `false`.
+    open var displayTimeBySwipingLeft: Bool = false
+
     private var indexPathForLastItem: IndexPath? {
         let lastSection = numberOfSections - 1
         guard lastSection >= 0, numberOfItems(inSection: lastSection) > 0 else { return nil }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Display message time by swiping left, similar to Instagram and iMessage.

Does this close any currently open issues?
------------------------------------------
#718 

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 11 and simulators

**iOS Version:** 13.3

**Swift Version:** 5

**MessageKit Version:** 4.0


**Light**
![image](https://user-images.githubusercontent.com/10138423/91660961-3cb78e80-eaee-11ea-9937-b45d62c7afbc.png)


**Dark**
![image](https://user-images.githubusercontent.com/10138423/91660973-522cb880-eaee-11ea-9d4a-e104e46d543f.png)

