### PR TITLE
 👻 Changed 'didChangeStatusBarOrientationNotification' to 'UIDevice.orie…

### DIFF
--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -346,7 +346,7 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(MessagesCollectionViewFlowLayout.handleOrientationChange(_:)),
-      name: UIApplication.didChangeStatusBarOrientationNotification,
+      name: UIDevice.orientationDidChangeNotification,
       object: nil)
   }
 


### PR DESCRIPTION
…ntationDidChangeNotification' due to deprecation.

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
A depcrecation warning on MessagesCollectionViewFlowLayout.Swift

Does this close any currently open issues?
------------------------------------------
No Issues Found


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->
None
Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** iOS 12 Pro Sim

**iOS Version:** 15.5

**Swift Version:** 5.5

**MessageKit Version:** Latest one from github


