### PR TITLE
Changed right inset for outgoingMessageBottomLabelAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ### Fixed
 
+Fixed the right text alignment for messageBottomLabel.
+
 ### Added
 
 ### Changed
+
+Changed right inset for outgoingMessageBottomLabelAlignment to 4 in MessageSizeCalculator - with previous value 42 the right alignment for messageBottomLabel didn't work correctly.
 
 ### Removed
 

--- a/Sources/Layout/MessageSizeCalculator.swift
+++ b/Sources/Layout/MessageSizeCalculator.swift
@@ -54,7 +54,7 @@ open class MessageSizeCalculator: CellSizeCalculator {
     public var outgoingMessageTopLabelAlignment = LabelAlignment(textAlignment: .right, textInsets: UIEdgeInsets(right: 42))
 
     public var incomingMessageBottomLabelAlignment = LabelAlignment(textAlignment: .left, textInsets: UIEdgeInsets(left: 42))
-    public var outgoingMessageBottomLabelAlignment = LabelAlignment(textAlignment: .right, textInsets: UIEdgeInsets(right: 42))
+    public var outgoingMessageBottomLabelAlignment = LabelAlignment(textAlignment: .right, textInsets: UIEdgeInsets(right: 4))
 
     public var incomingAccessoryViewSize = CGSize.zero
     public var outgoingAccessoryViewSize = CGSize.zero


### PR DESCRIPTION
Changed right inset for outgoingMessageBottomLabelAlignment to 4 in MessageSizeCalculator. With previous value 42 the right alignment for messageBottomLabel didn't work correctly.

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------

I changed right inset for outgoingMessageBottomLabelAlignment to 4 in MessageSizeCalculator. With previous value 42 the right alignment for messageBottomLabel didn't work correctly.

Does this close any currently open issues?
------------------------------------------
The issue was closed in 2018, but the solution provided didn't work today.


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
**Devices/Simulators:**
iPhone 11 Pro simulator
**iOS Version:** 
14.4
**Swift Version:** 
5.3
**MessageKit Version:** 
3.5.1


