### PR TITLE
Added listener for keyboard input mode changes (e.g. emoji keyboard)

### DIFF
--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -74,6 +74,7 @@ extension MessagesViewController {
       .subscribe(on: DispatchQueue.global())
       .receive(on: DispatchQueue.main)
       .removeDuplicates()
+      .delay(for: .milliseconds(50), scheduler: DispatchQueue.main) /// Wait for next runloop to lay out inputView properly
       .sink { [weak self] _ in
           self?.updateMessageCollectionViewBottomInset()
           

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -69,6 +69,20 @@ extension MessagesViewController {
       }
       .store(in: &disposeBag)
 
+    NotificationCenter.default
+      .publisher(for: UITextInputMode.currentInputModeDidChangeNotification)
+      .subscribe(on: DispatchQueue.global())
+      .receive(on: DispatchQueue.main)
+      .removeDuplicates()
+      .sink { [weak self] _ in
+          self?.updateMessageCollectionViewBottomInset()
+          
+          if !(self?.maintainPositionOnInputBarHeightChanged ?? false) {
+              self?.messagesCollectionView.scrollToLastItem()
+          }
+      }
+      .store(in: &disposeBag)
+
     /// Observe frame change of the input bar container to update collectioView bottom inset
     inputContainerView.publisher(for: \.center)
       .receive(on: DispatchQueue.main)


### PR DESCRIPTION
👻

What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes an issue in which a change in the keyboard type (e.g. opening the emoji keyboard) does not trigger an update in the keyboard inset.
I've just added a listener for the `currentInputModeDidChangeNotification` publisher which updates the bottom inset and scrolls to the latest message when received.


Does this close any currently open issues?
------------------------------------------
Nope


Any relevant logs, error output, etc?
-------------------------------------
Nope


Any other comments?
-------------------
Here's a screen recording of the current buggy state and the fixed version:

https://github.com/MessageKit/MessageKit/assets/163006218/bb865513-1e47-4732-a366-847795fda666

https://github.com/MessageKit/MessageKit/assets/163006218/e1a2c271-0906-43c6-ae27-bef7b1652b3f


Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 15 (Simulator)

**iOS Version:** 17.5

**Swift Version:** 5.10

**MessageKit Version:** 4.2.0


