### PR TITLE
Fix timestamp label layout when not in fullscreen

### DIFF
--- a/Sources/Views/Cells/MessageContentCell.swift
+++ b/Sources/Views/Cells/MessageContentCell.swift
@@ -365,9 +365,8 @@ open class MessageContentCell: MessageCollectionViewCell {
   open func layoutTimeLabelView(with attributes: MessagesCollectionViewLayoutAttributes) {
     let paddingLeft: CGFloat = 10
     let origin = CGPoint(
-      x: UIScreen.main.bounds.width + paddingLeft,
-      y: messageContainerView.frame.minY + messageContainerView.frame.height * 0.5 - messageTimestampLabel
-        .font.ascender * 0.5)
+        x: self.frame.maxX + paddingLeft,
+        y: messageContainerView.frame.minY + messageContainerView.frame.height * 0.5 - messageTimestampLabel.font.ascender * 0.5)
     let size = CGSize(width: attributes.messageTimeLabelSize.width, height: attributes.messageTimeLabelSize.height)
     messageTimestampLabel.frame = CGRect(origin: origin, size: size)
   }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
MessageKit shows timestamps when `showMessageTimestampOnSwipeLeft = true`, but I notice a bug that timestamp label layout is wrong when app isn't in fullscreen or is using UISplitViewController. So actually if we run the built-in Example project in iPad simulator, since it uses UISplitViewController, we can easily find this issue (screenshots below).

The fix is easy, just replace `UIScreen.main.bounds.width + paddingLeft` with `self.frame.maxX + paddingLeft`. Because the timestamp labels are relatively positioned to the `MessageContentCell`, not the screen.

Does this close any currently open issues?
------------------------------------------
No, I didn't find any related discussion.

Any relevant logs, error output, etc?
-------------------------------------
No, only UI layout

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Devices/Simulators:** Both simulator and real devices (iPad Pro 11-inch 2018)

**iOS Version:** iOS 17.5

**Swift Version:** Swift 5

**MessageKit Version:** v4.2.0

Screenshots before & after

![Simulator Screenshot - iPad (10th generation) - 2024-07-30 at 18 55 26](https://github.com/user-attachments/assets/00add5a4-bd77-4b06-b71d-b34db0afd5d4)

![Simulator Screenshot - iPad (10th generation) - 2024-07-30 at 18 49 53](https://github.com/user-attachments/assets/648d6a0e-4cca-4c7e-a5b4-f0f09bd83c4d)


