### PR TITLE
:zap: Memory leak fix by removing retain cycle in CameraInputBarAcces…

### DIFF
--- a/Example/Sources/Views/CameraInputBarAccessoryView.swift
+++ b/Example/Sources/Views/CameraInputBarAccessoryView.swift
@@ -45,13 +45,12 @@ extension CameraInputBarAccessoryViewDelegate {
     func configure(){
         let camera = makeButton(named: "ic_camera")
         camera.tintColor = .darkGray
-        camera.onTouchUpInside { (item) in
-            self.showImagePickerControllerActionSheet()
+        camera.onTouchUpInside { [weak self] item in
+            self?.showImagePickerControllerActionSheet()
         }
         self.setLeftStackViewWidthConstant(to: 35, animated: true)
         self.setStackViewItems([camera], forStack: .left, animated: false)
         self.inputPlugins = [attachmentManager]
-
     }
     
     override func didSelectSendButton() {
@@ -99,12 +98,12 @@ extension CameraInputBarAccessoryView : UIImagePickerControllerDelegate , UINavi
     @objc  func showImagePickerControllerActionSheet()  {
         
 
-        let photoLibraryAction = UIAlertAction(title: "Choose From Library", style: .default) { (action) in
-            self.showImagePickerController(sourceType: .photoLibrary)
+        let photoLibraryAction = UIAlertAction(title: "Choose From Library", style: .default) { [weak self] action in
+            self?.showImagePickerController(sourceType: .photoLibrary)
         }
         
-        let cameraAction = UIAlertAction(title: "Take From Camera", style: .default) { (action) in
-            self.showImagePickerController(sourceType: .camera)
+        let cameraAction = UIAlertAction(title: "Take From Camera", style: .default) { [weak self] action in
+            self?.showImagePickerController(sourceType: .camera)
         }
         
         let cancelAction = UIAlertAction(title: "Cancel", style: .default , handler: nil)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This issue  #1635 describes the memory leak.

To further explain with debug memory graph -

- `LaunchViewController` Active Objects.
<img width="400" alt="Screenshot 2021-12-05 at 1 12 41 AM" src="https://user-images.githubusercontent.com/19208687/144722155-1cd208c2-6004-4071-8861-aa5b765d2549.png">

- ` CameraInputBarAccessoryView` usage to get selected images in memory.
<img width="400" alt="Screenshot 2021-12-05 at 1 14 48 AM" src="https://user-images.githubusercontent.com/19208687/144722163-1522b5b7-1131-48de-a083-02efbab4775e.png">

- Back to `LaunchViewController` doing it selectinng image several times. No object gets deallocated. Can be tracked by `deinit {} ` as well in each object.
<img width="400" alt="Screenshot 2021-12-05 at 1 22 54 AM" src="https://user-images.githubusercontent.com/19208687/144722303-db7cdc46-8ecd-4edd-ac0c-b37da1c7263f.png">

It is fixed by removing retain cycle which kept the strong reference causing `ImageAttachmentCell`, `Attachmentmanager` to never get deallocated.

Does this close any currently open issues?
------------------------------------------
Closes #1635 


Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Devices/Simulators:** Simulator

**iOS Version:** 15

**Swift Version:** 5

**MessageKit Version:** 3.7


