### PR TITLE
Fix hiding typing indicator crash.

### DIFF
--- a/Sources/Controllers/MessagesViewController+TypingIndicator.swift
+++ b/Sources/Controllers/MessagesViewController+TypingIndicator.swift
@@ -50,14 +50,15 @@ extension MessagesViewController {
     }
 
     let section = messagesCollectionView.numberOfSections
-    messagesCollectionView.setTypingIndicatorViewHidden(isHidden)
 
     if animated {
       messagesCollectionView.performBatchUpdates({ [weak self] in
+        self?.messagesCollectionView.setTypingIndicatorViewHidden(isHidden)
         self?.performUpdatesForTypingIndicatorVisability(at: section)
         updates?()
       }, completion: completion)
     } else {
+      messagesCollectionView.setTypingIndicatorViewHidden(isHidden)
       performUpdatesForTypingIndicatorVisability(at: section)
       updates?()
       completion?(true)


### PR DESCRIPTION
👻

Set typing indicator hidden inside performBatchUpdates to prevent flow layout from requesting message type from DataSource for typing indicator section.

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Showing the typing indicator works fine, but when hiding it, a crash occurs in the following function of `MessagesDataSource` with message `index out of bounds`:
```swift
    func messageForItem(at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageType {
        return messages[indexPath.section]
    }
```

The stacktrace indicates this is coming from the following function in `MessagesCollectionViewFlowLayout`:
```swift
  open func cellSizeCalculatorForItem(at indexPath: IndexPath) -> CellSizeCalculator {
    if isSectionReservedForTypingIndicator(indexPath.section) {
      return typingIndicatorSizeCalculator
    }
    let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView) // Here
    switch message.kind {
// ...
```

This is because `messagesCollectionView.performBatchUpdates()` causes the `MessagesCollectionViewFlowLayout` to update. But because we have already set the typing indicator to `isHidden = true` before calling `performBatchUpdates()`, the call to `isSectionReservedForTypingIndicator` in flow layout will return false. This causes a call to `messageForItem` for a section dedicated to the typing indicator, which causes the `index out of bounds` crash since we are not expecting the library to request anything for this section.

When I made the change in this PR to my local codebase, it fixed the issue and the typing indicator hiding worked properly. This was tested within the app I am using MessageKit.

I've seen the example app crash a couple of times aswell and I think this might be because of the same issue. Specifically the advanced example.

Does this close any currently open issues?
------------------------------------------
Found this crash myself while developing an app that is using MessageKit.

Possible fix for https://github.com/MessageKit/MessageKit/issues/1788


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:**
- iPhone 11 Pro
- iPhone 12 Pro

**iOS Version:** 
- iOS 15.4
- iOS 16.0

**Swift Version:** Latest

**MessageKit Version:** 4.1.1


