### PR TITLE
Fix for overlapping detected matches

### DIFF
--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -363,7 +363,7 @@ open class MessageLabel: UILabel {
       .filter { $0.isCustom }
       .map { parseForMatches(with: $0, in: text, for: range) }
       .joined()
-    matches.append(contentsOf: regexs)
+    matches.append(contentsOf: removeOverlappingResults(Array(regexs)))
 
     // Get all Checking Types of detectors, except for .custom because they contain their own regex
     let detectorCheckingTypes = enabledDetectors
@@ -401,6 +401,28 @@ open class MessageLabel: UILabel {
     default:
       fatalError("You must pass a .custom DetectorType")
     }
+  }
+  
+  private func removeOverlappingResults(_ results: [NSTextCheckingResult]) -> [NSTextCheckingResult]
+  {
+    var filteredResults: [NSTextCheckingResult] = []
+    
+    for result in results {
+      let overlappingResults = results.filter { $0.range.intersection(result.range)?.length ?? 0 > 0 }
+      
+      if overlappingResults.count <= 1 {
+        filteredResults.append(result)
+        continue
+      }
+      
+      guard !filteredResults.contains(where: { $0.range == result.range }) else { continue }
+      let maxRangeResult = overlappingResults.max { $0.range.upperBound - $0.range.lowerBound < $1.range.upperBound - $1.range.lowerBound }
+      if let maxRangeResult {
+        filteredResults.append(maxRangeResult)
+      }
+    }
+    
+    return filteredResults
   }
 
   private func setRangesForDetectors(in checkingResults: [NSTextCheckingResult]) {

--- a/Tests/MessageKitTests/Controllers Test/MessageLabelTests.swift
+++ b/Tests/MessageKitTests/Controllers Test/MessageLabelTests.swift
@@ -82,6 +82,21 @@ final class MessageLabelTests: XCTestCase {
     let invalidMatches = extractCustomDetectors(for: detector, with: messageLabel)
     XCTAssertEqual(invalidMatches.count, 0)
   }
+  
+  func testCustomDetectionOverlapping() {
+    let testText = "address MNtz8Zz1cPD1CZadoc38jT5qeqeFBS6Aif can match multiple regex's"
+    
+    let messageLabel = MessageLabel()
+    let attributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key(rawValue: "Custom"): "CustomDetected"]
+    let detectors = [
+      DetectorType.custom(try! NSRegularExpression(pattern: "(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}", options: .caseInsensitive)), 
+      DetectorType.custom(try! NSRegularExpression(pattern: #"([3ML][\w]{26,33})|ltc1[\w]+"#, options: .caseInsensitive)), 
+      DetectorType.custom(try! NSRegularExpression(pattern: "[qmN][a-km-zA-HJ-NP-Z1-9]{26,33}", options: .caseInsensitive))]
+    
+    set(text: testText, and: detectors, with: attributes, to: messageLabel)
+    let matches = detectors.map { extractCustomDetectors(for: $0, with: messageLabel) }.joined()
+    XCTAssertEqual(matches.count, 1)
+  }
 
   func testSyncBetweenAttributedAndText() {
     let messageLabel = MessageLabel()


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When using in MessageLabel multiple custom detector types, some text can match multiple regex's, and then they will be applied, and final action will be related of tap position. My fix removes all overlapped matches and leaves only one biggest.

Sample:
Text in message: "address MNtz8Zz1cPD1CZadoc38jT5qeqeFBS6Aif can match multiple regex's"
Regex's for custom detectors: "(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}", "([3ML][\w]{26,33})|ltc1[\w]+", "[qmN][a-km-zA-HJ-NP-Z1-9]{26,33}"
Detected matches before fix: MNtz8Zz1cPD1CZadoc38jT5qeqeFBS6Aif, Ntz8Zz1cPD1CZadoc38jT5qeqeFBS6Aif, 1cPD1CZadoc38jT5qeqeFBS6Aif
Detected matches after fix: MNtz8Zz1cPD1CZadoc38jT5qeqeFBS6Aif

Does this close any currently open issues?
------------------------------------------
Nope


Any relevant logs, error output, etc?
-------------------------------------
Nope

Any other comments?
-------------------
Nope

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 15 (Simulator)

**iOS Version:** 17.5

**Swift Version:** 5.10

**MessageKit Version:** 4.2.0


