### PR TITLE
Make messageTimestampLabel center on messageContainerView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - Fixes an issue with Scroll problem on new messages with keyboard open [#1529](https://github.com/MessageKit/MessageKit/pull/1529) by [@politan8](https://github.com/politan8)
 
+- Fixes time stamp vertical alignment so labels align with messages when showMessageTimestampOnSwipeLeft is true.
+  by [@kurtsequoia](https://github.com/MessageKit/MessageKit/pull/1556)
+
 ### Added
 
 ### Changed

--- a/Sources/Views/Cells/MessageContentCell.swift
+++ b/Sources/Views/Cells/MessageContentCell.swift
@@ -357,7 +357,8 @@ open class MessageContentCell: MessageCollectionViewCell {
     /// - attributes: The `MessagesCollectionViewLayoutAttributes` for the cell.
     open func layoutTimeLabelView(with attributes: MessagesCollectionViewLayoutAttributes) {
         let paddingLeft: CGFloat = 10
-        let origin = CGPoint(x: UIScreen.main.bounds.width + paddingLeft, y: contentView.frame.size.height * 0.5)
+        let origin = CGPoint(x: UIScreen.main.bounds.width + paddingLeft,
+                             y: messageContainerView.frame.minY + messageContainerView.frame.height * 0.5 - messageTimestampLabel.font.ascender * 0.5)
         let size = CGSize(width: attributes.messageTimeLabelSize.width, height: attributes.messageTimeLabelSize.height)
         messageTimestampLabel.frame = CGRect(origin: origin, size: size)
     }


### PR DESCRIPTION
Currently the time stamps have their upper edge aligned vertically with the contentView center, but since the messageContainerView often extends outside of the contentView.  The vertical position of the time labels is very erratic and aligns differently for incoming vs outgoing messages, messages with different content, etc.

That makes it hard to associate the time labels with their messages, and is rather confusing.

This one line fix changes the layout so it vertically centers the upper extent of the label to the messageContainerView center.  That makes it track better visually and makes it much easier to associate time stamps with messages.

I have tested this in the example app In the simulator with all the different content types turned on.

I think it makes a big difference in the usability of the messageTimeStampLabel's.   

Here is the before.  Notice that the alignment is erratic and even when working as intended the text is below center:
<img width="453" alt="timeLabelAlignementBefore" src="https://user-images.githubusercontent.com/62399593/111504467-ebc35c80-8704-11eb-91d8-b3e66527805c.png">

Here is the after:
<img width="460" alt="timeLabelsAlignedAfter" src="https://user-images.githubusercontent.com/62399593/111504503-f54cc480-8704-11eb-9ccc-44c78c8c8bf6.png">
