### PR TITLE
Updating messagesCollectionView's bottom inset and content position on inpuBar height change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - **Breaking change**: Dropped support for iOS 12 [2bd234b](https://github.com/MessageKit/MessageKit/commit/2bd234b1e878f392089f166d6868ce644d6c9e95) by [@martinpucik](https://github.com/martinpucik)
 - **Breaking change**: Moved messageInputBar from inputAccessoryView to a subview in MessagesViewController [#1704](https://github.com/MessageKit/MessageKit/pull/1704) by [@martinpucik](https://github.com/martinpucik)
+- **Deprecation**: Deprecated `maintainPositionOnKeyboardFrameChangedMoved` in favor of `maintainPositionOnInputBarHeightChanged` which better describes the intended use of this property [#1704](https://github.com/MessageKit/MessageKit/pull/1705) by [@martinpucik](https://github.com/martinpucik)
 - **Breaking change**: Added an argument to `messageContainerMaxWidth` [cd4f75b](https://github.com/MessageKit/MessageKit/commit/cd4f75b561129fc25e6c4576000e5a92ccd81cad) by [@martinpucik](https://github.com/martinpucik)
     ```swift
     MessageSizeCalculator.messageContainerMaxWidth(for message: MessageType) -> CGFloat

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -60,13 +60,11 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
         configureMessageCollectionView()
         configureMessageInputBar()
         loadFirstMessages()
-
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        messagesCollectionView.scrollToLastItem(animated: false)
         MockSocket.shared.connect(with: [SampleData.shared.nathan, SampleData.shared.wu])
             .onNewMessage { [weak self] message in
                 self?.insertMessage(message)
@@ -86,6 +84,7 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
                 DispatchQueue.main.async {
                     self.messageList = messages
                     self.messagesCollectionView.reloadData()
+                    self.messagesCollectionView.scrollToLastItem(animated: false)
                 }
             }
         }
@@ -109,8 +108,7 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
         messagesCollectionView.messageCellDelegate = self
         
         scrollsToLastItemOnKeyboardBeginsEditing = true // default false
-        maintainPositionOnKeyboardFrameChanged = true // default false
-
+        maintainPositionOnInputBarHeightChanged = true // default false
         showMessageTimestampOnSwipeLeft = true // default false
         
         messagesCollectionView.refreshControl = refreshControl

--- a/Example/Sources/Views/SwiftUI/MessagesView.swift
+++ b/Example/Sources/Views/SwiftUI/MessagesView.swift
@@ -48,7 +48,7 @@ struct MessagesView: UIViewControllerRepresentable {
         messagesVC.messagesCollectionView.messagesDataSource = context.coordinator
         messagesVC.messageInputBar.delegate = context.coordinator
         messagesVC.scrollsToLastItemOnKeyboardBeginsEditing = true // default false
-        messagesVC.maintainPositionOnKeyboardFrameChanged = true // default false
+        messagesVC.maintainPositionOnInputBarHeightChanged = true // default false
         messagesVC.showMessageTimestampOnSwipeLeft = true // default false
         
         return messagesVC

--- a/Sources/Controllers/MessagesViewController+State.swift
+++ b/Sources/Controllers/MessagesViewController+State.swift
@@ -31,6 +31,8 @@ extension MessagesViewController {
     class State {
         /// Pan gesture for display the date of message by swiping left.
         var panGesture: UIPanGestureRecognizer?
+        var maintainPositionOnInputBarHeightChanged: Bool = false
+        var scrollsToLastItemOnKeyboardBeginsEditing: Bool = false
 
         let inputContainerView: MessagesInputContainerView = .init()
         let keyboardManager: KeyboardManager = KeyboardManager()
@@ -50,5 +52,37 @@ extension MessagesViewController {
     var disposeBag: Set<AnyCancellable> {
         get { state.disposeBag }
         set { state.disposeBag = newValue }
+    }
+}
+
+public extension MessagesViewController {
+    /// A Boolean value that determines whether the `MessagesCollectionView`
+    /// maintains it's current position when the height of the `MessageInputBar` changes.
+    ///
+    /// The default value of this property is `false`.
+    @available(*, deprecated, renamed: "maintainPositionOnInputBarHeightChanged", message: "Please use new property - maintainPositionOnInputBarHeightChanged")
+    var maintainPositionOnKeyboardFrameChanged: Bool {
+        get { state.maintainPositionOnInputBarHeightChanged }
+        set { state.maintainPositionOnInputBarHeightChanged = newValue }
+    }
+
+    /// A Boolean value that determines whether the `MessagesCollectionView`
+    /// maintains it's current position when the height of the `MessageInputBar` changes.
+    ///
+    /// The default value of this property is `false` and the `MessagesCollectionView` will scroll to bottom after the
+    /// height of the `MessageInputBar` changes.
+    var maintainPositionOnInputBarHeightChanged: Bool {
+        get { state.maintainPositionOnInputBarHeightChanged }
+        set { state.maintainPositionOnInputBarHeightChanged = newValue }
+    }
+
+    /// A Boolean value that determines whether the `MessagesCollectionView` scrolls to the
+    /// last item whenever the `InputTextView` begins editing.
+    ///
+    /// The default value of this property is `false`.
+    /// NOTE: This is related to `scrollToLastItem` whereas the below flag is related to `scrollToBottom` - check each function for differences
+    var scrollsToLastItemOnKeyboardBeginsEditing: Bool {
+        get { state.scrollsToLastItemOnKeyboardBeginsEditing }
+        set { state.scrollsToLastItemOnKeyboardBeginsEditing = newValue }
     }
 }

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -37,19 +37,6 @@ open class MessagesViewController: UIViewController, UICollectionViewDelegateFlo
     /// The `InputBarAccessoryView` used as the `inputAccessoryView` in the view controller.
     open lazy var messageInputBar = InputBarAccessoryView()
 
-    /// A Boolean value that determines whether the `MessagesCollectionView` scrolls to the
-    /// last item whenever the `InputTextView` begins editing.
-    ///
-    /// The default value of this property is `false`.
-    /// NOTE: This is related to `scrollToLastItem` whereas the below flag is related to `scrollToBottom` - check each function for differences
-    open var scrollsToLastItemOnKeyboardBeginsEditing: Bool = false
-
-    /// A Boolean value that determines whether the `MessagesCollectionView`
-    /// maintains it's current position when the height of the `MessageInputBar` changes.
-    ///
-    /// The default value of this property is `false`.
-    open var maintainPositionOnKeyboardFrameChanged: Bool = false
-
     /// Display the date of message by swiping left.
     /// The default value of this property is `false`.
     open var showMessageTimestampOnSwipeLeft: Bool = false {

--- a/Sources/Views/Cells/AudioMessageCell.swift
+++ b/Sources/Views/Cells/AudioMessageCell.swift
@@ -48,7 +48,7 @@ open class AudioMessageCell: MessageContentCell {
     }()
 
     public lazy var activityIndicatorView: UIActivityIndicatorView = {
-        let activityIndicatorView = UIActivityIndicatorView(style: .gray)
+        let activityIndicatorView = UIActivityIndicatorView(style: .medium)
         activityIndicatorView.hidesWhenStopped = true
         activityIndicatorView.isHidden = true
         return activityIndicatorView

--- a/Sources/Views/Cells/LocationMessageCell.swift
+++ b/Sources/Views/Cells/LocationMessageCell.swift
@@ -29,7 +29,7 @@ import MapKit
 open class LocationMessageCell: MessageContentCell {
 
     /// The activity indicator to be displayed while the map image is loading.
-    open var activityIndicator = UIActivityIndicatorView(style: .gray)
+    open var activityIndicator = UIActivityIndicatorView(style: .medium)
 
     /// The image view holding the map image.
     open var imageView = UIImageView()


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- When inputBar's textView changes size, messagesCollectionView will update it's bottom content inset
- If `maintainPositionOnInputBarHeightChanged` is set to false, content will scroll to bottom on textView height change to match iMessages behavior

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**iOS Version:** …

**Swift Version:** …

**MessageKit Version:** …


