### PR TITLE
fix timestamp label origin in landscape orientation

### DIFF
--- a/Sources/Views/Cells/MessageContentCell.swift
+++ b/Sources/Views/Cells/MessageContentCell.swift
@@ -357,7 +357,7 @@ open class MessageContentCell: MessageCollectionViewCell {
     /// - attributes: The `MessagesCollectionViewLayoutAttributes` for the cell.
     open func layoutTimeLabelView(with attributes: MessagesCollectionViewLayoutAttributes) {
         let paddingLeft: CGFloat = 10
-        let origin = CGPoint(x: contentView.frame.size.width + paddingLeft, y: contentView.frame.size.height * 0.5)
+        let origin = CGPoint(x: UIScreen.main.bounds.width + paddingLeft, y: contentView.frame.size.height * 0.5)
         let size = CGSize(width: attributes.messageTimeLabelSize.width, height: attributes.messageTimeLabelSize.height)
         messageTimestampLabel.frame = CGRect(origin: origin, size: size)
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
fix timestamp label origin in landscape orientation

Does this close any currently open issues?
------------------------------------------
#1497



<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->
Where has this been tested?
---------------------------
**Devices/Simulators:** All iPhone Devices

**iOS Version:** 14

**Swift Version:** 5

**MessageKit Version:** 3.4.2


