### PR TITLE
Improvement in logic for scrollToLastItem

### DIFF
--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -46,9 +46,14 @@ open class MessagesCollectionView: UICollectionView {
     internal var showMessageTimestampOnSwipeLeft: Bool = false
 
     private var indexPathForLastItem: IndexPath? {
-        let lastSection = numberOfSections - 1
-        guard lastSection >= 0, numberOfItems(inSection: lastSection) > 0 else { return nil }
-        return IndexPath(item: numberOfItems(inSection: lastSection) - 1, section: lastSection)
+        guard numberOfSections > 0 else { return nil }
+        
+        for offset in 1...numberOfSections {
+            let section = numberOfSections - offset
+            let lastItem = numberOfItems(inSection: section) - 1
+            if lastItem >= 0 { return IndexPath(item: lastItem, section: section) }
+        }
+        return nil
     }
 
     open var messagesCollectionViewFlowLayout: MessagesCollectionViewFlowLayout {
@@ -108,14 +113,8 @@ open class MessagesCollectionView: UICollectionView {
 
     // NOTE: It's possible for small content size this wouldn't work - https://github.com/MessageKit/MessageKit/issues/725
     public func scrollToLastItem(at pos: UICollectionView.ScrollPosition = .bottom, animated: Bool = true) {
-        guard numberOfSections > 0 else { return }
+        guard let indexPath = indexPathForLastItem else { return }
         
-        let lastSection = numberOfSections - 1
-        let lastItemIndex = numberOfItems(inSection: lastSection) - 1
-        
-        guard lastItemIndex >= 0 else { return }
-        
-        let indexPath = IndexPath(row: lastItemIndex, section: lastSection)
         scrollToItem(at: indexPath, at: pos, animated: animated)
     }
     

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -51,7 +51,9 @@ open class MessagesCollectionView: UICollectionView {
         for offset in 1...numberOfSections {
             let section = numberOfSections - offset
             let lastItem = numberOfItems(inSection: section) - 1
-            if lastItem >= 0 { return IndexPath(item: lastItem, section: section) }
+            if lastItem >= 0 {
+                return IndexPath(item: lastItem, section: section)
+            }
         }
         return nil
     }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
The default implementation of scrollToLastItem only considers the last section and therefore doesn't work if that section is empty. This change now iterates through the sections until it finds the actual last valid item index path. The `scrollToLastItem` function now also uses the `indexPathForLastItem` property instead of duplicating logic (it also wasn't being used).

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
N/A

Where has this been tested?
---------------------------
**Devices/Simulators:** N/A

**iOS Version:** iOS 14 and 15

**Swift Version:** Swift 5.1

**MessageKit Version:** Tested from 3.6.1 up to 3.7.0