### PR TITLE
Add to the view hierarchy manually avoiding inputAccessoryView

### DIFF
--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -74,14 +74,6 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
     /// Pan gesture for display the date of message by swiping left.
     private var panGesture: UIPanGestureRecognizer?
 
-//    open override var canBecomeFirstResponder: Bool {
-//        return true
-//    }
-//
-//    open override var inputAccessoryView: UIView? {
-//        return messageInputBar
-//    }
-
     open override var shouldAutorotate: Bool {
         return false
     }

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -37,6 +37,9 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
     /// The `InputBarAccessoryView` used as the `inputAccessoryView` in the view controller.
     open lazy var messageInputBar = InputBarAccessoryView()
 
+    /// The message bar is not added as an accessory view anymore. Manage the bottom constraint manually.
+    open var mesaageInputBarBottomConstraint: NSLayoutConstraint!
+
     /// A Boolean value that determines whether the `MessagesCollectionView` scrolls to the
     /// last item whenever the `InputTextView` begins editing.
     ///
@@ -242,10 +245,10 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
         messageInputBar.translatesAutoresizingMaskIntoConstraints = false
 
         let messagesBottom = messagesCollectionView.bottomAnchor.constraint(equalTo: messageInputBar.topAnchor)
-        let mesaageInputBarBottom = messageInputBar.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        mesaageInputBarBottomConstraint = messageInputBar.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         let messageInputBarLeading = messageInputBar.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor)
         let messageInputBarTrailing = messageInputBar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
-        NSLayoutConstraint.activate([messagesBottom, mesaageInputBarBottom, messageInputBarLeading, messageInputBarTrailing])
+        NSLayoutConstraint.activate([messagesBottom, mesaageInputBarBottomConstraint, messageInputBarLeading, messageInputBarTrailing])
     }
 
     // MARK: - Typing Indicator API

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -74,13 +74,13 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
     /// Pan gesture for display the date of message by swiping left.
     private var panGesture: UIPanGestureRecognizer?
 
-    open override var canBecomeFirstResponder: Bool {
-        return true
-    }
-
-    open override var inputAccessoryView: UIView? {
-        return messageInputBar
-    }
+//    open override var canBecomeFirstResponder: Bool {
+//        return true
+//    }
+//
+//    open override var inputAccessoryView: UIView? {
+//        return messageInputBar
+//    }
 
     open override var shouldAutorotate: Bool {
         return false
@@ -236,16 +236,24 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
 
     private func setupSubviews() {
         view.addSubview(messagesCollectionView)
+        view.addSubview(messageInputBar)
     }
 
     private func setupConstraints() {
         messagesCollectionView.translatesAutoresizingMaskIntoConstraints = false
-        
-        let top = messagesCollectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
-        let bottom = messagesCollectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+
+        let top = messagesCollectionView.topAnchor.constraint(equalTo: view.topAnchor, constant: view.safeAreaInsets.top)
         let leading = messagesCollectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor)
         let trailing = messagesCollectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
-        NSLayoutConstraint.activate([top, bottom, trailing, leading])
+        NSLayoutConstraint.activate([top, trailing, leading])
+
+        messageInputBar.translatesAutoresizingMaskIntoConstraints = false
+
+        let messagesBottom = messagesCollectionView.bottomAnchor.constraint(equalTo: messageInputBar.topAnchor)
+        let mesaageInputBarBottom = messageInputBar.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        let messageInputBarLeading = messageInputBar.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor)
+        let messageInputBarTrailing = messageInputBar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+        NSLayoutConstraint.activate([messagesBottom, mesaageInputBarBottom, messageInputBarLeading, messageInputBarTrailing])
     }
 
     // MARK: - Typing Indicator API

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -38,7 +38,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
     open lazy var messageInputBar = InputBarAccessoryView()
 
     /// The message bar is not added as an accessory view anymore. Manage the bottom constraint manually.
-    open var mesaageInputBarBottomConstraint: NSLayoutConstraint!
+    open var messageInputBarBottomConstraint: NSLayoutConstraint!
 
     /// A Boolean value that determines whether the `MessagesCollectionView` scrolls to the
     /// last item whenever the `InputTextView` begins editing.
@@ -245,10 +245,10 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
         messageInputBar.translatesAutoresizingMaskIntoConstraints = false
 
         let messagesBottom = messagesCollectionView.bottomAnchor.constraint(equalTo: messageInputBar.topAnchor)
-        mesaageInputBarBottomConstraint = messageInputBar.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        messageInputBarBottomConstraint = messageInputBar.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         let messageInputBarLeading = messageInputBar.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor)
         let messageInputBarTrailing = messageInputBar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
-        NSLayoutConstraint.activate([messagesBottom, mesaageInputBarBottomConstraint, messageInputBarLeading, messageInputBarTrailing])
+        NSLayoutConstraint.activate([messagesBottom, messageInputBarBottomConstraint, messageInputBarLeading, messageInputBarTrailing])
     }
 
     // MARK: - Typing Indicator API


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The message bar disappears either on tap or window level change. This happens only under some circumstances: the `MessagesViewController` must be added to the `UITabBarController` or `UINavigationController`. Not easy reproducible on the sample project.

Does this close any currently open issues?
------------------------------------------
https://github.com/MessageKit/MessageKit/issues/1508
https://github.com/nathantannar4/InputBarAccessoryView/issues/77


Where has this been tested?
---------------------------
**Devices/Simulators:** device and simulator

**iOS Version:** 14.3

**Swift Version:** 5

**MessageKit Version:** 3.4.2


