### PR TITLE
#1529 fix for collection view content inset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ### Fixed
 
+- Fixes an issue with Scroll problem on new messages with keyboard open [#1529](https://github.com/MessageKit/MessageKit/pull/1529) by [@politan8](https://github.com/politan8)
+
 ### Added
 
 ### Changed

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -98,6 +98,10 @@ internal extension MessagesViewController {
         let newBottomInset = requiredScrollViewBottomInset(forKeyboardFrame: keyboardEndFrame)
         let differenceOfBottomInset = newBottomInset - messageCollectionViewBottomInset
 
+        UIView.performWithoutAnimation {
+            messageCollectionViewBottomInset = newBottomInset
+        }
+        
         if maintainPositionOnKeyboardFrameChanged && differenceOfBottomInset != 0 {
             let contentOffset = CGPoint(x: messagesCollectionView.contentOffset.x, y: messagesCollectionView.contentOffset.y + differenceOfBottomInset)
             // Changing contentOffset to bigger number than the contentSize will result in a jump of content
@@ -106,10 +110,6 @@ internal extension MessagesViewController {
                 return
             }
             messagesCollectionView.setContentOffset(contentOffset, animated: false)
-        }
-
-        UIView.performWithoutAnimation {
-            messageCollectionViewBottomInset = newBottomInset
         }
     }
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
update target bottom offset of collection view despite the contentSize is smaller than viewport

Does this close any currently open issues?
------------------------------------------
#1529


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** device iPhone SE, simulator iPhone 11 Pro 14.4, simulator iPad Pro

**iOS Version:** 14.4, 14.4, 14.4

**Swift Version:** …

**MessageKit Version:** 3.5.1


