### PR TITLE
updated delegate name

### DIFF
--- a/Documentation/MessageInputBar.md
+++ b/Documentation/MessageInputBar.md
@@ -1,6 +1,6 @@
 # MessageInputBar
 
-The `MessageInputBar` is the reactive `InputAccessoryView` of the `MessagesViewController`. It has a fairly basic delegate, `MessageInputBarDelegate`, that can be used to detect when the send button is pressed however its individual `InputBarButtonItem`'s can be individually set up to react to various events.
+The `MessageInputBar` is the reactive `InputAccessoryView` of the `MessagesViewController`. It has a fairly basic delegate, `InputBarAccessoryViewDelegate`, that can be used to detect when the send button is pressed however its individual `InputBarButtonItem`'s can be individually set up to react to various events.
 
 ## Basic Setup
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
--------------------------------------------------
The delegate name 'MessageInputBarDelegate' is not available anymore, so I changed it to the recommended one - 'InputBarAccessoryViewDelegate'

Does this close any currently open issues?
------------------------------------------
no.


Any relevant logs, error output, etc?
no.
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
no.

Where has this been tested?
---------------------------
**Devices/Simulators:**
Iphone 12 Pro Simulator

**iOS Version:**
14.1

**Swift Version:**
5.1.2

**MessageKit Version:**
3.3.0


