### PR TITLE
Remove unwanted bottom scroll indicator inset

### DIFF
--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -227,6 +227,9 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIGestureRecogni
         messagesCollectionView.keyboardDismissMode = .interactive
         messagesCollectionView.alwaysBounceVertical = true
         messagesCollectionView.backgroundColor = .collectionViewBackground
+        if #available(iOS 13.0, *) {
+            messagesCollectionView.automaticallyAdjustsScrollIndicatorInsets = false
+        }
     }
 
     private func setupDelegates() {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR sets `automaticallyAdjustsScrollIndicatorInsets` of `messagesCollectionView` to `false` so that the scroll indicator flushes nicely to the bottom of the screen.


Does this close any currently open issues?
------------------------------------------
- Closes #1520 


Any relevant logs, error output, etc?
-------------------------------------
Left: before, right: after

<img src="https://user-images.githubusercontent.com/5944973/103983033-8f513780-51bf-11eb-9fbe-67f333e5f42e.jpg" width="300" align="left"/>
<img src="https://user-images.githubusercontent.com/5944973/103985040-34b9da80-51c3-11eb-94cc-f025fa7f4c1e.jpeg" width="300" />

Any other comments?
-------------------
Apple renamed `automaticallyAdjustsScrollViewInsets` to `automaticallyAdjustsScrollIndicatorInsets` as of iOS 13, but I do not have a simulator downloaded or test device to test if this issue persists in iOS 12 and below. 


Where has this been tested?
---------------------------
**Devices/Simulators:**
iPhone 12 mini
iPhone XS

**iOS Version:**
14.3, 13.7

**Swift Version:** …
5

**MessageKit Version:** …
4.3.2

