### PR TITLE
DocC Documentation

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,32 @@
+name: Deploy DocC
+
+on:
+  push:
+    branches:
+      - "main"
+permissions:
+  contents: write
+jobs:
+  build_docs:
+    runs-on: macos-12
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Build DocC
+        run: |
+          swift package resolve
+          xcodebuild docbuild -scheme MessageKit -derivedDataPath 'docc' -destination 'generic/platform=iOS';
+          $(xcrun --find docc) process-archive \
+            transform-for-static-hosting docc/Build/Products/Debug-iphoneos/MessageKit.doccarchive \
+            --hosting-base-path '' \
+            --output-path docs
+          $(xcrun --find docc) process-archive \
+            transform-for-static-hosting docc/Build/Products/Debug-iphoneos/InputBarAccessoryView.doccarchive \
+            --hosting-base-path InputBarAccessoryView \
+            --output-path docs/InputBarAccessoryView
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 build/
 DerivedData
 .build/
+docs/
+docc/
 
 ## Various settings
 *.pbxuser

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - platform: ios
+      documentation_targets: [MessageKit]

--- a/README.md
+++ b/README.md
@@ -4,17 +4,22 @@
   A community-driven replacement for JSQMessagesViewController
 </p>
 
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FMessageKit%2FMessageKit%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/MessageKit/MessageKit)
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FMessageKit%2FMessageKit%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/MessageKit/MessageKit)
-<a href="https://developer.apple.com/xcode">
-<img src="https://img.shields.io/badge/Xcode-13-blue.svg" alt="Xcode">
-</a>
-<a href="https://opensource.org/licenses/MIT">
-<img src="https://img.shields.io/badge/License-MIT-red.svg" alt="MIT">
-</a>
-<a href="https://github.com/MessageKit/MessageKit/issues">
-<img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat" alt="Contributions Welcome">
-</a>
+<p align="center">
+  <a href="https://swiftpackageindex.com/MessageKit/MessageKit">
+    <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FMessageKit%2FMessageKit%2Fbadge%3Ftype%3Dswift-versions"/>
+  <a href="https://swiftpackageindex.com/MessageKit/MessageKit">
+    <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FMessageKit%2FMessageKit%2Fbadge%3Ftype%3Dplatforms"/>
+  <br/>
+  <a href="https://developer.apple.com/xcode">
+  <img src="https://img.shields.io/badge/Xcode-13-blue.svg" alt="Xcode">
+  </a>
+  <a href="./LICENSE.md">
+  <img src="https://img.shields.io/github/license/MessageKit/MessageKit?color=red" alt="MIT">
+  </a>
+  <a href="https://github.com/MessageKit/MessageKit/issues">
+  <img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat" alt="Contributions Welcome">
+  </a>
+</p>
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/MessageKit/MessageKit/master/Assets/TypingIndicator.png" title="MessageKit header" width="400">
@@ -54,6 +59,9 @@ Older versions of Swift and Xcode don't support MessageKit via SPM.
 > For iOS 9 and iOS 10 please use version 3.1.1
 
 ## Getting Started
+
+Check out the full documentation here:<br>
+https://messagekit.github.io/documentation/messagekit
 
 ### Cell Structure
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- Adds auto-deployment of documentation on a branch `gh-pages` root when pushed to master.

Does this close any currently open issues?
------------------------------------------
No

Any other comments?
-------------------
The way DocC is set up, the new homepage of the docs would need to be `https://messagekit.github.io/documentation/messagekit`.
index.html would need to be modified with a redirect to avoid this, but it would be a hack as that's not how DocC currently works.
The automation also pushes InputAccessoryBarView's docs to the following URL:
`https://messagekit.github.io/inputbaraccessoryview/documentation/inputbaraccessoryview/`

Where has this been tested?
---------------------------
Locally for this repository, also on another project I work on, [VideoUIKit-iOS](https://github.com/AgoraIO-Community/VideoUIKit-iOS). This is probably already known, but as the owner and repo in MessageKit's instance are the same, the url base does not need the repo name after github.io.

To test it out locally, run the commands found in `.github/workflows/deploy_docs.yaml`, then launch the server with python for example: `python3 -m http.server`. And open `http://localhost:8000/documentation/messagekit/` in any browser.

<img width="1080" alt="Screenshot 2022-08-29 at 10 50 41" src="https://user-images.githubusercontent.com/5754073/187175636-29c33709-a723-4883-b46d-53eb59fdd6c6.png">


Once the next release of DocC and Xcode is out and available via GitHub Actions, this action can be adapted to use it with ease.
