### PR TITLE
Calling the delegate at the end of configure audio cell

### DIFF
--- a/Sources/Views/Cells/AudioMessageCell.swift
+++ b/Sources/Views/Cells/AudioMessageCell.swift
@@ -131,11 +131,11 @@ open class AudioMessageCell: MessageContentCell {
         playButton.imageView?.tintColor = tintColor
         durationLabel.textColor = tintColor
         progressView.tintColor = tintColor
-
-        displayDelegate.configureAudioCell(self, message: message)
-
+        
         if case let .audio(audioItem) = message.kind {
             durationLabel.text = displayDelegate.audioProgressTextFormat(audioItem.duration, for: self, in: messagesCollectionView)
         }
+
+        displayDelegate.configureAudioCell(self, message: message)
     }
 }


### PR DESCRIPTION
This fix the fact that the duration text is being override if is also inserted in the delegate method, creating sometimes a glitch or not updating properly the cell.

Tested in iOS 14


