### PR TITLE
Throw fatalError when the coordinate is invalid

### DIFF
--- a/Sources/Views/Cells/LocationMessageCell.swift
+++ b/Sources/Views/Cells/LocationMessageCell.swift
@@ -72,6 +72,8 @@ open class LocationMessageCell: MessageContentCell {
       in: messagesCollectionView)
 
     guard case .location(let locationItem) = message.kind else { fatalError("Configuring LocationMessageCell with wrong") }
+      
+    guard CLLocationCoordinate2DIsValid(locationItem.location.coordinate) else { fatalError("Coordinate is not valid") }
 
     activityIndicator.startAnimating()
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------

Throw fataError when the  coordinate is invalid in LocationMessageCell

Does this close any currently open issues?
------------------------------------------

YES .  https://github.com/MessageKit/MessageKit/issues/1872


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

iPhone12 pro

**iOS Version:** …

18.1

**Swift Version:** …

swift 5 

**MessageKit Version:** …

main branch
