### PR TITLE
Repair the crashes in the example app

### DIFF
--- a/.github/workflows/ci_pr_example.yml
+++ b/.github/workflows/ci_pr_example.yml
@@ -18,3 +18,5 @@ jobs:
         fetch-depth: 10
     - name: Build and run example project
       run: make build_example
+    - name: Run example UI tests
+      run: make test_example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 ### Fixed
 
 - Fix `make format`, `make lint` and the pre-commit hook, which still called the removed SwiftPM plugins by [@martinpucik](https://github.com/martinpucik)
+- Adopt the scene lifecycle in the example app, which crashed on launch on iOS 26 and later by [@martinpucik](https://github.com/martinpucik)
+- Add the missing camera and photo library usage descriptions to the example app, which crashed when you opened the camera by [@martinpucik](https://github.com/martinpucik)
+- Stop the example app from crashing when you switch off every message type in Settings by [@martinpucik](https://github.com/martinpucik)
+- Repair the example app UI test, which looked for a row that does not exist, and run it in CI by [@martinpucik](https://github.com/martinpucik)
 
 ### Updated
 

--- a/Example/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/ChatExample.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		032A15DD25965D9A00E00FE3 /* AlertService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032A15DC25965D9A00E00FE3 /* AlertService.swift */; };
 		032A15E225965E1100E00FE3 /* CameraInputBarAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032A15E125965E1100E00FE3 /* CameraInputBarAccessoryView.swift */; };
+		135CCA0F3036536700C6351F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135CCA0E3036536700C6351F /* SceneDelegate.swift */; };
 		138A04D428254AD300E2780F /* CustomInputBarExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138A04D328254AD300E2780F /* CustomInputBarExampleViewController.swift */; };
 		13EFA5D727AC5631003002CC /* MessageKit in Frameworks */ = {isa = PBXBuildFile; productRef = 13EFA5D627AC5631003002CC /* MessageKit */; };
 		13EFA5D927AC5634003002CC /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 13EFA5D827AC5634003002CC /* Kingfisher */; };
@@ -71,6 +72,7 @@
 /* Begin PBXFileReference section */
 		032A15DC25965D9A00E00FE3 /* AlertService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertService.swift; sourceTree = "<group>"; };
 		032A15E125965E1100E00FE3 /* CameraInputBarAccessoryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraInputBarAccessoryView.swift; sourceTree = "<group>"; };
+		135CCA0E3036536700C6351F /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		138A04D328254AD300E2780F /* CustomInputBarExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomInputBarExampleViewController.swift; sourceTree = "<group>"; };
 		13CCA04225793002005C19BB /* MessageKit */ = {isa = PBXFileReference; lastKnownFileType = folder; path = MessageKit; sourceTree = "<group>"; };
 		13EFA5D027AC5368003002CC /* MessageKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = MessageKit; path = ..; sourceTree = "<group>"; };
@@ -297,6 +299,7 @@
 				5074EF4B2163554900D82952 /* Sounds */,
 				385C2949211FF3930010B4BA /* View Controllers */,
 				385C2924211FF3310010B4BA /* Views */,
+				135CCA0E3036536700C6351F /* SceneDelegate.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -500,6 +503,7 @@
 				1C5433DD24C389C300A5383B /* MessagesView.swift in Sources */,
 				882B5E811CF7D53600B6E160 /* AppDelegate.swift in Sources */,
 				385C292D211FF3520010B4BA /* CustomMessageFlowLayout.swift in Sources */,
+				135CCA0F3036536700C6351F /* SceneDelegate.swift in Sources */,
 				032A15E225965E1100E00FE3 /* CameraInputBarAccessoryView.swift in Sources */,
 				38CCCC592258419300DD5482 /* AutocompleteExampleViewController.swift in Sources */,
 				63ECDAC2241889630016C349 /* MessageSubviewContainerViewController.swift in Sources */,
@@ -606,7 +610,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -659,7 +663,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -673,7 +677,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Resources/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -688,7 +692,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Resources/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -705,7 +709,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -722,7 +726,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -740,7 +744,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = UITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -756,7 +760,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = UITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Example/Sources/Data Generation/SampleData.swift
+++ b/Example/Sources/Data Generation/SampleData.swift
@@ -190,10 +190,12 @@ final internal class SampleData {
   }
 
   func randomMessageType() -> MessageTypes {
-    MessageTypes.allCases.compactMap {
+    let enabled: [MessageTypes] = MessageTypes.allCases.compactMap {
       guard UserDefaults.standard.bool(forKey: "\($0.rawValue)" + " Messages") else { return nil }
       return $0
-    }.random()!
+    }
+    // Settings lets every type be switched off, which would leave nothing to pick from.
+    return enabled.random() ?? .Text
   }
 
   // swiftlint:disable cyclomatic_complexity

--- a/Example/Sources/Extensions/AlertService.swift
+++ b/Example/Sources/Extensions/AlertService.swift
@@ -22,6 +22,6 @@ class AlertService {
       alert.addAction(action)
     }
 
-    UIApplication.shared.delegate?.window??.rootViewController?.present(alert, animated: true, completion: completion)
+    UIViewController.keyWindowRoot?.present(alert, animated: true, completion: completion)
   }
 }

--- a/Example/Sources/Extensions/UIViewController+Extensions.swift
+++ b/Example/Sources/Extensions/UIViewController+Extensions.swift
@@ -23,6 +23,16 @@
 import UIKit
 
 extension UIViewController {
+  /// The root view controller of the app's foreground window, for code that has no
+  /// view controller of its own to present from.
+  static var keyWindowRoot: UIViewController? {
+    UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .first { $0.activationState == .foregroundActive }?
+      .keyWindow?
+      .rootViewController
+  }
+
   func updateTitleView(title: String, subtitle: String?) {
     let titleLabel = UILabel(frame: CGRect(x: 0, y: -2, width: 0, height: 0))
     titleLabel.backgroundColor = UIColor.clear

--- a/Example/Sources/Resources/Info.plist
+++ b/Example/Sources/Resources/Info.plist
@@ -28,11 +28,32 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>MessageKit uses the camera so you can take a photo and attach it to a message.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>MessageKit uses your photo library so you can attach an existing photo to a message.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
+		<string>arm64</string>
 	</array>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>

--- a/Example/Sources/SceneDelegate.swift
+++ b/Example/Sources/SceneDelegate.swift
@@ -22,22 +22,24 @@
 
 import UIKit
 
-@main
-final internal class AppDelegate: UIResponder, UIApplicationDelegate {
-  func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    if UserDefaults.isFirstLaunch() {
-      // Enable Text Messages
-      UserDefaults.standard.set(true, forKey: "Text Messages")
-    }
-    return true
-  }
+final internal class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
 
-  func application(
-    _: UIApplication,
-    configurationForConnecting connectingSceneSession: UISceneSession,
-    options _: UIScene.ConnectionOptions)
-    -> UISceneConfiguration
-  {
-    UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+  func scene(_ scene: UIScene, willConnectTo _: UISceneSession, options _: UIScene.ConnectionOptions) {
+    guard let windowScene = scene as? UIWindowScene else { return }
+
+    let masterViewController = UINavigationController(rootViewController: LaunchViewController())
+    masterViewController.navigationItem.largeTitleDisplayMode = .never
+
+    let splitViewController = UISplitViewController()
+    splitViewController.viewControllers = UIDevice.current.userInterfaceIdiom == .pad
+      ? [masterViewController, UIViewController()]
+      : [masterViewController]
+    splitViewController.preferredDisplayMode = .oneBesideSecondary
+
+    let window = UIWindow(windowScene: windowScene)
+    window.rootViewController = splitViewController
+    window.makeKeyAndVisible()
+    self.window = window
   }
 }

--- a/Example/Sources/Views/CameraInputBarAccessoryView.swift
+++ b/Example/Sources/Views/CameraInputBarAccessoryView.swift
@@ -135,7 +135,7 @@ extension CameraInputBarAccessoryView: UIImagePickerControllerDelegate, UINaviga
   }
 
   func getRootViewController() -> UIViewController? {
-    (UIApplication.shared.delegate as? AppDelegate)?.window?.rootViewController
+    UIViewController.keyWindowRoot
   }
 }
 

--- a/Example/Sources/Views/SwiftUI/MessagesView.swift
+++ b/Example/Sources/Views/SwiftUI/MessagesView.swift
@@ -56,9 +56,12 @@ struct MessagesView: UIViewControllerRepresentable {
     }()
 
     var messages: Binding<[MessageType]>
+
+    /// Lets the first scroll happen without animation, so the initial messages do
+    /// not visibly flash past on the way to the bottom.
+    var hasScrolledToBottomOnce = false
   }
 
-  @State var initialized = false
   @Binding var messages: [MessageType]
 
   func makeUIViewController(context: Context) -> MessagesViewController {
@@ -75,9 +78,9 @@ struct MessagesView: UIViewControllerRepresentable {
     return messagesVC
   }
 
-  func updateUIViewController(_ uiViewController: MessagesViewController, context _: Context) {
+  func updateUIViewController(_ uiViewController: MessagesViewController, context: Context) {
     uiViewController.messagesCollectionView.reloadData()
-    scrollToBottom(uiViewController)
+    scrollToBottom(uiViewController, coordinator: context.coordinator)
   }
 
   func makeCoordinator() -> Coordinator {
@@ -86,11 +89,10 @@ struct MessagesView: UIViewControllerRepresentable {
 
   // MARK: Private
 
-  private func scrollToBottom(_ uiViewController: MessagesViewController) {
+  private func scrollToBottom(_ uiViewController: MessagesViewController, coordinator: Coordinator) {
     DispatchQueue.main.async {
-      // The initialized state variable allows us to start at the bottom with the initial messages without seeing the initial scroll flash by
-      uiViewController.messagesCollectionView.scrollToLastItem(animated: self.initialized)
-      self.initialized = true
+      uiViewController.messagesCollectionView.scrollToLastItem(animated: coordinator.hasScrolledToBottomOnce)
+      coordinator.hasScrolledToBottomOnce = true
     }
   }
 }

--- a/Example/UITests/ChatExampleUITests.swift
+++ b/Example/UITests/ChatExampleUITests.swift
@@ -17,28 +17,47 @@
 //
 
 import XCTest
-@testable import ChatExample
 
 final class ChatExampleUITests: XCTestCase {
+  // MARK: Internal
+
   override func setUp() {
     super.setUp()
 
     // In UI tests it is usually best to stop immediately when a failure occurs.
     continueAfterFailure = false
-    // UI tests must launch the application that they test.
-    // Doing this in setup will make sure it happens for each test method.
-    XCUIApplication().launch()
-
-    // In UI tests it’s important to set the initial state
-    // - such as interface orientation - required for your tests before they run.
-    // The setUp method is a good place to do this.
   }
 
-  func testExampleRuns() {
-    // Extremely simple UI test which is designed to run and display the example project
-    // This should show if there are any very obvious crashes on render
+  /// Smoke test: open every example in turn and check that it renders at least one
+  /// message. This catches very obvious crashes on render.
+  func testEveryExampleRenders() {
     let app = XCUIApplication()
-    app.tables.staticTexts["Test"].tap()
-    XCTAssertTrue(app.collectionViews.staticTexts["Check out this awesome UI library for Chat"].exists)
+    app.launch()
+
+    for example in Self.chatExamples {
+      let row = app.tables.staticTexts[example]
+      XCTAssertTrue(row.waitForExistence(timeout: 10), "Missing row for \(example)")
+      row.tap()
+
+      let collectionView = app.collectionViews.firstMatch
+      XCTAssertTrue(collectionView.waitForExistence(timeout: 10), "\(example) did not render a collection view")
+      XCTAssertGreaterThan(collectionView.cells.count, 0, "\(example) rendered no messages")
+
+      app.navigationBars.buttons.firstMatch.tap()
+    }
   }
+
+  // MARK: Private
+
+  /// The example rows that present a chat. Kept in sync with `LaunchViewController.Row`.
+  private static let chatExamples = [
+    "Basic Example",
+    "Advanced Example",
+    "Autocomplete Example",
+    "Embedded Example",
+    "Custom Layout Example",
+    "Subview Example",
+    "Custom InputBar Example",
+    "SwiftUI Example",
+  ]
 }

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,12 @@ framework:
 	@set -o pipefail && xcodebuild build -scheme MessageKit -destination "platform=iOS Simulator,name=iPhone 16" | xcpretty -c
 
 build_example:
-	@echo "Building & testing MessageKit Example app."
+	@echo "Building & analyzing MessageKit Example app."
 	@cd Example && set -o pipefail && xcodebuild build analyze -scheme ChatExample -destination "platform=iOS Simulator,name=iPhone 16" CODE_SIGNING_REQUIRED=NO | xcpretty -c
+
+test_example:
+	@echo "Running MessageKit Example app UI tests."
+	@cd Example && set -o pipefail && xcodebuild test -scheme ChatExampleUITests -destination "platform=iOS Simulator,name=iPhone 16" CODE_SIGNING_REQUIRED=NO | xcpretty -c
 
 format:
 	@echo "Formatting MessageKit."


### PR DESCRIPTION
The example app does not run on current iOS. This fixes that, plus two other crashes and the UI test that would have caught them.

## The launch crash

On iOS 26 and later UIKit traps when an app does not adopt the scene lifecycle:

```
Thread 0 Crashed:
UIKitCore  ___UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption_block_invoke
UIKitCore  -[UIApplication workspace:didCreateScene:withTransitionContext:completion:]
```

The example still built its window in `AppDelegate`. Window setup moves to a new `SceneDelegate`, and `Info.plist` declares `UIApplicationSceneManifest`. Two places read the window through `UIApplication.shared.delegate`, so they now go through the connected scene instead.

The crash is invisible under the debugger, which is why it survived: `Cmd-R` looks fine and only an unattached launch dies.

## The camera crash

The Advanced example shows a camera button whose action sheet offers "Take From Camera", but `Info.plist` had no `NSCameraUsageDescription`. Opening the camera killed the app on a device. Added, along with `NSPhotoLibraryUsageDescription`.

## The Settings crash

`randomMessageType()` force unwrapped `random()` on the list of enabled message types. Settings lets you switch all of them off, and the next message then crashed the app. It falls back to `.Text`.

## The UI test

`testExampleRuns` tapped a row named `"Test"`. The launch screen has no such row (the rows are "Basic Example", "Advanced Example", and so on), and it asserted on the sentence "Check out this awesome UI library for Chat", which appears nowhere in the project. The test could never pass.

It is now `testEveryExampleRenders`, which opens each of the 8 examples in turn and checks that each renders messages. This is what catches the launch crash above.

Nothing ran it: `make build_example` printed "Building & testing" but ran only `xcodebuild build analyze`, and the UI test lives in a separate scheme. There is now a `make test_example` target, and the example workflow runs it.

## Also

- `UIRequiredDeviceCapabilities` was `armv7`, a 32-bit architecture that cannot run this app.
- The SwiftUI example kept its "already scrolled once" flag in `@State` and mutated it from `updateUIViewController`. `@State` written outside `body` does not hold, so the first scroll always animated instead of starting silently at the bottom. The flag moves to the `Coordinator`.
- The example deployment target goes from 14.0 to 15.0. Xcode 26 and later refuse to build for iOS 14 at all, so the example currently does not compile on a current toolchain. `Package.swift` still declares `.iOS(.v14)` — raising the library minimum is a separate decision and is not in this PR.

## Verification

Built and ran on an iPhone 17 simulator (iOS 27). `testEveryExampleRenders` passes and walks all 8 examples; it fails on `main` because the app crashes at launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)