### PR TITLE
Fix typing indicator calulator based on delegate methods

### DIFF
--- a/Sources/Layout/TypingIndicatorCellSizeCalculator.swift
+++ b/Sources/Layout/TypingIndicatorCellSizeCalculator.swift
@@ -26,18 +26,13 @@ import UIKit
 
 open class TypingCellSizeCalculator: CellSizeCalculator {
 
-    open var height: CGFloat = 62
-
     public init(layout: MessagesCollectionViewFlowLayout? = nil) {
         super.init()
         self.layout = layout
     }
 
     open override func sizeForItem(at indexPath: IndexPath) -> CGSize {
-        guard let layout = layout else { return .zero }
-        let collectionViewWidth = layout.collectionView?.bounds.width ?? 0
-        let contentInset = layout.collectionView?.contentInset ?? .zero
-        let inset = layout.sectionInset.horizontal + contentInset.horizontal
-        return CGSize(width: collectionViewWidth - inset, height: height)
+        guard let layout = layout as? MessagesCollectionViewFlowLayout else { return .zero }
+        return layout.messagesLayoutDelegate.typingIndicatorViewSize(for: layout)
     }
 }

--- a/Sources/Protocols/MessagesLayoutDelegate.swift
+++ b/Sources/Protocols/MessagesLayoutDelegate.swift
@@ -52,12 +52,11 @@ public protocol MessagesLayoutDelegate: AnyObject {
     /// Specifies the size to use for a typing indicator view.
     ///
     /// - Parameters:
-    ///   - messagesCollectionView: The `MessagesCollectionView` in which this view will be displayed.
+    ///   - layout: The `MessagesCollectionViewFlowLayout` layout.
     ///
     /// - Note:
-    ///   The default value returned by this method is the width of the `messagesCollectionView` and
-    ///   a height of 52.
-    func typingIndicatorViewSize(in messagesCollectionView: MessagesCollectionView) -> CGSize
+    ///   The default value returned by this method is the width of the `messagesCollectionView` minus insets and a height of 62.
+    func typingIndicatorViewSize(for layout: MessagesCollectionViewFlowLayout) -> CGSize
 
     /// Specifies the top inset to use for a typing indicator view.
     ///
@@ -134,8 +133,11 @@ public extension MessagesLayoutDelegate {
         return .zero
     }
 
-    func typingIndicatorViewSize(in messagesCollectionView: MessagesCollectionView) -> CGSize {
-        return CGSize(width: messagesCollectionView.bounds.width, height: 48)
+    func typingIndicatorViewSize(for layout: MessagesCollectionViewFlowLayout) -> CGSize {
+        let collectionViewWidth = layout.messagesCollectionView.bounds.width
+        let contentInset = layout.messagesCollectionView.contentInset
+        let inset = layout.sectionInset.horizontal + contentInset.horizontal
+        return CGSize(width: collectionViewWidth - inset, height: 62)
     }
 
     func typingIndicatorViewTopInset(in messagesCollectionView: MessagesCollectionView) -> CGFloat {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix typing indicator size based on delegate methods.

Does this close any currently open issues?
------------------------------------------
Closes https://github.com/MessageKit/MessageKit/issues/1562


Any other comments?
-------------------
This is a breaking change as delegate method has changed, but it shouldn't break anything as default implementation was used in most of the cases.

Where has this been tested?
---------------------------
**Devices/Simulators:** Simulator

**iOS Version:** 14.4

**Swift Version:** 5.3

**MessageKit Version:** master


