### PR TITLE
Added ability to specify additionalBottomSpace for keyboardManager

### DIFF
--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -31,7 +31,10 @@ extension MessagesViewController {
   // MARK: - Register Observers
 
   internal func addKeyboardObservers() {
-    keyboardManager.bind(inputAccessoryView: inputContainerView)
+    keyboardManager.bind(
+      inputAccessoryView: inputContainerView, 
+      withAdditionalBottomSpace: { [weak self] in self?.inputBarAdditionalBottomSpace() ?? 0 }
+    )
     keyboardManager.bind(to: messagesCollectionView)
 
     /// Observe didBeginEditing to scroll content to last item if necessary

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -66,6 +66,11 @@ open class MessagesViewController: UIViewController, UICollectionViewDelegateFlo
     }
   }
 
+  /// withAdditionalBottomSpace parameter for InputBarAccessoryView's KeyboardManager
+  open func inputBarAdditionalBottomSpace() -> CGFloat {
+    0
+  }
+
   open override func viewDidLoad() {
     super.viewDidLoad()
     setupDefaults()


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Creates an open method that allows to specify withAdditionalBottomSpace argument for InputBarAccessoryView's bind method. This is necessary when MessageView does not occupy full screen and there is something on the bottom (in our case banner view)

Does this close any currently open issues?
------------------------------------------
I couldn't find any


Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 15 Pro, iPhone 15 Pro simulator

**iOS Version:** 17

**Swift Version:** 5.9

**MessageKit Version:** main branch


