### PR TITLE
[Fix] Fix swipe dismissal of UIImagePicker

### DIFF
--- a/Example/Sources/Views/CameraInputBarAccessoryView.swift
+++ b/Example/Sources/Views/CameraInputBarAccessoryView.swift
@@ -115,11 +115,12 @@ extension CameraInputBarAccessoryView : UIImagePickerControllerDelegate , UINavi
     func showImagePickerController(sourceType: UIImagePickerController.SourceType){
         
         let imgPicker = UIImagePickerController()
-         imgPicker.delegate = self
-         imgPicker.allowsEditing = true
-         imgPicker.sourceType = sourceType
-         inputAccessoryView?.isHidden = true
-         getRootViewController()?.present(imgPicker, animated: true, completion: nil)
+        imgPicker.delegate = self
+        imgPicker.allowsEditing = true
+        imgPicker.sourceType = sourceType
+        imgPicker.presentationController?.delegate = self
+        inputAccessoryView?.isHidden = true
+        getRootViewController()?.present(imgPicker, animated: true, completion: nil)
       
     }
     
@@ -196,4 +197,9 @@ extension CameraInputBarAccessoryView: AttachmentManagerDelegate {
 }
 
 
-
+extension CameraInputBarAccessoryView: UIAdaptivePresentationControllerDelegate {
+    // Swipe to dismiss image modal
+    public func presentationControllerWillDismiss(_ presentationController: UIPresentationController) {
+        isHidden = false
+    }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Currently, when you present a UIImagePickerController, iOS 13 adds a separate presentation context you have to handle. If you dismiss via swiping, the original dismiss handler does not work and the `isHidden` property of the inputBar is not restored. Users that use modals in their MessageViewControllers may not realize this and this provides a good example of how to handle that case.

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
The tabs and spacing were also messed up on these initializing lines so I fixed those as well.

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 13

**iOS Version:** 15

**Swift Version:** 5.1

**MessageKit Version:** 3.6.0


