### PR TITLE
Update chat bottom inset after input bar size change

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,7 +13,6 @@ disabled_rules:
 opt_in_rules:
   - force_unwrapping
   - implicitly_unwrapped_optional
-  - conditional_returns_on_newline
   - empty_count
   - empty_string
   - extension_access_modifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ See [MIGRATION_GUIDE.md](https://github.com/MessageKit/MessageKit/blob/main/Docu
 ### Fixed
 
 - Fixed iOS 13 deprecation warnings [#1715](https://github.com/MessageKit/MessageKit/pull/1715) by [@kaspik](https://github.com/Kaspik)
+- Updating bottom chat collectionView inset after InputBar container view frame change [#1725](https://github.com/MessageKit/MessageKit/pull/1725) by [@martinpucik](https://github.com/martinpucik)
 
 ### Removed
 

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -75,6 +75,13 @@ internal extension MessagesViewController {
             self?.updateMessageCollectionViewBottomInset()
         })
         .store(in: &disposeBag)
+
+        /// Observe frame change of the input bar container to not cover collectioView with inputBar
+        inputContainerView.publisher(for: \.center)
+            .sink(receiveValue: { [weak self] _ in
+                self?.updateMessageCollectionViewBottomInset()
+            })
+            .store(in: &disposeBag)
     }
 
     // MARK: - Updating insets


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Observing input bar size change to update bottom inset of chat collection view

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**iOS Version:** …

**Swift Version:** …

**MessageKit Version:** …


