### PR TITLE
Fix MessagesViewController.messagesCollectionView's height

### DIFF
--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -80,7 +80,7 @@ extension MessagesViewController {
 
   /// Updates bottom messagesCollectionView inset based on the position of inputContainerView
   internal func updateMessageCollectionViewBottomInset() {
-    let collectionViewHeight = messagesCollectionView.frame.height
+    let collectionViewHeight = messagesCollectionView.frame.maxY
     let newBottomInset = collectionViewHeight - (inputContainerView.frame.minY - additionalBottomInset) -
       automaticallyAddedBottomInset
     let normalizedNewBottomInset = max(0, newBottomInset)


### PR DESCRIPTION
👻<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Hello.
Thank you for MessageKit.
Found out that when I modify constraints for `MessagesViewController.messagesCollectionView` to shrink it, then `MessagesViewController.inputContainerView` overlaps `MessagesViewController.messagesCollectionView`. To fix it use `maxY` instead of `height`.

Does this close any currently open issues?
------------------------------------------
Did not find any related issues.


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** iPod Touch (7th generation)

**iOS Version:** iOS 15.6

**Swift Version:** Swift 5.6

**MessageKit Version:** 4.0.0


