### PR TITLE
Fix scrollToLastItem issues with sectionInset, footerView, and navigation bar blur

### DIFF
--- a/Example/Sources/View Controllers/LaunchViewController.swift
+++ b/Example/Sources/View Controllers/LaunchViewController.swift
@@ -43,6 +43,20 @@ final internal class LaunchViewController: UITableViewController {
     title = "MessageKit"
     navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
     navigationController?.navigationBar.tintColor = .primaryColor
+    if let navigationBar = self.navigationController?.navigationBar {
+        if #available(iOS 15.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.backgroundEffect = nil
+            appearance.backgroundColor = .white
+            navigationBar.standardAppearance = appearance
+            navigationBar.scrollEdgeAppearance = appearance
+        } else {
+            navigationBar.setBackgroundImage(UIImage(), for: .default)
+            navigationBar.shadowImage = UIImage()
+            navigationBar.barTintColor = .white
+        }
+    }
+      
     tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
     tableView.tableFooterView = UIView()
   }

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -80,7 +80,7 @@ open class MessagesCollectionView: UICollectionView {
   // MARK: Public
 
   // NOTE: It's possible for small content size this wouldn't work - https://github.com/MessageKit/MessageKit/issues/725
-  public func scrollToLastItem(at pos: UICollectionView.ScrollPosition = .bottom, animated: Bool = true) {
+  public func scrollToLastItem(at pos: UICollectionView.ScrollPosition = .top, animated: Bool = true) {
     guard let indexPath = indexPathForLastItem else { return }
 
     scrollToItem(at: indexPath, at: pos, animated: animated)


### PR DESCRIPTION
1. Fix the issue where scrollToLastItem does not take sectionInset.bottom and footerView into account.
2. Fix the issue where scrollToLastItem causes the navigation bar's blur effect to abruptly change.	
