### PR TITLE
Repair the formatting and linting entry points

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,7 +1,7 @@
 # options
---swiftversion 5.6
+--swiftversion 6.0
 --self remove # redundantSelf
---importgrouping testable-bottom # sortedImports
+--importgrouping testable-bottom # sortImports
 --commas always # trailingCommas
 --trimwhitespace always # trailingSpace
 --indent 2 #indent
@@ -51,7 +51,7 @@
 --rules redundantGet
 --rules redundantFileprivate
 --rules redundantRawValues
---rules sortedImports
+--rules sortImports
 --rules sortDeclarations
 --rules strongifiedSelf
 --rules trailingCommas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ### Fixed
 
+- Fix `make format`, `make lint` and the pre-commit hook, which still called the removed SwiftPM plugins by [@martinpucik](https://github.com/martinpucik)
+
 ### Updated
 
 - Update InputBarAccessoryView to fix some crashes and issues by [@kaspik](https://github.com/Kaspik)

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,13 @@ build_example:
 	@cd Example && set -o pipefail && xcodebuild build analyze -scheme ChatExample -destination "platform=iOS Simulator,name=iPhone 16" CODE_SIGNING_REQUIRED=NO | xcpretty -c
 
 format:
-	@swift package --allow-writing-to-package-directory format-source-code --file .
+	@echo "Formatting MessageKit."
+	@swiftformat .
 
 lint:
-	@swift package --disable-sandbox lint
+	@echo "Linting MessageKit."
+	@swiftformat --lint .
+	@swiftlint lint --quiet
 
 setup:
 	@mkdir -p .git/hooks

--- a/Scripts/pre-commit
+++ b/Scripts/pre-commit
@@ -1,6 +1,11 @@
 #!/bin/sh
 
+if ! command -v swiftformat >/dev/null 2>&1; then
+	echo "swiftformat not found. Install it with: brew install swiftformat"
+	exit 1
+fi
+
 git diff --diff-filter=d --staged --name-only | grep -e '\(.*\).swift$' | while read line; do
-	swift package --allow-writing-to-package-directory format-source-code --file "${line}";
+	swiftformat "${line}";
   git add "$line";
 done


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

`make format`, `make lint` and `Scripts/pre-commit` all still invoke the SwiftPM plugins that were deleted in 6bb47d5a ("Remove plugins that caused issues, migrate to swift 6"), so all three have been failing since October 2024:

```make
format:  @swift package --allow-writing-to-package-directory format-source-code --file .
lint:    @swift package --disable-sandbox lint
```

`Package.swift` has no plugins, and this PR deliberately does not add any back — that would put the dependency on every MessageKit consumer. Instead the targets call the `swiftformat` and `swiftlint` binaries directly, and the pre-commit hook now reports a missing `swiftformat` with an install hint rather than silently doing nothing.

Also modernises `.swiftformat`, which had drifted:

- `--swiftversion` said `5.6` while the package builds in Swift 6 language mode.
- `sortedImports` was renamed to `sortImports` upstream and emitted a deprecation warning on every run.

Verified against SwiftFormat 0.62.1 — the version preinstalled on the CI runners — that neither change alters which files need formatting, so this is purely a config refresh.

Does this close any currently open issues?
------------------------------------------

No.

Any other comments?
-------------------

**This intentionally does not reformat the codebase.** 47 of 123 files currently fail `swiftformat --lint`, so `make lint` will still report failures after this lands — the entry points work again, but the existing drift is untouched.

That reformat is deliberately left for a follow-up, because it touches `Sources/Views/MessagesCollectionView.swift`, which #1832 is currently modifying. Doing it here would force that contributor to rebase. The drift breaks down as roughly 252 `organizeDeclarations`, 49 `indent`, 29 `wrap` and 13 `trailingSpace` violations — about `+1032/-1010` across 47 files.

Where has this been tested?
---------------------------

Locally, with SwiftFormat 0.62.1 and SwiftLint 0.65.0 (the versions on the CI images):

- `make lint` runs and correctly fails on the pre-existing drift, with no deprecation warnings.
- `make format` runs and formats 47/123 files, confirming the target works end to end. That result was then discarded, since reformatting is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)