### PR TITLE
Observe inputBar frame change to update collectionView bottom inset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ See [MIGRATION_GUIDE.md](https://github.com/MessageKit/MessageKit/blob/main/Docu
     MessageSizeCalculator.messageContainerSize(for message: MessageType, at indexPath: IndexPath) -> CGSize
     ```
 - Updated InputBarAccessoryView to v6.1.0 [#1716](https://github.com/MessageKit/MessageKit/pull/1716) by [@martinpucik](https://github.com/martinpucik)
+- Observe inputBar frame change to update collectionView bottom inset instead of keyboard show/hide notifications [#1726](https://github.com/MessageKit/MessageKit/pull/1726) by [@martinpucik](https://github.com/martinpucik)
 
 ### Fixed
 

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -80,7 +80,6 @@ internal extension MessagesViewController {
 
     /// Updates bottom messagesCollectionView inset based on the position of inputContainerView
     func updateMessageCollectionViewBottomInset() {
-        guard self.presentedViewController == nil else { return }
         let collectionViewHeight = messagesCollectionView.frame.height
         let newBottomInset = collectionViewHeight - (inputContainerView.frame.minY - additionalBottomInset) - automaticallyAddedBottomInset
         let normalizedNewBottomInset = max(0, newBottomInset)

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -35,10 +35,11 @@ internal extension MessagesViewController {
         keyboardManager.bind(inputAccessoryView: inputContainerView)
         keyboardManager.bind(to: messagesCollectionView)
 
-        /// Observe didBeginEditing to scroll down the content
+        /// Observe didBeginEditing to scroll content to last item if necessary
         NotificationCenter.default
             .publisher(for: UITextView.textDidBeginEditingNotification)
             .subscribe(on: DispatchQueue.global())
+            /// Wait for inputBar frame change animation to end
             .delay(for: .milliseconds(200), scheduler: DispatchQueue.main)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] notification in
@@ -66,7 +67,7 @@ internal extension MessagesViewController {
             }
             .store(in: &disposeBag)
 
-        /// Observe frame change of the input bar container to not cover collectioView with inputBar
+        /// Observe frame change of the input bar container to update collectioView bottom inset
         inputContainerView.publisher(for: \.center)
             .receive(on: DispatchQueue.main)
             .removeDuplicates()

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -65,19 +65,10 @@ internal extension MessagesViewController {
             }
             .store(in: &disposeBag)
 
-        Publishers.MergeMany(
-            NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification),
-            NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)
-        )
-        .subscribe(on: DispatchQueue.global())
-        .receive(on: DispatchQueue.main)
-        .sink(receiveValue: { [weak self] _ in
-            self?.updateMessageCollectionViewBottomInset()
-        })
-        .store(in: &disposeBag)
-
         /// Observe frame change of the input bar container to not cover collectioView with inputBar
         inputContainerView.publisher(for: \.center)
+            .receive(on: DispatchQueue.main)
+            .removeDuplicates()
             .sink(receiveValue: { [weak self] _ in
                 self?.updateMessageCollectionViewBottomInset()
             })
@@ -88,7 +79,6 @@ internal extension MessagesViewController {
 
     /// Updates bottom messagesCollectionView inset based on the position of inputContainerView
     func updateMessageCollectionViewBottomInset() {
-        /// This is important to skip notifications from child modal controllers in iOS >= 13.0
         guard self.presentedViewController == nil else { return }
         let collectionViewHeight = messagesCollectionView.frame.height
         let newBottomInset = collectionViewHeight - (inputContainerView.frame.minY - additionalBottomInset) - automaticallyAddedBottomInset

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -39,6 +39,7 @@ internal extension MessagesViewController {
         NotificationCenter.default
             .publisher(for: UITextView.textDidBeginEditingNotification)
             .subscribe(on: DispatchQueue.global())
+            .delay(for: .milliseconds(200), scheduler: DispatchQueue.main)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] notification in
                 self?.handleTextViewDidBeginEditing(notification)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Rely on inputBar frame change rather than on keyboard notifications to update collectionView bottom inset
- No need for currently presented modal checks

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**iOS Version:** …

**Swift Version:** …

**MessageKit Version:** …


