### PR TITLE
Deprecated scrollToBottom() in favor of scrollToLastItem()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 ### Changed
 
 - Changed `resources` to `resource_bundle` in MessageKit.podspec [#1460](https://github.com/MessageKit/MessageKit/pull/1460) by [@martinpucik](https://github.com/martinpucik)
+- Changed dependency manager for Example project to SPM [#1504](https://github.com/MessageKit/MessageKit/pull/1504) by [@martinpucik](https://github.com/martinpucik)
+- Deprecated `messagesCollectionView.scrollToBottom` and `scrollsToBottomOnKeyboardBeginsEditing` in favor of `messagesCollectionView.scrollToLastItem` and `scrollsToLastItemOnKeyboardBeginsEditing`. This will be removed in a future release [#1505](https://github.com/MessageKit/MessageKit/pull/1505) by [@martinpucik](https://github.com/martinpucik)
 
 ### Removed
 

--- a/Example/Sources/View Controllers/AdvancedExampleViewController.swift
+++ b/Example/Sources/View Controllers/AdvancedExampleViewController.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017-2019 MessageKit
+ Copyright (c) 2017-2020 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -60,7 +60,7 @@ final class AdvancedExampleViewController: ChatViewController {
                 DispatchQueue.main.async {
                     self.messageList = messages
                     self.messagesCollectionView.reloadData()
-                    self.messagesCollectionView.scrollToBottom()
+                    self.messagesCollectionView.scrollToLastItem()
                 }
             }
         }
@@ -202,7 +202,7 @@ final class AdvancedExampleViewController: ChatViewController {
         updateTitleView(title: "MessageKit", subtitle: isHidden ? "2 Online" : "Typing...")
         setTypingIndicatorViewHidden(isHidden, animated: true, whilePerforming: updates) { [weak self] success in
             if success, self?.isLastSectionVisible() == true {
-                self?.messagesCollectionView.scrollToBottom(animated: true)
+                self?.messagesCollectionView.scrollToLastItem(animated: true)
             }
         }
     }

--- a/Example/Sources/View Controllers/AutocompleteExampleViewController.swift
+++ b/Example/Sources/View Controllers/AutocompleteExampleViewController.swift
@@ -1,10 +1,26 @@
-//
-//  AutocompleteExampleViewController.swift
-//  ChatExample
-//
-//  Created by Nathan Tannar on 2019-04-05.
-//  Copyright © 2019 MessageKit. All rights reserved.
-//
+/*
+ MIT License
+
+ Copyright (c) 2017-2020 MessageKit
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
 
 import UIKit
 import MessageKit
@@ -141,7 +157,7 @@ final class AutocompleteExampleViewController: ChatViewController {
     func setTypingIndicatorViewHidden(_ isHidden: Bool, performUpdates updates: (() -> Void)? = nil) {
         setTypingIndicatorViewHidden(isHidden, animated: true, whilePerforming: updates) { [weak self] success in
             if success, self?.isLastSectionVisible() == true {
-                self?.messagesCollectionView.scrollToBottom(animated: true)
+                self?.messagesCollectionView.scrollToLastItem(animated: true)
             }
         }
     }

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -87,7 +87,7 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
                 DispatchQueue.main.async {
                     self.messageList = messages
                     self.messagesCollectionView.reloadData()
-                    self.messagesCollectionView.scrollToBottom()
+                    self.messagesCollectionView.scrollToLastItem()
                 }
             }
         }
@@ -110,7 +110,7 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
         messagesCollectionView.messagesDataSource = self
         messagesCollectionView.messageCellDelegate = self
         
-        scrollsToBottomOnKeyboardBeginsEditing = true // default false
+        scrollsToLastItemOnKeyboardBeginsEditing = true // default false
         maintainPositionOnKeyboardFrameChanged = true // default false
 
         showMessageTimestampOnSwipeLeft = true // default false
@@ -140,7 +140,7 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
             }
         }, completion: { [weak self] _ in
             if self?.isLastSectionVisible() == true {
-                self?.messagesCollectionView.scrollToBottom(animated: true)
+                self?.messagesCollectionView.scrollToLastItem(animated: true)
             }
         })
     }
@@ -335,7 +335,7 @@ extension ChatViewController: InputBarAccessoryViewDelegate {
                 inputBar.sendButton.stopAnimating()
                 inputBar.inputTextView.placeholder = "Aa"
                 self?.insertMessages(components)
-                self?.messagesCollectionView.scrollToBottom(animated: true)
+                self?.messagesCollectionView.scrollToLastItem(animated: true)
             }
         }
     }

--- a/Example/Sources/Views/SwiftUI/MessagesView.swift
+++ b/Example/Sources/Views/SwiftUI/MessagesView.swift
@@ -1,10 +1,26 @@
-//
-//  MessagesView.swift
-//  ChatExample
-//
-//  Created by Kino Roy on 2020-07-18.
-//  Copyright © 2020 MessageKit. All rights reserved.
-//
+/*
+ MIT License
+
+ Copyright (c) 2017-2020 MessageKit
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
 
 import SwiftUI
 import MessageKit
@@ -15,7 +31,7 @@ final class MessageSwiftUIVC: MessagesViewController {
         super.viewDidAppear(animated)
         // Because SwiftUI wont automatically make our controller the first responder, we need to do it on viewDidAppear
         becomeFirstResponder()
-        messagesCollectionView.scrollToBottom(animated: true)
+        messagesCollectionView.scrollToLastItem(animated: true)
     }
 }
 
@@ -32,7 +48,7 @@ struct MessagesView: UIViewControllerRepresentable {
         messagesVC.messagesCollectionView.messagesLayoutDelegate = context.coordinator
         messagesVC.messagesCollectionView.messagesDataSource = context.coordinator
         messagesVC.messageInputBar.delegate = context.coordinator
-        messagesVC.scrollsToBottomOnKeyboardBeginsEditing = true // default false
+        messagesVC.scrollsToLastItemOnKeyboardBeginsEditing = true // default false
         messagesVC.maintainPositionOnKeyboardFrameChanged = true // default false
         messagesVC.showMessageTimestampOnSwipeLeft = true // default false
         
@@ -47,7 +63,7 @@ struct MessagesView: UIViewControllerRepresentable {
     private func scrollToBottom(_ uiViewController: MessagesViewController) {
         DispatchQueue.main.async {
             // The initialized state variable allows us to start at the bottom with the initial messages without seeing the inital scroll flash by
-            uiViewController.messagesCollectionView.scrollToBottom(animated: self.initialized)
+            uiViewController.messagesCollectionView.scrollToLastItem(animated: self.initialized)
             self.initialized = true
         }
     }

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017-2019 MessageKit
+ Copyright (c) 2017-2020 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -46,13 +46,16 @@ internal extension MessagesViewController {
     @objc
     private func handleTextViewDidBeginEditing(_ notification: Notification) {
         if scrollsToLastItemOnKeyboardBeginsEditing || scrollsToBottomOnKeyboardBeginsEditing {
-            guard let inputTextView = notification.object as? InputTextView,
-                inputTextView === messageInputBar.inputTextView else { return }
-
+            guard
+                let inputTextView = notification.object as? InputTextView,
+                inputTextView === messageInputBar.inputTextView
+            else {
+                return
+            }
             if scrollsToLastItemOnKeyboardBeginsEditing {
                 messagesCollectionView.scrollToLastItem()
             } else {
-                messagesCollectionView.scrollToBottom(animated: true)
+                messagesCollectionView.scrollToLastItem(animated: true)
             }
         }
     }

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- Copyright (c) 2017-2019 MessageKit
+ Copyright (c) 2017-2020 MessageKit
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,7 @@
  SOFTWARE.
  */
 
+import Foundation
 import UIKit
 import InputBarAccessoryView
 
@@ -48,6 +49,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
     ///
     /// The default value of this property is `false`.
     /// NOTE: This is related to `scrollToBottom` whereas the above flag is related to `scrollToLastItem` - check each function for differences
+    @available(*, deprecated, message: "Control scrolling to bottom on keyboardBeginEditing by using scrollsToLastItemOnKeyboardBeginsEditing instead", renamed: "scrollsToLastItemOnKeyboardBeginsEditing")
     open var scrollsToBottomOnKeyboardBeginsEditing: Bool = false
     
     /// A Boolean value that determines whether the `MessagesCollectionView`

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -1,7 +1,7 @@
 /*
  MIT License
  
- Copyright (c) 2017-2019 MessageKit
+ Copyright (c) 2017-2020 MessageKit
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -121,6 +121,7 @@ open class MessagesCollectionView: UICollectionView {
     
     // NOTE: This method seems to cause crash in certain cases - https://github.com/MessageKit/MessageKit/issues/725
     // Could try using `scrollToLastItem` above
+    @available(*, deprecated, message: "Scroll to bottom by using scrollToLastItem(:) instead", renamed: "scrollToLastItem")
     public func scrollToBottom(animated: Bool = false) {
         performBatchUpdates(nil) { [weak self] _ in
             guard let self = self else { return }
@@ -166,7 +167,7 @@ open class MessagesCollectionView: UICollectionView {
         return messagesCollectionViewFlowLayout.isSectionReservedForTypingIndicator(section)
     }
 
-    // MARK: View Register/Dequeue
+    // MARK: - View Register/Dequeue
 
     /// Registers a particular cell using its reuse-identifier
     public func register<T: UICollectionViewCell>(_ cellClass: T.Type) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- `messagesCollectionView.scrollToBottom` can crash in certain use cases. This PR adds `deprecated` flag to this method and `scrollsToBottomOnKeyboardBeginsEditing` property in favor of `messagesCollectionView.scrollToLastItem` and `scrollsToLastItemOnKeyboardBeginsEditing`

Does this close any currently open issues?
------------------------------------------
- N/A


Any relevant logs, error output, etc?
-------------------------------------
- N/A

Any other comments?
-------------------
- 👻

Where has this been tested?
---------------------------
**Devices/Simulators:** 
- Yes / Yes

**iOS Version:** 
- 14.2

**Swift Version:** 
- 5.3

**MessageKit Version:** 
- master


