### PR TITLE
Enforce make lint in CI

### DIFF
--- a/.github/workflows/ci_pr_lint.yml
+++ b/.github/workflows/ci_pr_lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on: pull_request
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Run SwiftFormat and SwiftLint
+    runs-on: macos-15
+    steps:
+    - name: Checkout the Git repository
+      uses: actions/checkout@v4
+    - name: Install the linters
+      run: brew install swiftformat swiftlint
+    - name: Lint
+      run: make lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
     
 ### Changed
 
+- Enforce `make lint` in CI and reformat the sources it flagged by [@martinpucik](https://github.com/martinpucik)
+
 - Migrate Danger from Ruby to Danger Swift and drop the `Gemfile` by [@martinpucik](https://github.com/martinpucik)
 
 ### Removed

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -26,29 +26,30 @@ let pullRequest = danger.github.pullRequest
 
 // Make it more obvious that a PR is a Draft
 if pullRequest.draft == true {
-    warn("PR is marked as Draft")
+  warn("PR is marked as Draft")
 }
 
 // Make it more obvious that a PR is a work in progress and shouldn't be merged yet
 if pullRequest.title.contains("[WIP]") {
-    warn("PR is marked as Work in Progress")
+  warn("PR is marked as Work in Progress")
 }
 
 // Mainly to encourage writing up some reasoning about the PR, rather than just leaving a title
 if (pullRequest.body ?? "").count < 5 {
-    fail("Please provide a summary in the Pull Request description")
+  fail("Please provide a summary in the Pull Request description")
 }
 
 let declaredTrivial = pullRequest.title.contains("#trivial")
 let hasChangelogEntry = danger.git.modifiedFiles.contains("CHANGELOG.md")
 if !hasChangelogEntry, !declaredTrivial {
-    fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/MessageKit/MessageKit/blob/main/CHANGELOG.md).")
+  fail(
+    "Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/MessageKit/MessageKit/blob/main/CHANGELOG.md).")
 }
 
 // Warn when there is a big PR
 let linesOfCode = (pullRequest.additions ?? 0) + (pullRequest.deletions ?? 0)
 if linesOfCode > 1000 {
-    warn("Big Pull Request - Please consider splitting up your changes into smaller Pull Requests.")
+  warn("Big Pull Request - Please consider splitting up your changes into smaller Pull Requests.")
 }
 
 // SwiftLint ships inside Danger Swift, so it only needs the `swiftlint` binary on the PATH

--- a/Example/Sources/Models/CustomLayoutSizeCalculator.swift
+++ b/Example/Sources/Models/CustomLayoutSizeCalculator.swift
@@ -40,7 +40,7 @@ class CustomLayoutSizeCalculator: CellSizeCalculator {
   }
 
   var messagesDataSource: MessagesDataSource {
-    self.messagesLayout.messagesDataSource
+    messagesLayout.messagesDataSource
   }
 
   override func sizeForItem(at indexPath: IndexPath) -> CGSize {

--- a/Example/Sources/View Controllers/AdvancedExampleViewController.swift
+++ b/Example/Sources/View Controllers/AdvancedExampleViewController.swift
@@ -172,31 +172,6 @@ final class AdvancedExampleViewController: ChatViewController {
     inputBarType = .custom(messageInputBar)
   }
 
-  // MARK: - Helpers
-
-  func isTimeLabelVisible(at indexPath: IndexPath) -> Bool {
-    indexPath.section % 3 == 0 && !isPreviousMessageSameSender(at: indexPath)
-  }
-
-  func isPreviousMessageSameSender(at indexPath: IndexPath) -> Bool {
-    guard indexPath.section - 1 >= 0 else { return false }
-    return messageList[indexPath.section].user == messageList[indexPath.section - 1].user
-  }
-
-  func isNextMessageSameSender(at indexPath: IndexPath) -> Bool {
-    guard indexPath.section + 1 < messageList.count else { return false }
-    return messageList[indexPath.section].user == messageList[indexPath.section + 1].user
-  }
-
-    func setTypingIndicatorViewHidden(_ isHidden: Bool, animated: Bool, performUpdates updates: (() -> Void)? = nil) {
-    updateTitleView(title: "MessageKit", subtitle: isHidden ? "2 Online" : "Typing...")
-    setTypingIndicatorViewHidden(isHidden, animated: animated, whilePerforming: updates) { [weak self] success in
-      if success, self?.isLastSectionVisible() == true {
-        self?.messagesCollectionView.scrollToLastItem(animated: true)
-      }
-    }
-  }
-
   // MARK: - MessagesDataSource
 
   override func cellTopLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
@@ -228,6 +203,31 @@ final class AdvancedExampleViewController: ChatViewController {
         attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .caption1)])
     }
     return nil
+  }
+
+  // MARK: - Helpers
+
+  func isTimeLabelVisible(at indexPath: IndexPath) -> Bool {
+    indexPath.section % 3 == 0 && !isPreviousMessageSameSender(at: indexPath)
+  }
+
+  func isPreviousMessageSameSender(at indexPath: IndexPath) -> Bool {
+    guard indexPath.section - 1 >= 0 else { return false }
+    return messageList[indexPath.section].user == messageList[indexPath.section - 1].user
+  }
+
+  func isNextMessageSameSender(at indexPath: IndexPath) -> Bool {
+    guard indexPath.section + 1 < messageList.count else { return false }
+    return messageList[indexPath.section].user == messageList[indexPath.section + 1].user
+  }
+
+  func setTypingIndicatorViewHidden(_ isHidden: Bool, animated: Bool, performUpdates updates: (() -> Void)? = nil) {
+    updateTitleView(title: "MessageKit", subtitle: isHidden ? "2 Online" : "Typing...")
+    setTypingIndicatorViewHidden(isHidden, animated: animated, whilePerforming: updates) { [weak self] success in
+      if success, self?.isLastSectionVisible() == true {
+        self?.messagesCollectionView.scrollToLastItem(animated: true)
+      }
+    }
   }
 
   // MARK: Private
@@ -290,7 +290,6 @@ final class AdvancedExampleViewController: ChatViewController {
     // or InputTextView padding
     messageInputBar.inputTextView.textContainerInset.bottom = 8
   }
-
 }
 
 // MARK: MessagesDisplayDelegate
@@ -305,7 +304,8 @@ extension AdvancedExampleViewController: MessagesDisplayDelegate {
   func detectorAttributes(
     for detector: DetectorType,
     and message: MessageType,
-    at _: IndexPath) -> [NSAttributedString.Key: Any]
+    at _: IndexPath)
+    -> [NSAttributedString.Key: Any]
   {
     switch detector {
     case .hashtag, .mention:
@@ -420,7 +420,8 @@ extension AdvancedExampleViewController: MessagesDisplayDelegate {
   func animationBlockForLocation(
     message _: MessageType,
     at _: IndexPath,
-    in _: MessagesCollectionView) -> ((UIImageView) -> Void)?
+    in _: MessagesCollectionView)
+    -> ((UIImageView) -> Void)?
   {
     { view in
       view.layer.transform = CATransform3DMakeScale(2, 2, 2)
@@ -492,7 +493,7 @@ extension AdvancedExampleViewController: CameraInputBarAccessoryViewDelegate {
   func inputBar(_ inputBar: InputBarAccessoryView, didPressSendButtonWith attachments: [AttachmentManager.Attachment]) {
     for item in attachments {
       if case .image(let image) = item {
-        self.sendImageMessage(photo: image)
+        sendImageMessage(photo: image)
       }
     }
     inputBar.invalidatePlugins()

--- a/Example/Sources/View Controllers/AutocompleteExampleViewController.swift
+++ b/Example/Sources/View Controllers/AutocompleteExampleViewController.swift
@@ -43,7 +43,7 @@ final class AutocompleteExampleViewController: ChatViewController {
 
   /// The object that manages autocomplete, from InputBarAccessoryView
   lazy var autocompleteManager: AutocompleteManager = { [unowned self] in
-    let manager = AutocompleteManager(for: self.messageInputBar.inputTextView)
+    let manager = AutocompleteManager(for: messageInputBar.inputTextView)
     manager.delegate = self
     manager.dataSource = self
     return manager
@@ -126,35 +126,6 @@ final class AutocompleteExampleViewController: ChatViewController {
     messageInputBar.setMiddleContentView(joinChatButton, animated: false)
   }
 
-  @objc
-  func joinChat() {
-    configureMessageInputBarForChat()
-  }
-
-  // MARK: - Helpers
-
-  func isTimeLabelVisible(at indexPath: IndexPath) -> Bool {
-    indexPath.section % 3 == 0 && !isPreviousMessageSameSender(at: indexPath)
-  }
-
-  func isPreviousMessageSameSender(at indexPath: IndexPath) -> Bool {
-    guard indexPath.section - 1 >= 0 else { return false }
-    return messageList[indexPath.section].user == messageList[indexPath.section - 1].user
-  }
-
-  func isNextMessageSameSender(at indexPath: IndexPath) -> Bool {
-    guard indexPath.section + 1 < messageList.count else { return false }
-    return messageList[indexPath.section].user == messageList[indexPath.section + 1].user
-  }
-
-  func setTypingIndicatorViewHidden(_ isHidden: Bool, performUpdates updates: (() -> Void)? = nil) {
-    setTypingIndicatorViewHidden(isHidden, animated: true, whilePerforming: updates) { [weak self] success in
-      if success, self?.isLastSectionVisible() == true {
-        self?.messagesCollectionView.scrollToLastItem(animated: true)
-      }
-    }
-  }
-
   // MARK: - MessagesDataSource
 
   override func cellTopLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
@@ -186,6 +157,35 @@ final class AutocompleteExampleViewController: ChatViewController {
         attributes: [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .caption1)])
     }
     return nil
+  }
+
+  @objc
+  func joinChat() {
+    configureMessageInputBarForChat()
+  }
+
+  // MARK: - Helpers
+
+  func isTimeLabelVisible(at indexPath: IndexPath) -> Bool {
+    indexPath.section % 3 == 0 && !isPreviousMessageSameSender(at: indexPath)
+  }
+
+  func isPreviousMessageSameSender(at indexPath: IndexPath) -> Bool {
+    guard indexPath.section - 1 >= 0 else { return false }
+    return messageList[indexPath.section].user == messageList[indexPath.section - 1].user
+  }
+
+  func isNextMessageSameSender(at indexPath: IndexPath) -> Bool {
+    guard indexPath.section + 1 < messageList.count else { return false }
+    return messageList[indexPath.section].user == messageList[indexPath.section + 1].user
+  }
+
+  func setTypingIndicatorViewHidden(_ isHidden: Bool, performUpdates updates: (() -> Void)? = nil) {
+    setTypingIndicatorViewHidden(isHidden, animated: true, whilePerforming: updates) { [weak self] success in
+      if success, self?.isLastSectionVisible() == true {
+        self?.messagesCollectionView.scrollToLastItem(animated: true)
+      }
+    }
   }
 
   // Async autocomplete requires the manager to reload
@@ -340,7 +340,8 @@ extension AutocompleteExampleViewController: MessagesDisplayDelegate {
   func detectorAttributes(
     for detector: DetectorType,
     and message: MessageType,
-    at _: IndexPath) -> [NSAttributedString.Key: Any]
+    at _: IndexPath)
+    -> [NSAttributedString.Key: Any]
   {
     switch detector {
     case .hashtag, .mention:

--- a/Example/Sources/View Controllers/BasicExampleViewController.swift
+++ b/Example/Sources/View Controllers/BasicExampleViewController.swift
@@ -68,9 +68,9 @@ extension BasicExampleViewController: MessagesDisplayDelegate {
   func messageStyle(for message: MessageType, at _: IndexPath, in _: MessagesCollectionView) -> MessageStyle {
     let tail: MessageStyle.TailCorner = isFromCurrentSender(message: message) ? .bottomRight : .bottomLeft
     if let image = UIImage(named: "bobbly") {
-        return .customImageTail(image, tail)
+      return .customImageTail(image, tail)
     } else {
-        return .bubbleTail(tail, .curved)
+      return .bubbleTail(tail, .curved)
     }
   }
 
@@ -105,7 +105,8 @@ extension BasicExampleViewController: MessagesDisplayDelegate {
   func animationBlockForLocation(
     message _: MessageType,
     at _: IndexPath,
-    in _: MessagesCollectionView) -> ((UIImageView) -> Void)?
+    in _: MessagesCollectionView)
+    -> ((UIImageView) -> Void)?
   {
     { view in
       view.layer.transform = CATransform3DMakeScale(2, 2, 2)

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -329,7 +329,6 @@ extension ChatViewController: InputBarAccessoryViewDelegate {
     let attributedText = inputBar.inputTextView.attributedText!
     let range = NSRange(location: 0, length: attributedText.length)
     attributedText.enumerateAttribute(.autocompleted, in: range, options: []) { _, range, _ in
-
       let substring = attributedText.attributedSubstring(from: range)
       let context = substring.attribute(.autocompletedContext, at: 0, effectiveRange: nil)
       print("Autocompleted: `", substring, "` with context: ", context ?? "-")

--- a/Example/Sources/View Controllers/MessageContainerController.swift
+++ b/Example/Sources/View Controllers/MessageContainerController.swift
@@ -24,6 +24,15 @@ import MapKit
 import UIKit
 
 final class MessageContainerController: UIViewController {
+  override var preferredStatusBarStyle: UIStatusBarStyle {
+    .lightContent
+  }
+
+  /// Required for the `MessageInputBar` to be visible
+  override var canBecomeFirstResponder: Bool {
+    conversationViewController.canBecomeFirstResponder
+  }
+
   let mapView = MKMapView()
 
   let bannerView: UIView = {
@@ -34,15 +43,6 @@ final class MessageContainerController: UIViewController {
   }()
 
   let conversationViewController = BasicExampleViewController()
-
-  override var preferredStatusBarStyle: UIStatusBarStyle {
-    .lightContent
-  }
-
-  /// Required for the `MessageInputBar` to be visible
-  override var canBecomeFirstResponder: Bool {
-    conversationViewController.canBecomeFirstResponder
-  }
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/Example/Sources/View Controllers/MessageSubviewContainerViewController.swift
+++ b/Example/Sources/View Controllers/MessageSubviewContainerViewController.swift
@@ -25,11 +25,11 @@ import Foundation
 import UIKit
 
 final class MessageSubviewContainerViewController: UIViewController {
-  let messageSubviewViewController = MessageSubviewViewController()
-
   override var preferredStatusBarStyle: UIStatusBarStyle {
     .lightContent
   }
+
+  let messageSubviewViewController = MessageSubviewViewController()
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/Example/Sources/View Controllers/MessageSubviewViewController.swift
+++ b/Example/Sources/View Controllers/MessageSubviewViewController.swift
@@ -30,7 +30,7 @@ final class MessageSubviewViewController: BasicExampleViewController {
 
   // In order to reach the subviewInputBar
   override var inputAccessoryView: UIView? {
-    self.subviewInputBar
+    subviewInputBar
   }
 
   override func viewDidLoad() {

--- a/Example/Sources/View Controllers/SettingsViewController.swift
+++ b/Example/Sources/View Controllers/SettingsViewController.swift
@@ -38,8 +38,6 @@ final internal class SettingsViewController: UITableViewController {
 
   // MARK: Internal
 
-  // MARK: - Properties
-
   let cells = [
     "Mock messages count",
     "Text Messages",
@@ -60,19 +58,6 @@ final internal class SettingsViewController: UITableViewController {
   // MARK: - Toolbar
 
   var messagesToolbar = UIToolbar()
-
-  @objc
-  func onDoneWithPickerView() {
-    let selectedMessagesCount = messagesPicker.selectedRow(inComponent: 0)
-    UserDefaults.standard.setMockMessages(count: selectedMessagesCount)
-    view.endEditing(false)
-    tableView.reloadData()
-  }
-
-  @objc
-  func dismissPickerView() {
-    view.endEditing(false)
-  }
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -118,6 +103,19 @@ final internal class SettingsViewController: UITableViewController {
         $0.becomeFirstResponder()
       }
     }
+  }
+
+  @objc
+  func onDoneWithPickerView() {
+    let selectedMessagesCount = messagesPicker.selectedRow(inComponent: 0)
+    UserDefaults.standard.setMockMessages(count: selectedMessagesCount)
+    view.endEditing(false)
+    tableView.reloadData()
+  }
+
+  @objc
+  func dismissPickerView() {
+    view.endEditing(false)
   }
 
   @objc

--- a/Example/Sources/Views/CameraInputBarAccessoryView.swift
+++ b/Example/Sources/Views/CameraInputBarAccessoryView.swift
@@ -41,6 +41,16 @@ class CameraInputBarAccessoryView: InputBarAccessoryView {
     return manager
   }()
 
+  override func didSelectSendButton() {
+    if attachmentManager.attachments.count > 0 {
+      (delegate as? CameraInputBarAccessoryViewDelegate)?
+        .inputBar(self, didPressSendButtonWith: attachmentManager.attachments)
+    }
+    else {
+      delegate?.inputBar(self, didPressSendButtonWith: inputTextView.text)
+    }
+  }
+
   func configure() {
     let camera = makeCameraButton()
     camera.tintColor = .darkGray
@@ -50,16 +60,6 @@ class CameraInputBarAccessoryView: InputBarAccessoryView {
     setLeftStackViewWidthConstant(to: 35, animated: true)
     setStackViewItems([camera], forStack: .left, animated: false)
     inputPlugins = [attachmentManager]
-  }
-
-  override func didSelectSendButton() {
-    if attachmentManager.attachments.count > 0 {
-      (delegate as? CameraInputBarAccessoryViewDelegate)?
-        .inputBar(self, didPressSendButtonWith: attachmentManager.attachments)
-    }
-    else {
-      delegate?.inputBar(self, didPressSendButtonWith: inputTextView.text)
-    }
   }
 
   // MARK: Private

--- a/Example/Sources/Views/CustomCell.swift
+++ b/Example/Sources/Views/CustomCell.swift
@@ -38,15 +38,15 @@ open class CustomCell: UICollectionViewCell {
 
   // MARK: Open
 
+  open override func layoutSubviews() {
+    super.layoutSubviews()
+    label.frame = contentView.bounds
+  }
+
   open func setupSubviews() {
     contentView.addSubview(label)
     label.textAlignment = .center
     label.font = UIFont.italicSystemFont(ofSize: 13)
-  }
-
-  open override func layoutSubviews() {
-    super.layoutSubviews()
-    label.frame = contentView.bounds
   }
 
   open func configure(with message: MessageType, at _: IndexPath, and _: MessagesCollectionView) {

--- a/Example/Sources/Views/SwiftUI/SwiftUIExampleView.swift
+++ b/Example/Sources/Views/SwiftUI/SwiftUIExampleView.swift
@@ -18,9 +18,9 @@ struct SwiftUIExampleView: View {
 
   var body: some View {
     MessagesView(messages: $messages).onAppear {
-      self.connectToMessageSocket()
+      connectToMessageSocket()
     }.onDisappear {
-      self.cleanupSocket()
+      cleanupSocket()
     }
     .navigationBarTitle("SwiftUI Example", displayMode: .inline)
     // Fixes the InputBarAccessoryView placement when the keyboard appears
@@ -31,7 +31,7 @@ struct SwiftUIExampleView: View {
 
   private func connectToMessageSocket() {
     MockSocket.shared.connect(with: [SampleData.shared.nathan, SampleData.shared.wu]).onNewMessage { message in
-      self.messages.append(message)
+      messages.append(message)
     }
   }
 

--- a/Sources/Controllers/MessagesViewController+Keyboard.swift
+++ b/Sources/Controllers/MessagesViewController+Keyboard.swift
@@ -32,9 +32,8 @@ extension MessagesViewController {
 
   internal func addKeyboardObservers() {
     keyboardManager.bind(
-      inputAccessoryView: inputContainerView, 
-      withAdditionalBottomSpace: { [weak self] in self?.inputBarAdditionalBottomSpace() ?? 0 }
-    )
+      inputAccessoryView: inputContainerView,
+      withAdditionalBottomSpace: { [weak self] in self?.inputBarAdditionalBottomSpace() ?? 0 })
     keyboardManager.bind(to: messagesCollectionView)
 
     /// Observe didBeginEditing to scroll content to last item if necessary
@@ -76,11 +75,11 @@ extension MessagesViewController {
       .removeDuplicates()
       .delay(for: .milliseconds(50), scheduler: DispatchQueue.main) /// Wait for next runloop to lay out inputView properly
       .sink { [weak self] _ in
-          self?.updateMessageCollectionViewBottomInset()
-          
-          if !(self?.maintainPositionOnInputBarHeightChanged ?? false) {
-              self?.messagesCollectionView.scrollToLastItem()
-          }
+        self?.updateMessageCollectionViewBottomInset()
+
+        if !(self?.maintainPositionOnInputBarHeightChanged ?? false) {
+          self?.messagesCollectionView.scrollToLastItem()
+        }
       }
       .store(in: &disposeBag)
 

--- a/Sources/Controllers/MessagesViewController+State.swift
+++ b/Sources/Controllers/MessagesViewController+State.swift
@@ -26,22 +26,26 @@ import InputBarAccessoryView
 import UIKit
 
 extension MessagesViewController {
-    @MainActor
-    final class State {
-        /// Pan gesture for display the date of message by swiping left.
-        var panGesture: UIPanGestureRecognizer?
-        var maintainPositionOnInputBarHeightChanged = false
-        var scrollsToLastItemOnKeyboardBeginsEditing = false
-
-        let inputContainerView: MessagesInputContainerView = .init()
-        @Published var inputBarType: MessageInputBarKind = .messageInputBar
-        let keyboardManager = KeyboardManager()
-        var disposeBag: Set<AnyCancellable> = .init()
-    }
+  // MARK: Public
 
   // MARK: - Getters
 
   public var keyboardManager: KeyboardManager { state.keyboardManager }
+
+  // MARK: Internal
+
+  @MainActor
+  final class State {
+    /// Pan gesture for display the date of message by swiping left.
+    var panGesture: UIPanGestureRecognizer?
+    var maintainPositionOnInputBarHeightChanged = false
+    var scrollsToLastItemOnKeyboardBeginsEditing = false
+
+    let inputContainerView: MessagesInputContainerView = .init()
+    @Published var inputBarType: MessageInputBarKind = .messageInputBar
+    let keyboardManager = KeyboardManager()
+    var disposeBag: Set<AnyCancellable> = .init()
+  }
 
   var panGesture: UIPanGestureRecognizer? {
     get { state.panGesture }

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -31,8 +31,8 @@ open class MessagesViewController: UIViewController, UICollectionViewDelegateFlo
   // MARK: Lifecycle
 
   deinit {
-      NotificationCenter.default.removeObserver(self, name: UIMenuController.willShowMenuNotification, object: nil)
-      MessageStyle.bubbleImageCache.removeAllObjects()
+    NotificationCenter.default.removeObserver(self, name: UIMenuController.willShowMenuNotification, object: nil)
+    MessageStyle.bubbleImageCache.removeAllObjects()
   }
 
   // MARK: Open
@@ -66,11 +66,6 @@ open class MessagesViewController: UIViewController, UICollectionViewDelegateFlo
     }
   }
 
-  /// withAdditionalBottomSpace parameter for InputBarAccessoryView's KeyboardManager
-  open func inputBarAdditionalBottomSpace() -> CGFloat {
-    0
-  }
-
   open override func viewDidLoad() {
     super.viewDidLoad()
     setupDefaults()
@@ -88,6 +83,11 @@ open class MessagesViewController: UIViewController, UICollectionViewDelegateFlo
   open override func viewSafeAreaInsetsDidChange() {
     super.viewSafeAreaInsetsDidChange()
     updateMessageCollectionViewBottomInset()
+  }
+
+  /// withAdditionalBottomSpace parameter for InputBarAccessoryView's KeyboardManager
+  open func inputBarAdditionalBottomSpace() -> CGFloat {
+    0
   }
 
   // MARK: - UICollectionViewDataSource
@@ -287,7 +287,7 @@ open class MessagesViewController: UIViewController, UICollectionViewDelegateFlo
     if isSectionReservedForTypingIndicator(indexPath.section) {
       return false
     }
-    return (action == NSSelectorFromString("copy:"))
+    return action == NSSelectorFromString("copy:")
   }
 
   open func collectionView(_: UICollectionView, performAction _: Selector, forItemAt indexPath: IndexPath, withSender _: Any?) {
@@ -314,8 +314,6 @@ open class MessagesViewController: UIViewController, UICollectionViewDelegateFlo
   public var selectedIndexPathForMenu: IndexPath?
 
   // MARK: Internal
-
-  // MARK: - Internal properties
 
   internal let state: State = .init()
 

--- a/Sources/Extensions/UIView+Extensions.swift
+++ b/Sources/Extensions/UIView+Extensions.swift
@@ -75,7 +75,8 @@ extension UIView {
     centerYConstant: CGFloat = 0,
     centerXConstant: CGFloat = 0,
     widthConstant: CGFloat = 0,
-    heightConstant: CGFloat = 0) -> [NSLayoutConstraint]
+    heightConstant: CGFloat = 0)
+    -> [NSLayoutConstraint]
   {
     if superview == nil {
       return []

--- a/Sources/Layout/MessageSizeCalculator.swift
+++ b/Sources/Layout/MessageSizeCalculator.swift
@@ -316,17 +316,20 @@ open class MessageSizeCalculator: CellSizeCalculator {
   }
 
   // MARK: Internal
+
   internal lazy var textContainer: NSTextContainer = {
     let textContainer = NSTextContainer()
     textContainer.maximumNumberOfLines = 0
     textContainer.lineFragmentPadding = 0
     return textContainer
   }()
+
   internal lazy var layoutManager: NSLayoutManager = {
     let layoutManager = NSLayoutManager()
     layoutManager.addTextContainer(textContainer)
     return layoutManager
   }()
+
   internal lazy var textStorage: NSTextStorage = {
     let textStorage = NSTextStorage()
     textStorage.addLayoutManager(layoutManager)

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -71,16 +71,6 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
   lazy open var typingIndicatorSizeCalculator = TypingCellSizeCalculator(layout: self)
   lazy open var linkPreviewMessageSizeCalculator = LinkPreviewMessageSizeCalculator(layout: self)
 
-  /// A method that by default checks if the section is the last in the
-  /// `messagesCollectionView` and that `isTypingIndicatorViewHidden`
-  /// is FALSE
-  ///
-  /// - Parameter section
-  /// - Returns: A Boolean indicating if the TypingIndicator should be presented at the given section
-  open func isSectionReservedForTypingIndicator(_ section: Int) -> Bool {
-    !isTypingIndicatorViewHidden && section == messagesCollectionView.numberOfSections - 1
-  }
-
   // MARK: - Attributes
 
   open override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
@@ -117,6 +107,16 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
     guard let flowLayoutContext = context as? UICollectionViewFlowLayoutInvalidationContext else { return context }
     flowLayoutContext.invalidateFlowLayoutDelegateMetrics = shouldInvalidateLayout(forBoundsChange: newBounds)
     return flowLayoutContext
+  }
+
+  /// A method that by default checks if the section is the last in the
+  /// `messagesCollectionView` and that `isTypingIndicatorViewHidden`
+  /// is FALSE
+  ///
+  /// - Parameter section
+  /// - Returns: A Boolean indicating if the TypingIndicator should be presented at the given section
+  open func isSectionReservedForTypingIndicator(_ section: Int) -> Bool {
+    !isTypingIndicatorViewHidden && section == messagesCollectionView.numberOfSections - 1
   }
 
   /// Note:

--- a/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
+++ b/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
@@ -23,7 +23,7 @@
 import UIKit
 
 /// The layout attributes used by a `MessageCollectionViewCell` to layout its subviews.
-open class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttributes  {
+open class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttributes {
   // MARK: Open
 
   // MARK: - Methods
@@ -55,7 +55,7 @@ open class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttribu
     // swiftlint:enable force_cast
   }
 
-  // MARK: - Properties
+  // MARK: Public
 
   public var avatarSize: CGSize = .zero
   public var avatarPosition = AvatarPosition(vertical: .cellBottom)

--- a/Sources/Models/MessageKitDateFormatter.swift
+++ b/Sources/Models/MessageKitDateFormatter.swift
@@ -48,8 +48,6 @@ open class MessageKitDateFormatter: @unchecked Sendable {
 
   // MARK: Public
 
-  // MARK: - Properties
-
   public static let shared = MessageKitDateFormatter()
 
   // MARK: - Methods

--- a/Sources/Models/MessageStyle.swift
+++ b/Sources/Models/MessageStyle.swift
@@ -30,7 +30,7 @@ public enum MessageStyle {
   case bubbleOutline(UIColor)
   case bubbleTail(TailCorner, TailStyle)
   case bubbleTailOutline(UIColor, TailCorner, TailStyle)
-  case customImageTail(UIImage,TailCorner)
+  case customImageTail(UIImage, TailCorner)
   case custom((MessageContainerView) -> Void)
 
   // MARK: Public
@@ -44,12 +44,12 @@ public enum MessageStyle {
     case bottomRight
 
     internal var imageOrientation: UIImage.Orientation {
-        switch self {
-            case .bottomRight: return .up
-            case .bottomLeft: return .upMirrored
-            case .topLeft: return .down
-            case .topRight: return .downMirrored
-        }
+      switch self {
+      case .bottomRight: return .up
+      case .bottomLeft: return .upMirrored
+      case .topLeft: return .down
+      case .topRight: return .downMirrored
+      }
     }
   }
 
@@ -76,7 +76,7 @@ public enum MessageStyle {
     {
       return cachedImage
     }
-      
+
     func strechAndCache(image: UIImage) -> UIImage {
       let stretchedImage = stretch(image)
       if let imageCacheKey = imageCacheKey {
@@ -84,7 +84,7 @@ public enum MessageStyle {
       }
       return stretchedImage
     }
-      
+
     if case .customImageTail(let image, let corner) = self {
       guard let cgImage = image.cgImage else { return nil }
       let image = UIImage(cgImage: cgImage, scale: image.scale, orientation: corner.imageOrientation)
@@ -111,13 +111,13 @@ public enum MessageStyle {
     return strechAndCache(image: image)
   }
 
-    // MARK: Internal
+  // MARK: Internal
 
-    nonisolated(unsafe) internal static let bubbleImageCache: NSCache<NSString, UIImage> = {
-        let cache = NSCache<NSString, UIImage>()
-        cache.name = "com.messagekit.MessageKit.bubbleImageCache"
-        return cache
-    }()
+  nonisolated(unsafe) internal static let bubbleImageCache: NSCache<NSString, UIImage> = {
+    let cache = NSCache<NSString, UIImage>()
+    cache.name = "com.messagekit.MessageKit.bubbleImageCache"
+    return cache
+  }()
 
   // MARK: Private
 

--- a/Sources/Protocols/MessagesDisplayDelegate.swift
+++ b/Sources/Protocols/MessagesDisplayDelegate.swift
@@ -158,7 +158,8 @@ public protocol MessagesDisplayDelegate: AnyObject {
   func snapshotOptionsForLocation(
     message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> LocationMessageSnapshotOptions
+    in messagesCollectionView: MessagesCollectionView)
+    -> LocationMessageSnapshotOptions
 
   /// Used to configure the annotation view of the map image on the given location message.
   ///
@@ -170,7 +171,8 @@ public protocol MessagesDisplayDelegate: AnyObject {
   func annotationViewForLocation(
     message: MessageType,
     at indexPath: IndexPath,
-    in messageCollectionView: MessagesCollectionView) -> MKAnnotationView?
+    in messageCollectionView: MessagesCollectionView)
+    -> MKAnnotationView?
 
   /// Ask the delegate for a custom animation block to run when whe map screenshot is ready to be displaied in the given location message.
   /// The animation block is called with the `UIImageView` to be animated.
@@ -183,7 +185,8 @@ public protocol MessagesDisplayDelegate: AnyObject {
   func animationBlockForLocation(
     message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> ((UIImageView) -> Void)?
+    in messagesCollectionView: MessagesCollectionView)
+    -> ((UIImageView) -> Void)?
 
   // MARK: - Media Messages
 
@@ -242,7 +245,8 @@ public protocol MessagesDisplayDelegate: AnyObject {
   func audioProgressTextFormat(
     _ duration: Float,
     for audioCell: AudioMessageCell,
-    in messageCollectionView: MessagesCollectionView) -> String
+    in messageCollectionView: MessagesCollectionView)
+    -> String
 
   /// Used to configure the `UIImageView` of a `LinkPreviewMessageCell`.
   /// - Parameters:
@@ -348,7 +352,8 @@ extension MessagesDisplayDelegate {
   public func animationBlockForLocation(
     message _: MessageType,
     at _: IndexPath,
-    in _: MessagesCollectionView) -> ((UIImageView) -> Void)?
+    in _: MessagesCollectionView)
+    -> ((UIImageView) -> Void)?
   {
     nil
   }

--- a/Sources/Protocols/MessagesLayoutDelegate.swift
+++ b/Sources/Protocols/MessagesLayoutDelegate.swift
@@ -91,7 +91,8 @@ public protocol MessagesLayoutDelegate: AnyObject {
   func cellBottomLabelHeight(
     for message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> CGFloat
+    in messagesCollectionView: MessagesCollectionView)
+    -> CGFloat
 
   /// Specifies the height for the message bubble's top label.
   ///
@@ -105,7 +106,8 @@ public protocol MessagesLayoutDelegate: AnyObject {
   func messageTopLabelHeight(
     for message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> CGFloat
+    in messagesCollectionView: MessagesCollectionView)
+    -> CGFloat
 
   /// Specifies the label alignment for the message bubble's top label.
   /// - Parameters:
@@ -117,7 +119,8 @@ public protocol MessagesLayoutDelegate: AnyObject {
   func messageTopLabelAlignment(
     for message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> LabelAlignment?
+    in messagesCollectionView: MessagesCollectionView)
+    -> LabelAlignment?
 
   /// Specifies the height for the `MessageContentCell`'s bottom label.
   ///
@@ -131,7 +134,8 @@ public protocol MessagesLayoutDelegate: AnyObject {
   func messageBottomLabelHeight(
     for message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> CGFloat
+    in messagesCollectionView: MessagesCollectionView)
+    -> CGFloat
 
   /// Specifies the label alignment for the message bubble's bottom label.
   /// - Parameters:
@@ -143,7 +147,8 @@ public protocol MessagesLayoutDelegate: AnyObject {
   func messageBottomLabelAlignment(
     for message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> LabelAlignment?
+    in messagesCollectionView: MessagesCollectionView)
+    -> LabelAlignment?
 
   /// Specifies the size for the `MessageContentCell`'s avatar image view.
   /// - Parameters:
@@ -167,7 +172,8 @@ public protocol MessagesLayoutDelegate: AnyObject {
   func textCellSizeCalculator(
     for message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> CellSizeCalculator?
+    in messagesCollectionView: MessagesCollectionView)
+    -> CellSizeCalculator?
 
   /// Attributed text cell size calculator for messages with MessageType.attributedText.
   ///
@@ -181,7 +187,8 @@ public protocol MessagesLayoutDelegate: AnyObject {
   func attributedTextCellSizeCalculator(
     for message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> CellSizeCalculator?
+    in messagesCollectionView: MessagesCollectionView)
+    -> CellSizeCalculator?
 
   /// Emoji cell size calculator for messages with MessageType.emoji.
   ///
@@ -195,7 +202,8 @@ public protocol MessagesLayoutDelegate: AnyObject {
   func emojiCellSizeCalculator(
     for message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> CellSizeCalculator?
+    in messagesCollectionView: MessagesCollectionView)
+    -> CellSizeCalculator?
 
   /// Photo cell size calculator for messages with MessageType.photo.
   ///
@@ -209,7 +217,8 @@ public protocol MessagesLayoutDelegate: AnyObject {
   func photoCellSizeCalculator(
     for message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> CellSizeCalculator?
+    in messagesCollectionView: MessagesCollectionView)
+    -> CellSizeCalculator?
 
   /// Video cell size calculator for messages with MessageType.video.
   ///
@@ -223,7 +232,8 @@ public protocol MessagesLayoutDelegate: AnyObject {
   func videoCellSizeCalculator(
     for message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> CellSizeCalculator?
+    in messagesCollectionView: MessagesCollectionView)
+    -> CellSizeCalculator?
 
   /// Location cell size calculator for messages with MessageType.location.
   ///
@@ -237,7 +247,8 @@ public protocol MessagesLayoutDelegate: AnyObject {
   func locationCellSizeCalculator(
     for message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> CellSizeCalculator?
+    in messagesCollectionView: MessagesCollectionView)
+    -> CellSizeCalculator?
 
   /// Audio cell size calculator for messages with MessageType.audio.
   ///
@@ -251,7 +262,8 @@ public protocol MessagesLayoutDelegate: AnyObject {
   func audioCellSizeCalculator(
     for message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> CellSizeCalculator?
+    in messagesCollectionView: MessagesCollectionView)
+    -> CellSizeCalculator?
 
   /// Contact cell size calculator for messages with MessageType.contact.
   ///
@@ -265,7 +277,8 @@ public protocol MessagesLayoutDelegate: AnyObject {
   func contactCellSizeCalculator(
     for message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> CellSizeCalculator?
+    in messagesCollectionView: MessagesCollectionView)
+    -> CellSizeCalculator?
 
   /// Custom cell size calculator for messages with MessageType.custom.
   ///
@@ -279,7 +292,8 @@ public protocol MessagesLayoutDelegate: AnyObject {
   func customCellSizeCalculator(
     for message: MessageType,
     at indexPath: IndexPath,
-    in messagesCollectionView: MessagesCollectionView) -> CellSizeCalculator
+    in messagesCollectionView: MessagesCollectionView)
+    -> CellSizeCalculator
 }
 
 extension MessagesLayoutDelegate {

--- a/Sources/Views/AvatarView.swift
+++ b/Sources/Views/AvatarView.swift
@@ -46,11 +46,21 @@ open class AvatarView: UIImageView {
 
   // MARK: Open
 
+  open override var frame: CGRect {
+    didSet {
+      setCorner(radius: radius)
+    }
+  }
+
+  open override var bounds: CGRect {
+    didSet {
+      setCorner(radius: radius)
+    }
+  }
+
   open var fontMinimumScaleFactor: CGFloat = 0.5
 
   open var adjustsFontSizeToFitWidth = true
-
-  // MARK: - Properties
 
   open var initials: String? {
     didSet {
@@ -67,19 +77,6 @@ open class AvatarView: UIImageView {
   open var placeholderTextColor: UIColor = .white {
     didSet {
       setImageFrom(initials: initials)
-    }
-  }
-
-  // MARK: - Overridden Properties
-  open override var frame: CGRect {
-    didSet {
-      setCorner(radius: self.radius)
-    }
-  }
-
-  open override var bounds: CGRect {
-    didSet {
-      setCorner(radius: self.radius)
     }
   }
 

--- a/Sources/Views/Cells/AudioMessageCell.swift
+++ b/Sources/Views/Cells/AudioMessageCell.swift
@@ -27,26 +27,6 @@ import UIKit
 open class AudioMessageCell: MessageContentCell {
   // MARK: Open
 
-  /// Responsible for setting up the constraints of the cell's subviews.
-  open func setupConstraints() {
-    playButton.constraint(equalTo: CGSize(width: 25, height: 25))
-    playButton.addConstraints(
-      left: messageContainerView.leftAnchor,
-      centerY: messageContainerView.centerYAnchor,
-      leftConstant: 5)
-    activityIndicatorView.addConstraints(centerY: playButton.centerYAnchor, centerX: playButton.centerXAnchor)
-    durationLabel.addConstraints(
-      right: messageContainerView.rightAnchor,
-      centerY: messageContainerView.centerYAnchor,
-      rightConstant: 15)
-    progressView.addConstraints(
-      left: playButton.rightAnchor,
-      right: durationLabel.leftAnchor,
-      centerY: messageContainerView.centerYAnchor,
-      leftConstant: 5,
-      rightConstant: 5)
-  }
-
   open override func setupSubviews() {
     super.setupSubviews()
     messageContainerView.addSubview(playButton)
@@ -124,6 +104,26 @@ open class AudioMessageCell: MessageContentCell {
     }
 
     displayDelegate.configureAudioCell(self, message: message)
+  }
+
+  /// Responsible for setting up the constraints of the cell's subviews.
+  open func setupConstraints() {
+    playButton.constraint(equalTo: CGSize(width: 25, height: 25))
+    playButton.addConstraints(
+      left: messageContainerView.leftAnchor,
+      centerY: messageContainerView.centerYAnchor,
+      leftConstant: 5)
+    activityIndicatorView.addConstraints(centerY: playButton.centerYAnchor, centerX: playButton.centerXAnchor)
+    durationLabel.addConstraints(
+      right: messageContainerView.rightAnchor,
+      centerY: messageContainerView.centerYAnchor,
+      rightConstant: 15)
+    progressView.addConstraints(
+      left: playButton.rightAnchor,
+      right: durationLabel.leftAnchor,
+      centerY: messageContainerView.centerYAnchor,
+      leftConstant: 5,
+      rightConstant: 5)
   }
 
   // MARK: Public

--- a/Sources/Views/Cells/ContactMessageCell.swift
+++ b/Sources/Views/Cells/ContactMessageCell.swift
@@ -50,32 +50,6 @@ open class ContactMessageCell: MessageContentCell {
     initialsLabel.text = ""
   }
 
-  open func setupConstraints() {
-    initialsContainerView.constraint(equalTo: CGSize(width: 26, height: 26))
-    let initialsConstraints = initialsContainerView.addConstraints(
-      left: messageContainerView.leftAnchor,
-      centerY: messageContainerView.centerYAnchor,
-      leftConstant: 5)
-    initialsConstraints.first?.identifier = ConstraintsID.initialsContainerLeftConstraint.rawValue
-    initialsContainerView.layer.cornerRadius = 13
-    initialsLabel.fillSuperview()
-    disclosureImageView.constraint(equalTo: CGSize(width: 20, height: 20))
-    let disclosureConstraints = disclosureImageView.addConstraints(
-      right: messageContainerView.rightAnchor,
-      centerY: messageContainerView.centerYAnchor,
-      rightConstant: -10)
-    disclosureConstraints.first?.identifier = ConstraintsID.disclosureRightConstraint.rawValue
-    nameLabel.addConstraints(
-      messageContainerView.topAnchor,
-      left: initialsContainerView.rightAnchor,
-      bottom: messageContainerView.bottomAnchor,
-      right: disclosureImageView.leftAnchor,
-      topConstant: 0,
-      leftConstant: 10,
-      bottomConstant: 0,
-      rightConstant: 5)
-  }
-
   // MARK: - Configure Cell
   open override func configure(
     with message: MessageType,
@@ -111,6 +85,32 @@ open class ContactMessageCell: MessageContentCell {
     let textColor = displayDelegate.textColor(for: message, at: indexPath, in: messagesCollectionView)
     nameLabel.textColor = textColor
     disclosureImageView.tintColor = textColor
+  }
+
+  open func setupConstraints() {
+    initialsContainerView.constraint(equalTo: CGSize(width: 26, height: 26))
+    let initialsConstraints = initialsContainerView.addConstraints(
+      left: messageContainerView.leftAnchor,
+      centerY: messageContainerView.centerYAnchor,
+      leftConstant: 5)
+    initialsConstraints.first?.identifier = ConstraintsID.initialsContainerLeftConstraint.rawValue
+    initialsContainerView.layer.cornerRadius = 13
+    initialsLabel.fillSuperview()
+    disclosureImageView.constraint(equalTo: CGSize(width: 20, height: 20))
+    let disclosureConstraints = disclosureImageView.addConstraints(
+      right: messageContainerView.rightAnchor,
+      centerY: messageContainerView.centerYAnchor,
+      rightConstant: -10)
+    disclosureConstraints.first?.identifier = ConstraintsID.disclosureRightConstraint.rawValue
+    nameLabel.addConstraints(
+      messageContainerView.topAnchor,
+      left: initialsContainerView.rightAnchor,
+      bottom: messageContainerView.bottomAnchor,
+      right: disclosureImageView.leftAnchor,
+      topConstant: 0,
+      leftConstant: 10,
+      bottomConstant: 0,
+      rightConstant: 5)
   }
 
   // MARK: Public

--- a/Sources/Views/Cells/LocationMessageCell.swift
+++ b/Sources/Views/Cells/LocationMessageCell.swift
@@ -41,12 +41,6 @@ open class LocationMessageCell: MessageContentCell {
     setupConstraints()
   }
 
-  /// Responsible for setting up the constraints of the cell's subviews.
-  open func setupConstraints() {
-    imageView.fillSuperview()
-    activityIndicator.centerInSuperview()
-  }
-
   open override func prepareForReuse() {
     super.prepareForReuse()
     snapShotter?.cancel()
@@ -59,7 +53,8 @@ open class LocationMessageCell: MessageContentCell {
   {
     super.configure(with: message, at: indexPath, and: messagesCollectionView)
 
-    guard case .location(let locationItem) = message.kind else { fatalError("Configuring LocationMessageCell with wrong message kind") }
+    guard case .location(let locationItem) = message.kind
+    else { fatalError("Configuring LocationMessageCell with wrong message kind") }
     guard CLLocationCoordinate2DIsValid(locationItem.location.coordinate) else {
       return
     }
@@ -118,6 +113,12 @@ open class LocationMessageCell: MessageContentCell {
       self.imageView.image = composedImage
       animationBlock?(self.imageView)
     }
+  }
+
+  /// Responsible for setting up the constraints of the cell's subviews.
+  open func setupConstraints() {
+    imageView.fillSuperview()
+    activityIndicator.centerInSuperview()
   }
 
   // MARK: Private

--- a/Sources/Views/Cells/MediaMessageCell.swift
+++ b/Sources/Views/Cells/MediaMessageCell.swift
@@ -37,15 +37,6 @@ open class MediaMessageCell: MessageContentCell {
     return imageView
   }()
 
-  // MARK: - Methods
-
-  /// Responsible for setting up the constraints of the cell's subviews.
-  open func setupConstraints() {
-    imageView.fillSuperview()
-    playButtonView.centerInSuperview()
-    playButtonView.constraint(equalTo: CGSize(width: 35, height: 35))
-  }
-
   open override func setupSubviews() {
     super.setupSubviews()
     messageContainerView.addSubview(imageView)
@@ -92,5 +83,14 @@ open class MediaMessageCell: MessageContentCell {
       return
     }
     delegate?.didTapImage(in: self)
+  }
+
+  // MARK: - Methods
+
+  /// Responsible for setting up the constraints of the cell's subviews.
+  open func setupConstraints() {
+    imageView.fillSuperview()
+    playButtonView.centerInSuperview()
+    playButtonView.constraint(equalTo: CGSize(width: 35, height: 35))
   }
 }

--- a/Sources/Views/Cells/MessageContentCell.swift
+++ b/Sources/Views/Cells/MessageContentCell.swift
@@ -100,18 +100,6 @@ open class MessageContentCell: MessageCollectionViewCell {
     messageTimestampLabel.attributedText = nil
   }
 
-  open func setupSubviews() {
-    contentView.addSubviews(
-      accessoryView,
-      cellTopLabel,
-      messageTopLabel,
-      messageBottomLabel,
-      cellBottomLabel,
-      messageContainerView,
-      avatarView,
-      messageTimestampLabel)
-  }
-
   // MARK: - Configuration
 
   open override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
@@ -126,6 +114,50 @@ open class MessageContentCell: MessageCollectionViewCell {
     layoutAvatarView(with: attributes)
     layoutAccessoryView(with: attributes)
     layoutTimeLabelView(with: attributes)
+  }
+
+  /// Handle tap gesture on contentView and its subviews.
+  open override func handleTapGesture(_ gesture: UIGestureRecognizer) {
+    let touchLocation = gesture.location(in: self)
+
+    switch true {
+    case messageContainerView.frame
+      .contains(touchLocation) && !cellContentView(canHandle: convert(touchLocation, to: messageContainerView)):
+      delegate?.didTapMessage(in: self)
+    case avatarView.frame.contains(touchLocation):
+      delegate?.didTapAvatar(in: self)
+    case cellTopLabel.frame.contains(touchLocation):
+      delegate?.didTapCellTopLabel(in: self)
+    case cellBottomLabel.frame.contains(touchLocation):
+      delegate?.didTapCellBottomLabel(in: self)
+    case messageTopLabel.frame.contains(touchLocation):
+      delegate?.didTapMessageTopLabel(in: self)
+    case messageBottomLabel.frame.contains(touchLocation):
+      delegate?.didTapMessageBottomLabel(in: self)
+    case accessoryView.frame.contains(touchLocation):
+      delegate?.didTapAccessoryView(in: self)
+    default:
+      delegate?.didTapBackground(in: self)
+    }
+  }
+
+  /// Handle long press gesture, return true when gestureRecognizer's touch point in `messageContainerView`'s frame
+  open override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+    let touchPoint = gestureRecognizer.location(in: self)
+    guard gestureRecognizer.isKind(of: UILongPressGestureRecognizer.self) else { return false }
+    return messageContainerView.frame.contains(touchPoint)
+  }
+
+  open func setupSubviews() {
+    contentView.addSubviews(
+      accessoryView,
+      cellTopLabel,
+      messageTopLabel,
+      messageBottomLabel,
+      cellBottomLabel,
+      messageContainerView,
+      avatarView,
+      messageTimestampLabel)
   }
 
   /// Used to configure the cell.
@@ -165,38 +197,6 @@ open class MessageContentCell: MessageCollectionViewCell {
     messageBottomLabel.attributedText = bottomMessageLabelText
     messageTimestampLabel.attributedText = messageTimestampLabelText
     messageTimestampLabel.isHidden = !messagesCollectionView.showMessageTimestampOnSwipeLeft
-  }
-
-  /// Handle tap gesture on contentView and its subviews.
-  open override func handleTapGesture(_ gesture: UIGestureRecognizer) {
-    let touchLocation = gesture.location(in: self)
-
-    switch true {
-    case messageContainerView.frame
-      .contains(touchLocation) && !cellContentView(canHandle: convert(touchLocation, to: messageContainerView)):
-      delegate?.didTapMessage(in: self)
-    case avatarView.frame.contains(touchLocation):
-      delegate?.didTapAvatar(in: self)
-    case cellTopLabel.frame.contains(touchLocation):
-      delegate?.didTapCellTopLabel(in: self)
-    case cellBottomLabel.frame.contains(touchLocation):
-      delegate?.didTapCellBottomLabel(in: self)
-    case messageTopLabel.frame.contains(touchLocation):
-      delegate?.didTapMessageTopLabel(in: self)
-    case messageBottomLabel.frame.contains(touchLocation):
-      delegate?.didTapMessageBottomLabel(in: self)
-    case accessoryView.frame.contains(touchLocation):
-      delegate?.didTapAccessoryView(in: self)
-    default:
-      delegate?.didTapBackground(in: self)
-    }
-  }
-
-  /// Handle long press gesture, return true when gestureRecognizer's touch point in `messageContainerView`'s frame
-  open override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-    let touchPoint = gestureRecognizer.location(in: self)
-    guard gestureRecognizer.isKind(of: UILongPressGestureRecognizer.self) else { return false }
-    return messageContainerView.frame.contains(touchPoint)
   }
 
   /// Handle `ContentView`'s tap gesture, return false when `ContentView` doesn't needs to handle gesture
@@ -365,8 +365,8 @@ open class MessageContentCell: MessageCollectionViewCell {
   open func layoutTimeLabelView(with attributes: MessagesCollectionViewLayoutAttributes) {
     let paddingLeft: CGFloat = 10
     let origin = CGPoint(
-        x: self.frame.maxX + paddingLeft,
-        y: messageContainerView.frame.minY + messageContainerView.frame.height * 0.5 - messageTimestampLabel.font.ascender * 0.5)
+      x: frame.maxX + paddingLeft,
+      y: messageContainerView.frame.minY + messageContainerView.frame.height * 0.5 - messageTimestampLabel.font.ascender * 0.5)
     let size = CGSize(width: attributes.messageTimeLabelSize.width, height: attributes.messageTimeLabelSize.height)
     messageTimestampLabel.frame = CGRect(origin: origin, size: size)
   }

--- a/Sources/Views/Cells/TextMessageCell.swift
+++ b/Sources/Views/Cells/TextMessageCell.swift
@@ -24,17 +24,15 @@ import UIKit
 
 /// A subclass of `MessageContentCell` used to display text messages.
 open class TextMessageCell: MessageContentCell {
-  /// The label used to display the message's text.
-  open var messageLabel = MessageLabel()
-
-  // MARK: - Properties
-
   /// The `MessageCellDelegate` for the cell.
   open override weak var delegate: MessageCellDelegate? {
     didSet {
       messageLabel.delegate = delegate
     }
   }
+
+  /// The label used to display the message's text.
+  open var messageLabel = MessageLabel()
 
   // MARK: - Methods
 

--- a/Sources/Views/Cells/TypingIndicatorCell.swift
+++ b/Sources/Views/Cells/TypingIndicatorCell.swift
@@ -38,10 +38,6 @@ open class TypingIndicatorCell: MessageCollectionViewCell {
 
   // MARK: Open
 
-  open func setupSubviews() {
-    addSubview(typingBubble)
-  }
-
   open override func prepareForReuse() {
     super.prepareForReuse()
     if typingBubble.isAnimating {
@@ -52,6 +48,10 @@ open class TypingIndicatorCell: MessageCollectionViewCell {
   open override func layoutSubviews() {
     super.layoutSubviews()
     typingBubble.frame = bounds.inset(by: insets)
+  }
+
+  open func setupSubviews() {
+    addSubview(typingBubble)
   }
 
   // MARK: Public

--- a/Sources/Views/MessageContainerView.swift
+++ b/Sources/Views/MessageContainerView.swift
@@ -25,21 +25,19 @@ import UIKit
 open class MessageContainerView: UIImageView {
   // MARK: Open
 
-  open var style: MessageStyle = .none {
-    didSet {
-      applyMessageStyle()
-    }
-  }
-
   open override var frame: CGRect {
     didSet {
       sizeMaskToView()
     }
   }
 
-  // MARK: Private
+  open var style: MessageStyle = .none {
+    didSet {
+      applyMessageStyle()
+    }
+  }
 
-  // MARK: - Properties
+  // MARK: Private
 
   private let imageMask = UIImageView()
 

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -41,32 +41,6 @@ open class MessageLabel: UILabel {
 
   // MARK: Open
 
-  // MARK: - Public Properties
-
-  open weak var delegate: MessageLabelDelegate?
-
-  open internal(set) var addressAttributes: [NSAttributedString.Key: Any] = defaultAttributes
-
-  open internal(set) var dateAttributes: [NSAttributedString.Key: Any] = defaultAttributes
-
-  open internal(set) var phoneNumberAttributes: [NSAttributedString.Key: Any] = defaultAttributes
-
-  open internal(set) var urlAttributes: [NSAttributedString.Key: Any] = defaultAttributes
-
-  open internal(set) var transitInformationAttributes: [NSAttributedString.Key: Any] = defaultAttributes
-
-  open internal(set) var hashtagAttributes: [NSAttributedString.Key: Any] = defaultAttributes
-
-  open internal(set) var mentionAttributes: [NSAttributedString.Key: Any] = defaultAttributes
-
-  open internal(set) var customAttributes: [NSRegularExpression: [NSAttributedString.Key: Any]] = [:]
-
-  open var enabledDetectors: [DetectorType] = [] {
-    didSet {
-      setTextStorage(attributedText, shouldParse: true)
-    }
-  }
-
   open override var attributedText: NSAttributedString? {
     didSet {
       setTextStorage(attributedText, shouldParse: true)
@@ -113,17 +87,43 @@ open class MessageLabel: UILabel {
     }
   }
 
-  open var textInsets: UIEdgeInsets = .zero {
-    didSet {
-      if !isConfiguring { setNeedsDisplay() }
-    }
-  }
-
   open override var intrinsicContentSize: CGSize {
     var size = super.intrinsicContentSize
     size.width += textInsets.horizontal
     size.height += textInsets.vertical
     return size
+  }
+
+  // MARK: - Public Properties
+
+  open weak var delegate: MessageLabelDelegate?
+
+  open internal(set) var addressAttributes: [NSAttributedString.Key: Any] = defaultAttributes
+
+  open internal(set) var dateAttributes: [NSAttributedString.Key: Any] = defaultAttributes
+
+  open internal(set) var phoneNumberAttributes: [NSAttributedString.Key: Any] = defaultAttributes
+
+  open internal(set) var urlAttributes: [NSAttributedString.Key: Any] = defaultAttributes
+
+  open internal(set) var transitInformationAttributes: [NSAttributedString.Key: Any] = defaultAttributes
+
+  open internal(set) var hashtagAttributes: [NSAttributedString.Key: Any] = defaultAttributes
+
+  open internal(set) var mentionAttributes: [NSAttributedString.Key: Any] = defaultAttributes
+
+  open internal(set) var customAttributes: [NSRegularExpression: [NSAttributedString.Key: Any]] = [:]
+
+  open var enabledDetectors: [DetectorType] = [] {
+    didSet {
+      setTextStorage(attributedText, shouldParse: true)
+    }
+  }
+
+  open var textInsets: UIEdgeInsets = .zero {
+    didSet {
+      if !isConfiguring { setNeedsDisplay() }
+    }
   }
 
   // MARK: - Open Methods
@@ -155,13 +155,11 @@ open class MessageLabel: UILabel {
 
   // MARK: Public
 
-  public static var defaultAttributes: [NSAttributedString.Key: Any] = {
-    [
-      NSAttributedString.Key.foregroundColor: UIColor.darkText,
-      NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue,
-      NSAttributedString.Key.underlineColor: UIColor.darkText,
-    ]
-  }()
+  public static var defaultAttributes: [NSAttributedString.Key: Any] = [
+    NSAttributedString.Key.foregroundColor: UIColor.darkText,
+    NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue,
+    NSAttributedString.Key.underlineColor: UIColor.darkText,
+  ]
 
   public func setAttributes(_ attributes: [NSAttributedString.Key: Any], detector: DetectorType) {
     switch detector {
@@ -393,7 +391,8 @@ open class MessageLabel: UILabel {
   private func parseForMatches(
     with detector: DetectorType,
     in text: NSAttributedString,
-    for range: NSRange) -> [NSTextCheckingResult]
+    for range: NSRange)
+    -> [NSTextCheckingResult]
   {
     switch detector {
     case .custom(let regex):
@@ -402,26 +401,26 @@ open class MessageLabel: UILabel {
       fatalError("You must pass a .custom DetectorType")
     }
   }
-  
-  private func removeOverlappingResults(_ results: [NSTextCheckingResult]) -> [NSTextCheckingResult]
-  {
+
+  private func removeOverlappingResults(_ results: [NSTextCheckingResult]) -> [NSTextCheckingResult] {
     var filteredResults: [NSTextCheckingResult] = []
-    
+
     for result in results {
       let overlappingResults = results.filter { $0.range.intersection(result.range)?.length ?? 0 > 0 }
-      
+
       if overlappingResults.count <= 1 {
         filteredResults.append(result)
         continue
       }
-      
+
       guard !filteredResults.contains(where: { $0.range == result.range }) else { continue }
-      let maxRangeResult = overlappingResults.max { $0.range.upperBound - $0.range.lowerBound < $1.range.upperBound - $1.range.lowerBound }
+      let maxRangeResult = overlappingResults
+        .max { $0.range.upperBound - $0.range.lowerBound < $1.range.upperBound - $1.range.lowerBound }
       if let maxRangeResult {
         filteredResults.append(maxRangeResult)
       }
     }
-    
+
     return filteredResults
   }
 

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -45,8 +45,6 @@ open class MessagesCollectionView: UICollectionView {
 
   // MARK: Open
 
-  // MARK: - Properties
-
   open weak var messagesDataSource: MessagesDataSource?
 
   open weak var messagesDisplayDelegate: MessagesDisplayDelegate?
@@ -85,18 +83,18 @@ open class MessagesCollectionView: UICollectionView {
 
     scrollToItem(at: indexPath, at: pos, animated: animated)
   }
-    
+
   public func scrollToBottom(animated: Bool = true) {
     guard let indexPath = indexPathForLastItem else { return }
-    
+
     // scroll to the item without animation to get the desired offset
     scrollToItem(at: indexPath, at: .bottom, animated: false)
     let targetOffset = contentOffset
-        
+
     // calculate the adjusted offset, considering the bottom section inset
     let sectionInsetBottom = (collectionViewLayout as? UICollectionViewFlowLayout)?.sectionInset.bottom ?? 0
     let adjustedOffset = CGPoint(x: targetOffset.x, y: targetOffset.y + sectionInsetBottom)
-        
+
     // set content offset to the adjusted offset
     setContentOffset(adjustedOffset, animated: animated)
   }

--- a/Sources/Views/PlayButtonView.swift
+++ b/Sources/Views/PlayButtonView.swift
@@ -60,8 +60,6 @@ open class PlayButtonView: UIView {
 
   // MARK: Public
 
-  // MARK: - Properties
-
   public let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .light))
   public let triangleView = UIView()
 

--- a/Sources/Views/TypingBubble.swift
+++ b/Sources/Views/TypingBubble.swift
@@ -38,10 +38,6 @@ open class TypingBubble: UIView {
 
   // MARK: Open
 
-  // MARK: - Properties
-
-  open var isPulseEnabled = true
-
   open override var backgroundColor: UIColor? {
     set {
       [contentBubble, cornerBubble, tinyBubble].forEach { $0.backgroundColor = newValue }
@@ -50,6 +46,8 @@ open class TypingBubble: UIView {
       contentBubble.backgroundColor
     }
   }
+
+  open var isPulseEnabled = true
 
   // MARK: - Animation Layers
 
@@ -71,14 +69,6 @@ open class TypingBubble: UIView {
     animation.repeatCount = .infinity
     animation.autoreverses = true
     return animation
-  }
-
-  open func setupSubviews() {
-    addSubview(tinyBubble)
-    addSubview(cornerBubble)
-    addSubview(contentBubble)
-    contentBubble.addSubview(typingIndicator)
-    backgroundColor = .incomingMessageBackground
   }
 
   // MARK: - Layout
@@ -129,6 +119,14 @@ open class TypingBubble: UIView {
       bottom: offset,
       right: contentBubbleFrameCornerRadius / 1.25)
     typingIndicator.frame = contentBubble.bounds.inset(by: insets)
+  }
+
+  open func setupSubviews() {
+    addSubview(tinyBubble)
+    addSubview(cornerBubble)
+    addSubview(contentBubble)
+    contentBubble.addSubview(typingIndicator)
+    backgroundColor = .incomingMessageBackground
   }
 
   // MARK: - Animation API

--- a/Sources/Views/TypingIndicator.swift
+++ b/Sources/Views/TypingIndicator.swift
@@ -87,24 +87,24 @@ open class TypingIndicator: UIView {
 
   /// Sets the state of the `TypingIndicator` to animating and applies animation layers
   open func startAnimating() {
-      defer { isAnimating = true }
-      guard !isAnimating else { return }
-      var delay: TimeInterval = 0
-      for dot in dots {
-          let currentDelay = delay
-          DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-              guard let self = self else { return }
-              if self.isBounceEnabled {
-                  dot.layer.add(self.initialOffsetAnimationLayer, forKey: AnimationKeys.offset)
-                  let bounceLayer = self.bounceAnimationLayer
-                  bounceLayer.timeOffset = currentDelay + 0.33
-                  dot.layer.add(bounceLayer, forKey: AnimationKeys.bounce)
-              }
-              if self.isFadeEnabled {
-                  dot.layer.add(self.opacityAnimationLayer, forKey: AnimationKeys.opacity)
-              }
-          }
-          delay += 0.33
+    defer { isAnimating = true }
+    guard !isAnimating else { return }
+    var delay: TimeInterval = 0
+    for dot in dots {
+      let currentDelay = delay
+      DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+        guard let self = self else { return }
+        if isBounceEnabled {
+          dot.layer.add(initialOffsetAnimationLayer, forKey: AnimationKeys.offset)
+          let bounceLayer = bounceAnimationLayer
+          bounceLayer.timeOffset = currentDelay + 0.33
+          dot.layer.add(bounceLayer, forKey: AnimationKeys.bounce)
+        }
+        if isFadeEnabled {
+          dot.layer.add(opacityAnimationLayer, forKey: AnimationKeys.opacity)
+        }
+      }
+      delay += 0.33
     }
   }
 
@@ -136,9 +136,7 @@ open class TypingIndicator: UIView {
 
   public let stackView = UIStackView()
 
-  public let dots: [BubbleCircle] = {
-    [BubbleCircle(), BubbleCircle(), BubbleCircle()]
-  }()
+  public let dots: [BubbleCircle] = [BubbleCircle(), BubbleCircle(), BubbleCircle()]
 
   // MARK: Private
 

--- a/Tests/MessageKitTests/Controllers Test/MessageLabelTests.swift
+++ b/Tests/MessageKitTests/Controllers Test/MessageLabelTests.swift
@@ -83,17 +83,18 @@ final class MessageLabelTests: XCTestCase {
     let invalidMatches = extractCustomDetectors(for: detector, with: messageLabel)
     XCTAssertEqual(invalidMatches.count, 0)
   }
-  
+
   func testCustomDetectionOverlapping() {
     let testText = "address MNtz8Zz1cPD1CZadoc38jT5qeqeFBS6Aif can match multiple regex's"
-    
+
     let messageLabel = MessageLabel()
     let attributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key(rawValue: "Custom"): "CustomDetected"]
     let detectors = [
-      DetectorType.custom(try! NSRegularExpression(pattern: "(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}", options: .caseInsensitive)), 
-      DetectorType.custom(try! NSRegularExpression(pattern: #"([3ML][\w]{26,33})|ltc1[\w]+"#, options: .caseInsensitive)), 
-      DetectorType.custom(try! NSRegularExpression(pattern: "[qmN][a-km-zA-HJ-NP-Z1-9]{26,33}", options: .caseInsensitive))]
-    
+      DetectorType.custom(try! NSRegularExpression(pattern: "(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}", options: .caseInsensitive)),
+      DetectorType.custom(try! NSRegularExpression(pattern: #"([3ML][\w]{26,33})|ltc1[\w]+"#, options: .caseInsensitive)),
+      DetectorType.custom(try! NSRegularExpression(pattern: "[qmN][a-km-zA-HJ-NP-Z1-9]{26,33}", options: .caseInsensitive)),
+    ]
+
     set(text: testText, and: detectors, with: attributes, to: messageLabel)
     let matches = detectors.map { extractCustomDetectors(for: $0, with: messageLabel) }.joined()
     XCTAssertEqual(matches.count, 1)

--- a/Tests/MessageKitTests/Controllers Test/MessagesViewControllerTests.swift
+++ b/Tests/MessageKitTests/Controllers Test/MessagesViewControllerTests.swift
@@ -28,262 +28,263 @@ import XCTest
 
 @MainActor
 final class MessagesViewControllerTests: XCTestCase {
+  // MARK: Internal
 
-    // MARK: - Private helper API
+  // MARK: - Test
 
-    private func makeSUT() -> MessagesViewController {
-        let sut = MessagesViewController()
-        sut.messagesCollectionView.messagesLayoutDelegate = layoutDelegate
-        sut.messagesCollectionView.messagesDisplayDelegate = layoutDelegate
-        _ = sut.view
-        sut.beginAppearanceTransition(true, animated: true)
-        sut.endAppearanceTransition()
-        sut.view.layoutIfNeeded()
+  func testNumberOfSectionWithoutData_isZero() {
+    let messagesDataSource = MockMessagesDataSource()
+    let sut = makeSUT()
+    sut.messagesCollectionView.messagesDataSource = messagesDataSource
 
-        return sut
-    }
+    XCTAssertEqual(sut.messagesCollectionView.numberOfSections, 0)
+  }
 
-    // MARK: - Test
+  func testNumberOfSection_isNumberOfMessages() {
+    let messagesDataSource = MockMessagesDataSource()
+    let sut = makeSUT()
+    sut.messagesCollectionView.messagesDataSource = messagesDataSource
+    messagesDataSource.messages = makeMessages(for: messagesDataSource.senders)
 
-    func testNumberOfSectionWithoutData_isZero() {
-        let messagesDataSource = MockMessagesDataSource()
-        let sut = makeSUT()
-        sut.messagesCollectionView.messagesDataSource = messagesDataSource
+    sut.messagesCollectionView.reloadData()
 
-        XCTAssertEqual(sut.messagesCollectionView.numberOfSections, 0)
-    }
+    let count = sut.messagesCollectionView.numberOfSections
+    let expectedCount = messagesDataSource.numberOfSections(in: sut.messagesCollectionView)
 
-    func testNumberOfSection_isNumberOfMessages() {
-        let messagesDataSource = MockMessagesDataSource()
-        let sut = makeSUT()
-        sut.messagesCollectionView.messagesDataSource = messagesDataSource
-        messagesDataSource.messages = makeMessages(for: messagesDataSource.senders)
+    XCTAssertEqual(count, expectedCount)
+  }
 
-        sut.messagesCollectionView.reloadData()
+  func testNumberOfItemInSection_isOne() {
+    let messagesDataSource = MockMessagesDataSource()
+    let sut = makeSUT()
+    sut.messagesCollectionView.messagesDataSource = messagesDataSource
+    messagesDataSource.messages = makeMessages(for: messagesDataSource.senders)
 
-        let count = sut.messagesCollectionView.numberOfSections
-        let expectedCount = messagesDataSource.numberOfSections(in: sut.messagesCollectionView)
+    sut.messagesCollectionView.reloadData()
 
-        XCTAssertEqual(count, expectedCount)
-    }
+    XCTAssertEqual(sut.messagesCollectionView.numberOfItems(inSection: 0), 1)
+    XCTAssertEqual(sut.messagesCollectionView.numberOfItems(inSection: 1), 1)
+  }
 
-    func testNumberOfItemInSection_isOne() {
-        let messagesDataSource = MockMessagesDataSource()
-        let sut = makeSUT()
-        sut.messagesCollectionView.messagesDataSource = messagesDataSource
-        messagesDataSource.messages = makeMessages(for: messagesDataSource.senders)
+  func testCellForItemWithTextData_returnsTextMessageCell() {
+    let messagesDataSource = MockMessagesDataSource()
+    let sut = makeSUT()
+    sut.messagesCollectionView.messagesDataSource = messagesDataSource
+    messagesDataSource.messages.append(MockMessage(
+      text: "Test",
+      user: messagesDataSource.senders[0],
+      messageId: "test_id"))
 
-        sut.messagesCollectionView.reloadData()
+    sut.messagesCollectionView.reloadData()
 
-        XCTAssertEqual(sut.messagesCollectionView.numberOfItems(inSection: 0), 1)
-        XCTAssertEqual(sut.messagesCollectionView.numberOfItems(inSection: 1), 1)
-    }
+    let cell = sut.messagesCollectionView.dataSource?.collectionView(
+      sut.messagesCollectionView,
+      cellForItemAt: IndexPath(item: 0, section: 0))
 
-    func testCellForItemWithTextData_returnsTextMessageCell() {
-        let messagesDataSource = MockMessagesDataSource()
-        let sut = makeSUT()
-        sut.messagesCollectionView.messagesDataSource = messagesDataSource
-        messagesDataSource.messages.append(MockMessage(
-            text: "Test",
-            user: messagesDataSource.senders[0],
-            messageId: "test_id"))
+    XCTAssertNotNil(cell)
+    XCTAssertTrue(cell is TextMessageCell)
+  }
 
-        sut.messagesCollectionView.reloadData()
+  func testCellForItemWithAttributedTextData_returnsTextMessageCell() {
+    let messagesDataSource = MockMessagesDataSource()
+    let sut = makeSUT()
+    sut.messagesCollectionView.messagesDataSource = messagesDataSource
+    let attributes = [NSAttributedString.Key.foregroundColor: UIColor.outgoingMessageLabel]
+    let attriutedString = NSAttributedString(string: "Test", attributes: attributes)
+    messagesDataSource.messages.append(MockMessage(
+      attributedText: attriutedString,
+      user: messagesDataSource.senders[0],
+      messageId: "test_id"))
 
-        let cell = sut.messagesCollectionView.dataSource?.collectionView(
-            sut.messagesCollectionView,
-            cellForItemAt: IndexPath(item: 0, section: 0))
+    sut.messagesCollectionView.reloadData()
 
-        XCTAssertNotNil(cell)
-        XCTAssertTrue(cell is TextMessageCell)
-    }
+    let cell = sut.messagesCollectionView.dataSource?.collectionView(
+      sut.messagesCollectionView,
+      cellForItemAt: IndexPath(item: 0, section: 0))
 
-    func testCellForItemWithAttributedTextData_returnsTextMessageCell() {
-        let messagesDataSource = MockMessagesDataSource()
-        let sut = makeSUT()
-        sut.messagesCollectionView.messagesDataSource = messagesDataSource
-        let attributes = [NSAttributedString.Key.foregroundColor: UIColor.outgoingMessageLabel]
-        let attriutedString = NSAttributedString(string: "Test", attributes: attributes)
-        messagesDataSource.messages.append(MockMessage(
-            attributedText: attriutedString,
-            user: messagesDataSource.senders[0],
-            messageId: "test_id"))
+    XCTAssertNotNil(cell)
+    XCTAssertTrue(cell is TextMessageCell)
+  }
 
-        sut.messagesCollectionView.reloadData()
+  func testCellForItemWithPhotoData_returnsMediaMessageCell() {
+    let messagesDataSource = MockMessagesDataSource()
+    let sut = makeSUT()
+    sut.messagesCollectionView.messagesDataSource = messagesDataSource
+    messagesDataSource.messages.append(MockMessage(
+      image: UIImage(),
+      user: messagesDataSource.senders[0],
+      messageId: "test_id"))
 
-        let cell = sut.messagesCollectionView.dataSource?.collectionView(
-            sut.messagesCollectionView,
-            cellForItemAt: IndexPath(item: 0, section: 0))
+    sut.messagesCollectionView.reloadData()
 
-        XCTAssertNotNil(cell)
-        XCTAssertTrue(cell is TextMessageCell)
-    }
+    let cell = sut.messagesCollectionView.dataSource?.collectionView(
+      sut.messagesCollectionView,
+      cellForItemAt: IndexPath(item: 0, section: 0))
 
-    func testCellForItemWithPhotoData_returnsMediaMessageCell() {
-        let messagesDataSource = MockMessagesDataSource()
-        let sut = makeSUT()
-        sut.messagesCollectionView.messagesDataSource = messagesDataSource
-        messagesDataSource.messages.append(MockMessage(
-            image: UIImage(),
-            user: messagesDataSource.senders[0],
-            messageId: "test_id"))
+    XCTAssertNotNil(cell)
+    XCTAssertTrue(cell is MediaMessageCell)
+  }
 
-        sut.messagesCollectionView.reloadData()
+  func testCellForItemWithVideoData_returnsMediaMessageCell() {
+    let messagesDataSource = MockMessagesDataSource()
+    let sut = makeSUT()
+    sut.messagesCollectionView.messagesDataSource = messagesDataSource
+    messagesDataSource.messages.append(MockMessage(
+      thumbnail: UIImage(),
+      user: messagesDataSource.senders[0],
+      messageId: "test_id"))
 
-        let cell = sut.messagesCollectionView.dataSource?.collectionView(
-            sut.messagesCollectionView,
-            cellForItemAt: IndexPath(item: 0, section: 0))
+    sut.messagesCollectionView.reloadData()
 
-        XCTAssertNotNil(cell)
-        XCTAssertTrue(cell is MediaMessageCell)
-    }
+    let cell = sut.messagesCollectionView.dataSource?.collectionView(
+      sut.messagesCollectionView,
+      cellForItemAt: IndexPath(item: 0, section: 0))
 
-    func testCellForItemWithVideoData_returnsMediaMessageCell() {
-        let messagesDataSource = MockMessagesDataSource()
-        let sut = makeSUT()
-        sut.messagesCollectionView.messagesDataSource = messagesDataSource
-        messagesDataSource.messages.append(MockMessage(
-            thumbnail: UIImage(),
-            user: messagesDataSource.senders[0],
-            messageId: "test_id"))
+    XCTAssertNotNil(cell)
+    XCTAssertTrue(cell is MediaMessageCell)
+  }
 
-        sut.messagesCollectionView.reloadData()
+  func testCellForItemWithLocationData_returnsLocationMessageCell() {
+    let messagesDataSource = MockMessagesDataSource()
+    let sut = makeSUT()
+    sut.messagesCollectionView.messagesDataSource = messagesDataSource
+    messagesDataSource.messages.append(MockMessage(
+      location: CLLocation(latitude: 60.0, longitude: 70.0),
+      user: messagesDataSource.senders[0],
+      messageId: "test_id"))
 
-        let cell = sut.messagesCollectionView.dataSource?.collectionView(
-            sut.messagesCollectionView,
-            cellForItemAt: IndexPath(item: 0, section: 0))
+    sut.messagesCollectionView.reloadData()
 
-        XCTAssertNotNil(cell)
-        XCTAssertTrue(cell is MediaMessageCell)
-    }
+    let cell = sut.messagesCollectionView.dataSource?.collectionView(
+      sut.messagesCollectionView,
+      cellForItemAt: IndexPath(item: 0, section: 0))
 
-    func testCellForItemWithLocationData_returnsLocationMessageCell() {
-        let messagesDataSource = MockMessagesDataSource()
-        let sut = makeSUT()
-        sut.messagesCollectionView.messagesDataSource = messagesDataSource
-        messagesDataSource.messages.append(MockMessage(
-            location: CLLocation(latitude: 60.0, longitude: 70.0),
-            user: messagesDataSource.senders[0],
-            messageId: "test_id"))
+    XCTAssertNotNil(cell)
+    XCTAssertTrue(cell is LocationMessageCell)
+  }
 
-        sut.messagesCollectionView.reloadData()
+  func testCellForItemWithAudioData_returnsAudioMessageCell() {
+    let messagesDataSource = MockMessagesDataSource()
+    let sut = makeSUT()
+    sut.messagesCollectionView.messagesDataSource = messagesDataSource
+    messagesDataSource.messages.append(MockMessage(
+      audioURL: URL(fileURLWithPath: ""),
+      duration: 4.0,
+      user: messagesDataSource.senders[0],
+      messageId: "test_id"))
 
-        let cell = sut.messagesCollectionView.dataSource?.collectionView(
-            sut.messagesCollectionView,
-            cellForItemAt: IndexPath(item: 0, section: 0))
+    sut.messagesCollectionView.reloadData()
 
-        XCTAssertNotNil(cell)
-        XCTAssertTrue(cell is LocationMessageCell)
-    }
+    let cell = sut.messagesCollectionView.dataSource?.collectionView(
+      sut.messagesCollectionView,
+      cellForItemAt: IndexPath(item: 0, section: 0))
 
-    func testCellForItemWithAudioData_returnsAudioMessageCell() {
-        let messagesDataSource = MockMessagesDataSource()
-        let sut = makeSUT()
-        sut.messagesCollectionView.messagesDataSource = messagesDataSource
-        messagesDataSource.messages.append(MockMessage(
-            audioURL: URL(fileURLWithPath: ""),
-            duration: 4.0,
-            user: messagesDataSource.senders[0],
-            messageId: "test_id"))
+    XCTAssertNotNil(cell)
+    XCTAssertTrue(cell is AudioMessageCell)
+  }
 
-        sut.messagesCollectionView.reloadData()
+  func testCellForItemWithLinkPreviewData_returnsLinkPreviewMessageCell() {
+    let messagesDataSource = MockMessagesDataSource()
+    let sut = makeSUT()
+    sut.messagesCollectionView.messagesDataSource = messagesDataSource
 
-        let cell = sut.messagesCollectionView.dataSource?.collectionView(
-            sut.messagesCollectionView,
-            cellForItemAt: IndexPath(item: 0, section: 0))
+    let linkItem = MockLinkItem(
+      text: "https://link.test",
+      attributedText: nil,
+      url: URL(string: "https://github.com/MessageKit")!,
+      title: "Link Title",
+      teaser: "Link Teaser",
+      thumbnailImage: UIImage())
 
-        XCTAssertNotNil(cell)
-        XCTAssertTrue(cell is AudioMessageCell)
-    }
+    messagesDataSource.messages.append(MockMessage(
+      linkItem: linkItem,
+      user: messagesDataSource.senders[0],
+      messageId: "test_id"))
 
-    func testCellForItemWithLinkPreviewData_returnsLinkPreviewMessageCell() {
-        let messagesDataSource = MockMessagesDataSource()
-        let sut = makeSUT()
-        sut.messagesCollectionView.messagesDataSource = messagesDataSource
+    sut.messagesCollectionView.reloadData()
 
-        let linkItem = MockLinkItem(
-            text: "https://link.test",
-            attributedText: nil,
-            url: URL(string: "https://github.com/MessageKit")!,
-            title: "Link Title",
-            teaser: "Link Teaser",
-            thumbnailImage: UIImage())
+    let cell = sut.messagesCollectionView.dataSource?.collectionView(
+      sut.messagesCollectionView,
+      cellForItemAt: IndexPath(item: 0, section: 0))
 
-        messagesDataSource.messages.append(MockMessage(
-            linkItem: linkItem,
-            user: messagesDataSource.senders[0],
-            messageId: "test_id"))
+    XCTAssertNotNil(cell)
+    XCTAssertTrue(cell is LinkPreviewMessageCell)
+  }
 
-        sut.messagesCollectionView.reloadData()
+  // MARK: - Setups
 
-        let cell = sut.messagesCollectionView.dataSource?.collectionView(
-            sut.messagesCollectionView,
-            cellForItemAt: IndexPath(item: 0, section: 0))
+  func testSubviewsSetup() {
+    let controller = MessagesViewController()
+    XCTAssertTrue(controller.view.subviews.contains(controller.messagesCollectionView))
+  }
 
-        XCTAssertNotNil(cell)
-        XCTAssertTrue(cell is LinkPreviewMessageCell)
-    }
+  func testDelegateAndDataSourceSetup() {
+    let controller = MessagesViewController()
+    controller.view.layoutIfNeeded()
+    XCTAssertTrue(controller.messagesCollectionView.delegate is MessagesViewController)
+    XCTAssertTrue(controller.messagesCollectionView.dataSource is MessagesViewController)
+  }
 
-    // MARK: - Setups
+  func testDefaultPropertyValues() {
+    let controller = MessagesViewController()
+    XCTAssertNotNil(controller.messagesCollectionView)
+    XCTAssertTrue(controller.messagesCollectionView.collectionViewLayout is MessagesCollectionViewFlowLayout)
 
-    func testSubviewsSetup() {
-        let controller = MessagesViewController()
-        XCTAssertTrue(controller.view.subviews.contains(controller.messagesCollectionView))
-    }
+    controller.view.layoutIfNeeded()
+    XCTAssertTrue(controller.extendedLayoutIncludesOpaqueBars)
+    XCTAssertEqual(controller.view.backgroundColor, UIColor.collectionViewBackground)
+    XCTAssertEqual(controller.messagesCollectionView.keyboardDismissMode, UIScrollView.KeyboardDismissMode.interactive)
+    XCTAssertTrue(controller.messagesCollectionView.alwaysBounceVertical)
+  }
 
-    func testDelegateAndDataSourceSetup() {
-        let controller = MessagesViewController()
-        controller.view.layoutIfNeeded()
-        XCTAssertTrue(controller.messagesCollectionView.delegate is MessagesViewController)
-        XCTAssertTrue(controller.messagesCollectionView.dataSource is MessagesViewController)
-    }
+  // MARK: Private
 
-    func testDefaultPropertyValues() {
-        let controller = MessagesViewController()
-        XCTAssertNotNil(controller.messagesCollectionView)
-        XCTAssertTrue(controller.messagesCollectionView.collectionViewLayout is MessagesCollectionViewFlowLayout)
+  // swiftlint:disable:next weak_delegate
+  private var layoutDelegate = MockLayoutDelegate()
 
-        controller.view.layoutIfNeeded()
-        XCTAssertTrue(controller.extendedLayoutIncludesOpaqueBars)
-        XCTAssertEqual(controller.view.backgroundColor, UIColor.collectionViewBackground)
-        XCTAssertEqual(controller.messagesCollectionView.keyboardDismissMode, UIScrollView.KeyboardDismissMode.interactive)
-        XCTAssertTrue(controller.messagesCollectionView.alwaysBounceVertical)
-    }
+  // MARK: - Private helper API
 
-    // MARK: Private
+  private func makeSUT() -> MessagesViewController {
+    let sut = MessagesViewController()
+    sut.messagesCollectionView.messagesLayoutDelegate = layoutDelegate
+    sut.messagesCollectionView.messagesDisplayDelegate = layoutDelegate
+    _ = sut.view
+    sut.beginAppearanceTransition(true, animated: true)
+    sut.endAppearanceTransition()
+    sut.view.layoutIfNeeded()
 
-    // swiftlint:disable:next weak_delegate
-    private var layoutDelegate = MockLayoutDelegate()
+    return sut
+  }
 
-    // MARK: - Assistants
+  // MARK: - Assistants
 
-    private func makeMessages(for senders: [MockUser]) -> [MessageType] {
-        [
-            MockMessage(text: "Text 1", user: senders[0], messageId: "test_id_1"),
-            MockMessage(text: "Text 2", user: senders[1], messageId: "test_id_2"),
-        ]
-    }
+  private func makeMessages(for senders: [MockUser]) -> [MessageType] {
+    [
+      MockMessage(text: "Text 1", user: senders[0], messageId: "test_id_1"),
+      MockMessage(text: "Text 2", user: senders[1], messageId: "test_id_2"),
+    ]
+  }
 }
 
 // MARK: - MockLayoutDelegate
 
 private class MockLayoutDelegate: MessagesLayoutDelegate, MessagesDisplayDelegate {
-    // MARK: - LocationMessageLayoutDelegate
+  // MARK: - LocationMessageLayoutDelegate
 
-    func heightForLocation(message _: MessageType, at _: IndexPath, with _: CGFloat, in _: MessagesCollectionView) -> CGFloat {
-        0.0
-    }
+  func heightForLocation(message _: MessageType, at _: IndexPath, with _: CGFloat, in _: MessagesCollectionView) -> CGFloat {
+    0.0
+  }
 
-    func heightForMedia(message _: MessageType, at _: IndexPath, with _: CGFloat, in _: MessagesCollectionView) -> CGFloat {
-        10.0
-    }
+  func heightForMedia(message _: MessageType, at _: IndexPath, with _: CGFloat, in _: MessagesCollectionView) -> CGFloat {
+    10.0
+  }
 
-    func snapshotOptionsForLocation(
-        message _: MessageType,
-        at _: IndexPath,
-        in _: MessagesCollectionView)
+  func snapshotOptionsForLocation(
+    message _: MessageType,
+    at _: IndexPath,
+    in _: MessagesCollectionView)
     -> LocationMessageSnapshotOptions
-    {
-        LocationMessageSnapshotOptions()
-    }
+  {
+    LocationMessageSnapshotOptions()
+  }
 }

--- a/Tests/MessageKitTests/MessageKitTests.swift
+++ b/Tests/MessageKitTests/MessageKitTests.swift
@@ -25,7 +25,7 @@ import XCTest
 @testable import MessageKit
 
 final class MessageKitTests: XCTestCase {
-    static let allTests = [
-        "",
-    ]
+  static let allTests = [
+    "",
+  ]
 }

--- a/Tests/MessageKitTests/Mocks/MockMessagesDataSource.swift
+++ b/Tests/MessageKitTests/Mocks/MockMessagesDataSource.swift
@@ -25,25 +25,25 @@ import Foundation
 
 @MainActor
 class MockMessagesDataSource: MessagesDataSource {
-    var messages: [MessageType] = []
-    let senders: [MockUser] = [
-        MockUser(senderId: "sender_1", displayName: "Sender 1"),
-        MockUser(senderId: "sender_2", displayName: "Sender 2"),
-    ]
+  var messages: [MessageType] = []
+  let senders: [MockUser] = [
+    MockUser(senderId: "sender_1", displayName: "Sender 1"),
+    MockUser(senderId: "sender_2", displayName: "Sender 2"),
+  ]
 
-    var currentUser: MockUser {
-        senders[0]
-    }
+  var currentUser: MockUser {
+    senders[0]
+  }
 
-    var currentSender: SenderType {
-        currentUser
-    }
+  var currentSender: SenderType {
+    currentUser
+  }
 
-    func numberOfSections(in _: MessagesCollectionView) -> Int {
-        messages.count
-    }
+  func numberOfSections(in _: MessagesCollectionView) -> Int {
+    messages.count
+  }
 
-    func messageForItem(at indexPath: IndexPath, in _: MessagesCollectionView) -> MessageType {
-        messages[indexPath.section]
-    }
+  func messageForItem(at indexPath: IndexPath, in _: MessagesCollectionView) -> MessageType {
+    messages[indexPath.section]
+  }
 }

--- a/Tests/MessageKitTests/Protocols Tests/MessagesDisplayDelegateTests.swift
+++ b/Tests/MessageKitTests/Protocols Tests/MessagesDisplayDelegateTests.swift
@@ -28,217 +28,223 @@ import XCTest
 
 @MainActor
 final class MessagesDisplayDelegateTests: XCTestCase {
-    // MARK: - Private helper API
+  // MARK: Internal
 
-    private func makeSUT() -> MockMessagesViewController {
-        let sut = MockMessagesViewController()
-        _ = sut.view
-        sut.beginAppearanceTransition(true, animated: true)
-        sut.endAppearanceTransition()
-        sut.viewDidLoad()
-        sut.view.layoutIfNeeded()
+  func testBackGroundColorDefaultState() {
+    let sut = makeSUT()
+    XCTAssertEqual(
+      sut.backgroundColor(
+        for: sut.dataProvider.messages[0],
+        at: IndexPath(item: 0, section: 0),
+        in: sut.messagesCollectionView),
+      UIColor.outgoingMessageBackground)
+    XCTAssertNotEqual(
+      sut.backgroundColor(
+        for: sut.dataProvider.messages[0],
+        at: IndexPath(item: 0, section: 0),
+        in: sut.messagesCollectionView),
+      UIColor.incomingMessageBackground)
+    XCTAssertEqual(
+      sut.backgroundColor(
+        for: sut.dataProvider.messages[1],
+        at: IndexPath(item: 1, section: 0),
+        in: sut.messagesCollectionView),
+      UIColor.incomingMessageBackground)
+    XCTAssertNotEqual(
+      sut.backgroundColor(
+        for: sut.dataProvider.messages[1],
+        at: IndexPath(item: 1, section: 0),
+        in: sut.messagesCollectionView),
+      UIColor.outgoingMessageBackground)
+  }
 
-        return sut
+  func testBackgroundColorWithoutDataSource_returnsWhiteForDefault() {
+    let sut = makeSUT()
+    sut.messagesCollectionView.messagesDataSource = nil
+    let backgroundColor = sut.backgroundColor(
+      for: sut.dataProvider.messages[0],
+      at: IndexPath(item: 0, section: 0),
+      in: sut.messagesCollectionView)
+
+    XCTAssertEqual(backgroundColor, UIColor.white)
+  }
+
+  func testBackgroundColorForMessageWithEmoji_returnsClearForDefault() {
+    let sut = makeSUT()
+    sut.dataProvider.messages.append(MockMessage(
+      emoji: "🤔",
+      user: sut.dataProvider.currentUser,
+      messageId: "003"))
+    let backgroundColor = sut.backgroundColor(
+      for: sut.dataProvider.messages[2],
+      at: IndexPath(item: 0, section: 0),
+      in: sut.messagesCollectionView)
+
+    XCTAssertEqual(backgroundColor, .clear)
+  }
+
+  func testCellTopLabelDefaultState() {
+    let sut = makeSUT()
+    XCTAssertNil(sut.dataProvider.cellTopLabelAttributedText(
+      for: sut.dataProvider.messages[0],
+      at: IndexPath(item: 0, section: 0)))
+  }
+
+  func testMessageBottomLabelDefaultState() {
+    let sut = makeSUT()
+    XCTAssertNil(sut.dataProvider.messageBottomLabelAttributedText(
+      for: sut.dataProvider.messages[0],
+      at: IndexPath(item: 0, section: 0)))
+  }
+
+  func testMessageStyle_returnsBubleTypeForDefault() {
+    let sut = makeSUT()
+    let type = sut.messageStyle(
+      for: sut.dataProvider.messages[0],
+      at: IndexPath(item: 0, section: 0),
+      in: sut.messagesCollectionView)
+
+    let result: Bool
+    switch type {
+    case .bubble:
+      result = true
+    default:
+      result = false
     }
 
-    // MARK: Internal
+    XCTAssertTrue(result)
+  }
 
-    func testBackGroundColorDefaultState() {
-        let sut = makeSUT()
-        XCTAssertEqual(
-            sut.backgroundColor(
-                for: sut.dataProvider.messages[0],
-                at: IndexPath(item: 0, section: 0),
-                in: sut.messagesCollectionView),
-            UIColor.outgoingMessageBackground)
-        XCTAssertNotEqual(
-            sut.backgroundColor(
-                for: sut.dataProvider.messages[0],
-                at: IndexPath(item: 0, section: 0),
-                in: sut.messagesCollectionView),
-            UIColor.incomingMessageBackground)
-        XCTAssertEqual(
-            sut.backgroundColor(
-                for: sut.dataProvider.messages[1],
-                at: IndexPath(item: 1, section: 0),
-                in: sut.messagesCollectionView),
-            UIColor.incomingMessageBackground)
-        XCTAssertNotEqual(
-            sut.backgroundColor(
-                for: sut.dataProvider.messages[1],
-                at: IndexPath(item: 1, section: 0),
-                in: sut.messagesCollectionView),
-            UIColor.outgoingMessageBackground)
-    }
+  func testMessageHeaderView_isNotNil() {
+    let sut = makeSUT()
+    let indexPath = IndexPath(item: 0, section: 1)
+    XCTAssert(sut.dataProvider != nil)
+    let headerView = sut.messageHeaderView(for: indexPath, in: sut.messagesCollectionView)
+    XCTAssertNotNil(headerView)
+  }
 
-    func testBackgroundColorWithoutDataSource_returnsWhiteForDefault() {
-        let sut = makeSUT()
-        sut.messagesCollectionView.messagesDataSource = nil
-        let backgroundColor = sut.backgroundColor(
-            for: sut.dataProvider.messages[0],
-            at: IndexPath(item: 0, section: 0),
-            in: sut.messagesCollectionView)
+  // MARK: Private
 
-        XCTAssertEqual(backgroundColor, UIColor.white)
-    }
+  // MARK: - Private helper API
 
-    func testBackgroundColorForMessageWithEmoji_returnsClearForDefault() {
-        let sut = makeSUT()
-        sut.dataProvider.messages.append(MockMessage(
-            emoji: "🤔",
-            user: sut.dataProvider.currentUser,
-            messageId: "003"))
-        let backgroundColor = sut.backgroundColor(
-            for: sut.dataProvider.messages[2],
-            at: IndexPath(item: 0, section: 0),
-            in: sut.messagesCollectionView)
+  private func makeSUT() -> MockMessagesViewController {
+    let sut = MockMessagesViewController()
+    _ = sut.view
+    sut.beginAppearanceTransition(true, animated: true)
+    sut.endAppearanceTransition()
+    sut.viewDidLoad()
+    sut.view.layoutIfNeeded()
 
-        XCTAssertEqual(backgroundColor, .clear)
-    }
-
-    func testCellTopLabelDefaultState() {
-        let sut = makeSUT()
-        XCTAssertNil(sut.dataProvider.cellTopLabelAttributedText(
-            for: sut.dataProvider.messages[0],
-            at: IndexPath(item: 0, section: 0)))
-    }
-
-    func testMessageBottomLabelDefaultState() {
-        let sut = makeSUT()
-        XCTAssertNil(sut.dataProvider.messageBottomLabelAttributedText(
-            for: sut.dataProvider.messages[0],
-            at: IndexPath(item: 0, section: 0)))
-    }
-
-    func testMessageStyle_returnsBubleTypeForDefault() {
-        let sut = makeSUT()
-        let type = sut.messageStyle(
-            for: sut.dataProvider.messages[0],
-            at: IndexPath(item: 0, section: 0),
-            in: sut.messagesCollectionView)
-
-        let result: Bool
-        switch type {
-            case .bubble:
-                result = true
-            default:
-                result = false
-        }
-
-        XCTAssertTrue(result)
-    }
-
-    func testMessageHeaderView_isNotNil() {
-        let sut = makeSUT()
-        let indexPath = IndexPath(item: 0, section: 1)
-        XCTAssert(sut.dataProvider != nil)
-        let headerView = sut.messageHeaderView(for: indexPath, in: sut.messagesCollectionView)
-        XCTAssertNotNil(headerView)
-    }
+    return sut
+  }
 }
 
 // MARK: - TextMessageDisplayDelegateTests
 
 @MainActor
 class TextMessageDisplayDelegateTests: XCTestCase {
-    // MARK: - Private helper API
+  // MARK: Internal
 
-    private func makeSUT() -> MockMessagesViewController {
-        let sut = MockMessagesViewController()
-        _ = sut.view
-        sut.beginAppearanceTransition(true, animated: true)
-        sut.endAppearanceTransition()
-        return sut
-    }
+  func testTextColorFromCurrentSender_returnsWhiteForDefault() {
+    let sut = makeSUT()
+    let textColor = sut.textColor(
+      for: sut.dataProvider.messages[0],
+      at: IndexPath(item: 0, section: 0),
+      in: sut.messagesCollectionView)
 
-    func testTextColorFromCurrentSender_returnsWhiteForDefault() {
-        let sut = makeSUT()
-        let textColor = sut.textColor(
-            for: sut.dataProvider.messages[0],
-            at: IndexPath(item: 0, section: 0),
-            in: sut.messagesCollectionView)
+    XCTAssertEqual(textColor, UIColor.outgoingMessageLabel)
+  }
 
-        XCTAssertEqual(textColor, UIColor.outgoingMessageLabel)
-    }
+  func testTextColorFromYou_returnsDarkTextForDefault() {
+    let sut = makeSUT()
+    let textColor = sut.textColor(
+      for: sut.dataProvider.messages[1],
+      at: IndexPath(item: 0, section: 0),
+      in: sut.messagesCollectionView)
 
-    func testTextColorFromYou_returnsDarkTextForDefault() {
-        let sut = makeSUT()
-        let textColor = sut.textColor(
-            for: sut.dataProvider.messages[1],
-            at: IndexPath(item: 0, section: 0),
-            in: sut.messagesCollectionView)
+    XCTAssertEqual(textColor, UIColor.incomingMessageLabel)
+  }
 
-        XCTAssertEqual(textColor, UIColor.incomingMessageLabel)
-    }
+  func testTextColorWithoutDataSource_returnsDarkTextForDefault() {
+    let sut = makeSUT()
+    let dataSource = sut.makeDataSource()
+    sut.messagesCollectionView.messagesDataSource = dataSource
+    let textColor = sut.textColor(
+      for: sut.dataProvider.messages[1],
+      at: IndexPath(item: 0, section: 0),
+      in: sut.messagesCollectionView)
 
-    func testTextColorWithoutDataSource_returnsDarkTextForDefault() {
-        let sut = makeSUT()
-        let dataSource = sut.makeDataSource()
-        sut.messagesCollectionView.messagesDataSource = dataSource
-        let textColor = sut.textColor(
-            for: sut.dataProvider.messages[1],
-            at: IndexPath(item: 0, section: 0),
-            in: sut.messagesCollectionView)
+    XCTAssertEqual(textColor, UIColor.incomingMessageLabel)
+  }
 
-        XCTAssertEqual(textColor, UIColor.incomingMessageLabel)
-    }
+  func testEnableDetectors_returnsEmptyForDefault() {
+    let sut = makeSUT()
+    let detectors = sut.enabledDetectors(
+      for: sut.dataProvider.messages[1],
+      at: IndexPath(item: 0, section: 0),
+      in: sut.messagesCollectionView)
+    let expectedDetectors: [DetectorType] = []
 
-    func testEnableDetectors_returnsEmptyForDefault() {
-        let sut = makeSUT()
-        let detectors = sut.enabledDetectors(
-            for: sut.dataProvider.messages[1],
-            at: IndexPath(item: 0, section: 0),
-            in: sut.messagesCollectionView)
-        let expectedDetectors: [DetectorType] = []
+    XCTAssertEqual(detectors, expectedDetectors)
+  }
 
-        XCTAssertEqual(detectors, expectedDetectors)
-    }
+  // MARK: Private
+
+  // MARK: - Private helper API
+
+  private func makeSUT() -> MockMessagesViewController {
+    let sut = MockMessagesViewController()
+    _ = sut.view
+    sut.beginAppearanceTransition(true, animated: true)
+    sut.endAppearanceTransition()
+    return sut
+  }
 }
 
 // MARK: - MockMessagesViewController
 
 @MainActor
 private class MockMessagesViewController: MessagesViewController, MessagesDisplayDelegate, MessagesLayoutDelegate {
-    // MARK: Internal
+  // MARK: Internal
 
-    var dataProvider: MockMessagesDataSource!
+  var dataProvider: MockMessagesDataSource!
 
-    func heightForLocation(message _: MessageType, at _: IndexPath, with _: CGFloat, in _: MessagesCollectionView) -> CGFloat {
-        200
-    }
+  override func viewDidLoad() {
+    super.viewDidLoad()
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    dataProvider = makeDataSource()
+    messagesCollectionView.messagesDisplayDelegate = self
+    messagesCollectionView.messagesDataSource = dataProvider
+    messagesCollectionView.messagesLayoutDelegate = self
+    messagesCollectionView.reloadData()
+  }
 
-        dataProvider = makeDataSource()
-        messagesCollectionView.messagesDisplayDelegate = self
-        messagesCollectionView.messagesDataSource = dataProvider
-        messagesCollectionView.messagesLayoutDelegate = self
-        messagesCollectionView.reloadData()
-    }
+  func heightForLocation(message _: MessageType, at _: IndexPath, with _: CGFloat, in _: MessagesCollectionView) -> CGFloat {
+    200
+  }
 
-    func snapshotOptionsForLocation(
-        message _: MessageType,
-        at _: IndexPath,
-        in _: MessagesCollectionView)
+  func snapshotOptionsForLocation(
+    message _: MessageType,
+    at _: IndexPath,
+    in _: MessagesCollectionView)
     -> LocationMessageSnapshotOptions
-    {
-        LocationMessageSnapshotOptions()
-    }
+  {
+    LocationMessageSnapshotOptions()
+  }
 
-    // MARK: Fileprivate
+  // MARK: Fileprivate
 
-    fileprivate func makeDataSource() -> MockMessagesDataSource {
-        let dataSource = MockMessagesDataSource()
-        dataSource.messages.append(MockMessage(
-            text: "Text 1",
-            user: dataSource.senders[0],
-            messageId: "001"))
-        dataSource.messages.append(MockMessage(
-            text: "Text 2",
-            user: dataSource.senders[1],
-            messageId: "002"))
+  fileprivate func makeDataSource() -> MockMessagesDataSource {
+    let dataSource = MockMessagesDataSource()
+    dataSource.messages.append(MockMessage(
+      text: "Text 1",
+      user: dataSource.senders[0],
+      messageId: "001"))
+    dataSource.messages.append(MockMessage(
+      text: "Text 2",
+      user: dataSource.senders[1],
+      messageId: "002"))
 
-        return dataSource
-    }
+    return dataSource
+  }
 }

--- a/Tests/MessageKitTests/Views Tests/AvatarViewTests.swift
+++ b/Tests/MessageKitTests/Views Tests/AvatarViewTests.swift
@@ -26,67 +26,71 @@ import XCTest
 
 @MainActor
 final class AvatarViewTests: XCTestCase {
-    // MARK: - Private helper API
+  // MARK: Internal
 
-    private func makeAvatarView() -> AvatarView {
-        let avatarView = AvatarView()
-        avatarView.frame.size = CGSize(width: 30, height: 30)
-        return avatarView
-    }
+  func testNoParams() {
+    let avatarView = makeAvatarView()
 
-    func testNoParams() {
-        let avatarView = makeAvatarView()
+    XCTAssertEqual(avatarView.layer.cornerRadius, 15.0)
+    // For certain dynamic colors, need to compare cgColor in XCTest
+    // https://stackoverflow.com/questions/58065340/how-to-compare-two-uidynamicprovidercolor
+    XCTAssertEqual(avatarView.backgroundColor!.cgColor, UIColor.avatarViewBackground.cgColor)
+  }
 
-        XCTAssertEqual(avatarView.layer.cornerRadius, 15.0)
-        // For certain dynamic colors, need to compare cgColor in XCTest
-        // https://stackoverflow.com/questions/58065340/how-to-compare-two-uidynamicprovidercolor
-        XCTAssertEqual(avatarView.backgroundColor!.cgColor, UIColor.avatarViewBackground.cgColor)
-    }
+  func testWithImage() {
+    let avatarView = makeAvatarView()
 
-    func testWithImage() {
-        let avatarView = makeAvatarView()
+    let avatar = Avatar(image: UIImage())
+    avatarView.set(avatar: avatar)
+    XCTAssertEqual(avatar.initials, "?")
+    XCTAssertEqual(avatarView.layer.cornerRadius, 15.0)
+    XCTAssertEqual(avatarView.backgroundColor!.cgColor, UIColor.avatarViewBackground.cgColor)
+  }
 
-        let avatar = Avatar(image: UIImage())
-        avatarView.set(avatar: avatar)
-        XCTAssertEqual(avatar.initials, "?")
-        XCTAssertEqual(avatarView.layer.cornerRadius, 15.0)
-        XCTAssertEqual(avatarView.backgroundColor!.cgColor, UIColor.avatarViewBackground.cgColor)
-    }
+  func testInitialsOnly() {
+    let avatarView = makeAvatarView()
 
-    func testInitialsOnly() {
-        let avatarView = makeAvatarView()
+    let avatar = Avatar(initials: "DL")
+    avatarView.set(avatar: avatar)
+    XCTAssertEqual(avatarView.initials, avatar.initials)
+    XCTAssertEqual(avatar.initials, "DL")
+    XCTAssertEqual(avatarView.layer.cornerRadius, 15.0)
+    XCTAssertEqual(avatarView.backgroundColor!.cgColor, UIColor.avatarViewBackground.cgColor)
+  }
 
-        let avatar = Avatar(initials: "DL")
-        avatarView.set(avatar: avatar)
-        XCTAssertEqual(avatarView.initials, avatar.initials)
-        XCTAssertEqual(avatar.initials, "DL")
-        XCTAssertEqual(avatarView.layer.cornerRadius, 15.0)
-        XCTAssertEqual(avatarView.backgroundColor!.cgColor, UIColor.avatarViewBackground.cgColor)
-    }
+  func testSetBackground() {
+    let avatarView = makeAvatarView()
+    XCTAssertEqual(avatarView.backgroundColor!.cgColor, UIColor.avatarViewBackground.cgColor)
+    avatarView.backgroundColor = UIColor.red
+    XCTAssertEqual(avatarView.backgroundColor!, UIColor.red)
+  }
 
-    func testSetBackground() {
-        let avatarView = makeAvatarView()
-        XCTAssertEqual(avatarView.backgroundColor!.cgColor, UIColor.avatarViewBackground.cgColor)
-        avatarView.backgroundColor = UIColor.red
-        XCTAssertEqual(avatarView.backgroundColor!, UIColor.red)
-    }
+  func testGetImage() {
+    let avatarView = makeAvatarView()
 
-    func testGetImage() {
-        let avatarView = makeAvatarView()
+    let image = UIImage()
+    let avatar = Avatar(image: image)
+    avatarView.set(avatar: avatar)
+    XCTAssertEqual(avatarView.image, image)
+  }
 
-        let image = UIImage()
-        let avatar = Avatar(image: image)
-        avatarView.set(avatar: avatar)
-        XCTAssertEqual(avatarView.image, image)
-    }
+  func testRoundedCorners() {
+    let avatarView = makeAvatarView()
 
-    func testRoundedCorners() {
-        let avatarView = makeAvatarView()
+    let avatar = Avatar(image: UIImage())
+    avatarView.set(avatar: avatar)
+    XCTAssertEqual(avatarView.layer.cornerRadius, 15.0)
+    avatarView.setCorner(radius: 2)
+    XCTAssertEqual(avatarView.layer.cornerRadius, 2.0)
+  }
 
-        let avatar = Avatar(image: UIImage())
-        avatarView.set(avatar: avatar)
-        XCTAssertEqual(avatarView.layer.cornerRadius, 15.0)
-        avatarView.setCorner(radius: 2)
-        XCTAssertEqual(avatarView.layer.cornerRadius, 2.0)
-    }
+  // MARK: Private
+
+  // MARK: - Private helper API
+
+  private func makeAvatarView() -> AvatarView {
+    let avatarView = AvatarView()
+    avatarView.frame.size = CGSize(width: 30, height: 30)
+    return avatarView
+  }
 }

--- a/Tests/MessageKitTests/Views Tests/MessageCollectionViewCellTests.swift
+++ b/Tests/MessageKitTests/Views Tests/MessageCollectionViewCellTests.swift
@@ -28,54 +28,56 @@ import XCTest
 
 @MainActor
 final class MessageContentCellTests: XCTestCase {
-    let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+  let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
 
-    func testInit() {
-        let cell = MessageContentCell(frame: frame)
-        XCTAssertEqual(cell.contentView.autoresizingMask, [.flexibleWidth, .flexibleHeight])
-        XCTAssert(cell.contentView.subviews.contains(cell.cellTopLabel))
-        XCTAssert(cell.contentView.subviews.contains(cell.messageBottomLabel))
-        XCTAssert(cell.contentView.subviews.contains(cell.avatarView))
-        XCTAssert(cell.contentView.subviews.contains(cell.messageContainerView))
-    }
+  func testInit() {
+    let cell = MessageContentCell(frame: frame)
+    XCTAssertEqual(cell.contentView.autoresizingMask, [.flexibleWidth, .flexibleHeight])
+    XCTAssert(cell.contentView.subviews.contains(cell.cellTopLabel))
+    XCTAssert(cell.contentView.subviews.contains(cell.messageBottomLabel))
+    XCTAssert(cell.contentView.subviews.contains(cell.avatarView))
+    XCTAssert(cell.contentView.subviews.contains(cell.messageContainerView))
+  }
 
-    func testMessageContainerViewPropertiesSetup() {
-        let cell = MessageContentCell(frame: frame)
-        XCTAssertTrue(cell.messageContainerView.clipsToBounds)
-        XCTAssertTrue(cell.messageContainerView.layer.masksToBounds)
-    }
+  func testMessageContainerViewPropertiesSetup() {
+    let cell = MessageContentCell(frame: frame)
+    XCTAssertTrue(cell.messageContainerView.clipsToBounds)
+    XCTAssertTrue(cell.messageContainerView.layer.masksToBounds)
+  }
 
-    func testPrepareForReuse() {
-        let cell = MessageContentCell(frame: frame)
-        cell.prepareForReuse()
-        XCTAssertNil(cell.cellTopLabel.text)
-        XCTAssertNil(cell.cellTopLabel.attributedText)
-        XCTAssertNil(cell.messageBottomLabel.text)
-        XCTAssertNil(cell.messageBottomLabel.attributedText)
-    }
+  func testPrepareForReuse() {
+    let cell = MessageContentCell(frame: frame)
+    cell.prepareForReuse()
+    XCTAssertNil(cell.cellTopLabel.text)
+    XCTAssertNil(cell.cellTopLabel.attributedText)
+    XCTAssertNil(cell.messageBottomLabel.text)
+    XCTAssertNil(cell.messageBottomLabel.attributedText)
+  }
 
-    func testApplyLayoutAttributes() {
-        let cell = MessageContentCell(frame: frame)
-        let layoutAttributes = MessagesCollectionViewLayoutAttributes()
-        layoutAttributes.avatarPosition = AvatarPosition(horizontal: .cellLeading, vertical: .cellBottom)
-        cell.apply(layoutAttributes)
+  func testApplyLayoutAttributes() {
+    let cell = MessageContentCell(frame: frame)
+    let layoutAttributes = MessagesCollectionViewLayoutAttributes()
+    layoutAttributes.avatarPosition = AvatarPosition(horizontal: .cellLeading, vertical: .cellBottom)
+    cell.apply(layoutAttributes)
 
-        XCTAssertEqual(cell.avatarView.frame, layoutAttributes.frame)
-        XCTAssertEqual(cell.messageContainerView.frame.size, layoutAttributes.messageContainerSize)
-        XCTAssertEqual(cell.cellTopLabel.frame.size, layoutAttributes.cellTopLabelSize)
-        XCTAssertEqual(cell.messageBottomLabel.frame.size, layoutAttributes.messageBottomLabelSize)
-    }
+    XCTAssertEqual(cell.avatarView.frame, layoutAttributes.frame)
+    XCTAssertEqual(cell.messageContainerView.frame.size, layoutAttributes.messageContainerSize)
+    XCTAssertEqual(cell.cellTopLabel.frame.size, layoutAttributes.cellTopLabelSize)
+    XCTAssertEqual(cell.messageBottomLabel.frame.size, layoutAttributes.messageBottomLabelSize)
+  }
 }
 
+// MARK: MessageContentCellTests.MockMessagesDisplayDelegate
+
 extension MessageContentCellTests {
-    private class MockMessagesDisplayDelegate: MessagesDisplayDelegate {
-        func snapshotOptionsForLocation(
-            message _: MessageType,
-            at _: IndexPath,
-            in _: MessagesCollectionView)
-        -> LocationMessageSnapshotOptions
-        {
-            LocationMessageSnapshotOptions()
-        }
+  private class MockMessagesDisplayDelegate: MessagesDisplayDelegate {
+    func snapshotOptionsForLocation(
+      message _: MessageType,
+      at _: IndexPath,
+      in _: MessagesCollectionView)
+      -> LocationMessageSnapshotOptions
+    {
+      LocationMessageSnapshotOptions()
     }
+  }
 }

--- a/Tests/MessageKitTests/Views Tests/MessagesCollectionViewTests.swift
+++ b/Tests/MessageKitTests/Views Tests/MessagesCollectionViewTests.swift
@@ -25,13 +25,13 @@ import XCTest
 
 @MainActor
 class MessagesCollectionViewTests: XCTestCase {
-    let rect = CGRect(x: 0, y: 0, width: 100, height: 100)
-    let layout = MessagesCollectionViewFlowLayout()
+  let rect = CGRect(x: 0, y: 0, width: 100, height: 100)
+  let layout = MessagesCollectionViewFlowLayout()
 
-    func testInit() {
-        let messagesCollectionView = MessagesCollectionView(frame: rect, collectionViewLayout: layout)
-        XCTAssertEqual(messagesCollectionView.frame, rect)
-        XCTAssertEqual(messagesCollectionView.collectionViewLayout, layout)
-        XCTAssertEqual(messagesCollectionView.backgroundColor, UIColor.collectionViewBackground)
-    }
+  func testInit() {
+    let messagesCollectionView = MessagesCollectionView(frame: rect, collectionViewLayout: layout)
+    XCTAssertEqual(messagesCollectionView.frame, rect)
+    XCTAssertEqual(messagesCollectionView.collectionViewLayout, layout)
+    XCTAssertEqual(messagesCollectionView.backgroundColor, UIColor.collectionViewBackground)
+  }
 }


### PR DESCRIPTION
Stacked on #1906 (which is stacked on #1905). Review those first; this PR targets #1906's branch.

## The problem

`make lint` fails on `main`:

```
$ swiftformat --lint .
Source input did not pass lint check.
46/125 files require formatting.
```

25 of those are in `Sources`, 13 in the example, 7 in `Tests`, and one is `Dangerfile.swift`.

Nothing ever ran it. There are workflows for the tests, the framework, the example app, and Danger — but none for lint, so the drift from the repo's own `.swiftformat` grew unchecked. Some of it is not cosmetic: `AppDelegate.swift` and `AdvancedExampleViewController.swift` had genuinely misindented lines.

## The change

Two parts:

1. A `Lint` workflow that installs SwiftFormat and SwiftLint and runs `make lint` on every PR.
2. The formatting that workflow then demands, so it starts green.

The second part is the whole 46-file diff. It is `swiftformat .` output and nothing else — no hand edits. Almost all of it is two rules:

- `organizeDeclarations` moving members into the configured order
- `redundantSelf` dropping explicit `self.`

SwiftLint already passed and needed no changes.

## Reviewing this

The diff is large but mechanical. To confirm it is only formatting, check out the branch and run `swiftformat .` on the parent commit — the result should be identical.

## Verification

- `make lint` exits 0.
- MessageKit unit tests: 60 of 60 pass on an iPhone 17 simulator (iOS 27).
- The example app builds, and its unit and UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)