### PR TITLE
Fix Xcode case

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can [just add](https://developer.apple.com/documentation/xcode/adding_packag
 ```
 https://github.com/MessageKit/MessageKit
 ```
-Older versions of Swift and XCode don't support MessageKit via SPM.
+Older versions of Swift and Xcode don't support MessageKit via SPM.
 
 ### [Manual](https://github.com/MessageKit/MessageKit/blob/master/Documentation/MANUAL_INSTALLATION.md)
 


### PR DESCRIPTION
I hate to be that guy; I hate seeing Xcode written with an improper case even more… 🙃

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix a typo

Does this close any currently open issues?
------------------------------------------
I don’t think so.


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->
N/A

Any other comments?
-------------------
None.

Where has this been tested?
---------------------------
**Devices/Simulators:** N/A

**iOS Version:** N/A

**Swift Version:** N/A

**MessageKit Version:** N/A


