### PR TITLE
Fix the NaN crash due to the zero width or height of the bubble

### DIFF
--- a/Sources/Views/TypingBubble.swift
+++ b/Sources/Views/TypingBubble.swift
@@ -104,6 +104,12 @@ open class TypingBubble: UIView {
         
         // To maintain the iMessage like bubble the width:height ratio of the frame
         // must be close to 1.65
+        
+        //In order to prevent NaN crash when assigning the frame of the contentBubble
+        guard bounds.width > 0,
+              bounds.height > 0
+        else { return}
+        
         let ratio = bounds.width / bounds.height
         let extraRightInset = bounds.width - 1.65/ratio*bounds.width
         


### PR DESCRIPTION
Fix for NaN crash. Prevents setting a frame with a NaN value.

