### PR TITLE
check section is for typing

### DIFF
--- a/Documentation/CUSTOM_CELLS.md
+++ b/Documentation/CUSTOM_CELLS.md
@@ -46,6 +46,10 @@ open class MyCustomMessagesFlowLayout: MessagesCollectionViewFlowLayout {
     lazy open var customMessageSizeCalculator = CustomMessageSizeCalculator(layout: self)
 
     override open func cellSizeCalculatorForItem(at indexPath: IndexPath) -> CellSizeCalculator {
+        //before checking the messages check if section is reserved for typing otherwise it will cause IndexOutOfBounds error
+        if isSectionReservedForTypingIndicator(indexPath.section) {
+            return typingIndicatorSizeCalculator
+        }
         let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
         if case .custom = message.kind {
             return customMessageSizeCalculator
@@ -69,7 +73,10 @@ internal class ConversationViewController: MessagesViewController {
         guard let messagesDataSource = messagesCollectionView.messagesDataSource else {
             fatalError("Ouch. nil data source for messages")
         }
-
+        //before checking the messages check if section is reserved for typing otherwise it will cause IndexOutOfBounds error
+        if isSectionReservedForTypingIndicator(indexPath.section){
+            return super.collectionView(collectionView, cellForItemAt: indexPath)
+        }
         let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
         if case .custom = message.kind {
             let cell = messagesCollectionView.dequeueReusableCell(MyCustomCell.self, for: indexPath)


### PR DESCRIPTION
Check if section is reserved for typing in custom cell guide

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Update the guide for custom cell implementation to check for typing section otherwise it would cause index out of range

Does this close any currently open issues?
------------------------------------------
I think #1387 is related


Any relevant logs, error output, etc?
-------------------------------------
<!--
Swift/ContiguousArrayBuffer.swift:580: Fatal error: Index out of range
-->

Any other comments?
-------------------

Where has this been tested?
---------------------------
**Devices/Simulators:**  iPhone 13 Pro Max

**iOS Version:** 15.0

**Swift Version:** 5.5.1

**MessageKit Version:**3.7.0


