### PR TITLE
Fix for SwiftUI example IBAV position issues (example app)

### DIFF
--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -333,7 +333,7 @@ extension ChatViewController: InputBarAccessoryViewDelegate {
 
       let substring = attributedText.attributedSubstring(from: range)
       let context = substring.attribute(.autocompletedContext, at: 0, effectiveRange: nil)
-      print("Autocompleted: `", substring, "` with context: ", context ?? [])
+      print("Autocompleted: `", substring, "` with context: ", context ?? "-")
     }
 
     let components = inputBar.inputTextView.components

--- a/Example/Sources/Views/SwiftUI/SwiftUIExampleView.swift
+++ b/Example/Sources/Views/SwiftUI/SwiftUIExampleView.swift
@@ -23,9 +23,20 @@ struct SwiftUIExampleView: View {
       self.cleanupSocket()
     }
     .navigationBarTitle("SwiftUI Example", displayMode: .inline)
+    .modifier(IgnoresSafeArea()) //fixes issue with IBAV placement when keyboard appears
   }
 
   // MARK: Private
+    
+  private struct IgnoresSafeArea: ViewModifier {
+      func body(content: Content) -> some View {
+          if #available(iOS 14.0, *) {
+              content.ignoresSafeArea(.keyboard, edges: .bottom)
+          } else {
+              content
+          }
+      }
+  }
 
   private func connectToMessageSocket() {
     MockSocket.shared.connect(with: [SampleData.shared.nathan, SampleData.shared.wu]).onNewMessage { message in


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes IBAV position issues in the SwiftUI example of the example app by adding `ignorersSafeArea` modifier to the body.

I also fixed a small warning in the example app while I was at it.

Does this close any currently open issues?
------------------------------------------
https://github.com/MessageKit/MessageKit/issues/1734 and a couple of others probably

Any other comments?
-------------------
The fix also needs IBAV 6.3.0 to work properly, which was added to MessageKit today. Hence I send this PR today.

Also iOS 13 users are out of luck..., but it forced me to do a iOS version check which made things a bit ugly.

Where has this been tested?
---------------------------
iPhone and iPad simulator and iPhone Xs with iOS 16
MessageKit 4.2.0


