### PR TITLE
Build the example app in the Swift 6 language mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ### Fixed
 
+- **Breaking Change** Annotate `MessageCellDelegate` and `MessageLabelDelegate` with `@MainActor`. Their sibling delegate protocols `MessagesDataSource`, `MessagesLayoutDelegate` and `MessagesDisplayDelegate` already carried the annotation, so consumers building in the Swift 6 language mode had to work around these two with `@preconcurrency` by [@martinpucik](https://github.com/martinpucik)
 - Fix `make format`, `make lint` and the pre-commit hook, which still called the removed SwiftPM plugins by [@martinpucik](https://github.com/martinpucik)
 - Adopt the scene lifecycle in the example app, which crashed on launch on iOS 26 and later by [@martinpucik](https://github.com/martinpucik)
 - Add the missing camera and photo library usage descriptions to the example app, which crashed when you opened the camera by [@martinpucik](https://github.com/martinpucik)
@@ -23,6 +24,7 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 ### Changed
 
 - Enforce `make lint` in CI and reformat the sources it flagged by [@martinpucik](https://github.com/martinpucik)
+- Build the example app in the Swift 6 language mode, so that CI exercises the same strict concurrency checking as the library, and replace its `DispatchQueue` hops with structured concurrency by [@martinpucik](https://github.com/martinpucik)
 
 - Migrate Danger from Ruby to Danger Swift and drop the `Gemfile` by [@martinpucik](https://github.com/martinpucik)
 

--- a/Example/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/ChatExample.xcodeproj/project.pbxproj
@@ -615,7 +615,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -666,7 +666,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};

--- a/Example/Sources/Data Generation/SampleData.swift
+++ b/Example/Sources/Data Generation/SampleData.swift
@@ -25,6 +25,7 @@ import CoreLocation
 import MessageKit
 import UIKit
 
+@MainActor
 final internal class SampleData {
   // MARK: Lifecycle
 

--- a/Example/Sources/Extensions/AlertService.swift
+++ b/Example/Sources/Extensions/AlertService.swift
@@ -9,6 +9,7 @@
 import Foundation
 import UIKit
 
+@MainActor
 class AlertService {
   static func showAlert(
     style: UIAlertController.Style,

--- a/Example/Sources/View Controllers/AdvancedExampleViewController.swift
+++ b/Example/Sources/View Controllers/AdvancedExampleViewController.swift
@@ -83,26 +83,23 @@ final class AdvancedExampleViewController: ChatViewController {
   }
 
   override func loadFirstMessages() {
-    DispatchQueue.global(qos: .userInitiated).async {
+    Task {
       let count = UserDefaults.standard.mockMessagesCount()
       SampleData.shared.getAdvancedMessages(count: count) { messages in
-        DispatchQueue.main.async {
-          self.messageList = messages
-          self.messagesCollectionView.reloadData()
-          self.messagesCollectionView.scrollToLastItem()
-        }
+        self.messageList = messages
+        self.messagesCollectionView.reloadData()
+        self.messagesCollectionView.scrollToLastItem()
       }
     }
   }
 
   override func loadMoreMessages() {
-    DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1) {
+    Task {
+      try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
       SampleData.shared.getAdvancedMessages(count: 20) { messages in
-        DispatchQueue.main.async {
-          self.messageList.insert(contentsOf: messages, at: 0)
-          self.messagesCollectionView.reloadDataAndKeepOffset()
-          self.refreshControl.endRefreshing()
-        }
+        self.messageList.insert(contentsOf: messages, at: 0)
+        self.messagesCollectionView.reloadDataAndKeepOffset()
+        self.refreshControl.endRefreshing()
       }
     }
   }

--- a/Example/Sources/View Controllers/AutocompleteExampleViewController.swift
+++ b/Example/Sources/View Controllers/AutocompleteExampleViewController.swift
@@ -192,17 +192,15 @@ final class AutocompleteExampleViewController: ChatViewController {
   func inputBar(_: InputBarAccessoryView, textViewTextDidChangeTo _: String) {
     guard autocompleteManager.currentSession != nil, autocompleteManager.currentSession?.prefix == "#" else { return }
     // Load some data asyncronously for the given session.prefix
-    DispatchQueue.global(qos: .default).async {
+    Task { [weak self] in
       // fake background loading task
       var array: [AutocompleteCompletion] = []
       for _ in 1 ... 10 {
         array.append(AutocompleteCompletion(text: Lorem.word()))
       }
-      sleep(1)
-      DispatchQueue.main.async { [weak self] in
-        self?.asyncCompletions = array
-        self?.autocompleteManager.reloadData()
-      }
+      try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+      self?.asyncCompletions = array
+      self?.autocompleteManager.reloadData()
     }
   }
 
@@ -245,9 +243,11 @@ final class AutocompleteExampleViewController: ChatViewController {
   }
 }
 
-// MARK: AutocompleteManagerDelegate, AutocompleteManagerDataSource
+// MARK: @preconcurrency AutocompleteManagerDelegate, @preconcurrency AutocompleteManagerDataSource
 
-extension AutocompleteExampleViewController: AutocompleteManagerDelegate, AutocompleteManagerDataSource {
+extension AutocompleteExampleViewController: @preconcurrency AutocompleteManagerDelegate,
+  @preconcurrency AutocompleteManagerDataSource
+{
   // MARK: - AutocompleteManagerDataSource
 
   func autocompleteManager(_: AutocompleteManager, autocompleteSourceFor prefix: String) -> [AutocompleteCompletion] {

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -75,27 +75,24 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
   }
 
   func loadFirstMessages() {
-    DispatchQueue.global(qos: .userInitiated).async {
+    Task {
       let count = UserDefaults.standard.mockMessagesCount()
       SampleData.shared.getMessages(count: count) { messages in
-        DispatchQueue.main.async {
-          self.messageList = messages
-          self.messagesCollectionView.reloadData()
-          self.messagesCollectionView.scrollToLastItem(animated: false)
-        }
+        self.messageList = messages
+        self.messagesCollectionView.reloadData()
+        self.messagesCollectionView.scrollToLastItem(animated: false)
       }
     }
   }
 
   @objc
   func loadMoreMessages() {
-    DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1) {
+    Task {
+      try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
       SampleData.shared.getMessages(count: 20) { messages in
-        DispatchQueue.main.async {
-          self.messageList.insert(contentsOf: messages, at: 0)
-          self.messagesCollectionView.reloadDataAndKeepOffset()
-          self.refreshControl.endRefreshing()
-        }
+        self.messageList.insert(contentsOf: messages, at: 0)
+        self.messagesCollectionView.reloadDataAndKeepOffset()
+        self.refreshControl.endRefreshing()
       }
     }
   }
@@ -314,9 +311,9 @@ extension ChatViewController: MessageLabelDelegate {
   }
 }
 
-// MARK: InputBarAccessoryViewDelegate
+// MARK: @preconcurrency InputBarAccessoryViewDelegate
 
-extension ChatViewController: InputBarAccessoryViewDelegate {
+extension ChatViewController: @preconcurrency InputBarAccessoryViewDelegate {
   // MARK: Internal
 
   @objc
@@ -342,15 +339,13 @@ extension ChatViewController: InputBarAccessoryViewDelegate {
     inputBar.inputTextView.placeholder = "Sending..."
     // Resign first responder for iPad split view
     inputBar.inputTextView.resignFirstResponder()
-    DispatchQueue.global(qos: .default).async {
+    Task { [weak self] in
       // fake send request task
-      sleep(1)
-      DispatchQueue.main.async { [weak self] in
-        inputBar.sendButton.stopAnimating()
-        inputBar.inputTextView.placeholder = "Aa"
-        self?.insertMessages(components)
-        self?.messagesCollectionView.scrollToLastItem(animated: true)
-      }
+      try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+      inputBar.sendButton.stopAnimating()
+      inputBar.inputTextView.placeholder = "Aa"
+      self?.insertMessages(components)
+      self?.messagesCollectionView.scrollToLastItem(animated: true)
     }
   }
 

--- a/Example/Sources/Views/CameraInputBarAccessoryView.swift
+++ b/Example/Sources/Views/CameraInputBarAccessoryView.swift
@@ -135,9 +135,9 @@ extension CameraInputBarAccessoryView: UIImagePickerControllerDelegate, UINaviga
   }
 }
 
-// MARK: AttachmentManagerDelegate
+// MARK: @preconcurrency AttachmentManagerDelegate
 
-extension CameraInputBarAccessoryView: AttachmentManagerDelegate {
+extension CameraInputBarAccessoryView: @preconcurrency AttachmentManagerDelegate {
   // MARK: - AttachmentManagerDelegate
 
   func attachmentManager(_: AttachmentManager, shouldBecomeVisible: Bool) {

--- a/Example/Sources/Views/SwiftUI/MessagesView.swift
+++ b/Example/Sources/Views/SwiftUI/MessagesView.swift
@@ -137,9 +137,9 @@ extension MessagesView.Coordinator: MessagesDataSource {
   }
 }
 
-// MARK: - MessagesView.Coordinator + InputBarAccessoryViewDelegate
+// MARK: - MessagesView.Coordinator + @preconcurrency InputBarAccessoryViewDelegate
 
-extension MessagesView.Coordinator: InputBarAccessoryViewDelegate {
+extension MessagesView.Coordinator: @preconcurrency InputBarAccessoryViewDelegate {
   func inputBar(_ inputBar: InputBarAccessoryView, didPressSendButtonWith text: String) {
     let message = MockMessage(text: text, user: SampleData.shared.currentSender, messageId: UUID().uuidString, date: Date())
     messages.wrappedValue.append(message)

--- a/Example/Tests/ChatExampleTests.swift
+++ b/Example/Tests/ChatExampleTests.swift
@@ -19,6 +19,7 @@
 import XCTest
 @testable import ChatExample
 
+@MainActor
 final class ChatExampleTests: XCTestCase {
   /// Settings lets every message type be switched off. `randomMessageType()` used to
   /// force unwrap the empty result, which crashed the app on the next message.

--- a/Example/UITests/ChatExampleUITests.swift
+++ b/Example/UITests/ChatExampleUITests.swift
@@ -18,6 +18,7 @@
 
 import XCTest
 
+@MainActor
 final class ChatExampleUITests: XCTestCase {
   // MARK: Internal
 

--- a/Sources/Protocols/MessageCellDelegate.swift
+++ b/Sources/Protocols/MessageCellDelegate.swift
@@ -25,6 +25,7 @@ import Foundation
 // MARK: - MessageCellDelegate
 
 /// A protocol used by `MessageContentCell` subclasses to detect taps in the cell's subviews.
+@MainActor
 public protocol MessageCellDelegate: MessageLabelDelegate {
   /// Triggered when a tap occurs in the background of the cell.
   ///

--- a/Sources/Protocols/MessageLabelDelegate.swift
+++ b/Sources/Protocols/MessageLabelDelegate.swift
@@ -25,6 +25,7 @@ import Foundation
 // MARK: - MessageLabelDelegate
 
 /// A protocol used to handle tap events on detected text.
+@MainActor
 public protocol MessageLabelDelegate: AnyObject {
   /// Triggered when a tap occurs on a detected address.
   ///


### PR DESCRIPTION
> Stacked on #1914 → #1913 → #1911 → #1910 → #1909. Base is `chore/remove-dead-files`.

## Summary

The package declares `swiftLanguageModes: [.v6]`, but the example project still set `SWIFT_VERSION = 5.0`. CI built the example with no strict concurrency checking, so it validated none of the surface a consumer migrating to Swift 6 actually meets.

## It found a real library defect

Three of MessageKit's delegate protocols carry `@MainActor`:

| Protocol | `@MainActor` before | after |
| --- | --- | --- |
| `MessagesDataSource` | yes | yes |
| `MessagesLayoutDelegate` | yes | yes |
| `MessagesDisplayDelegate` | yes | yes |
| **`MessageCellDelegate`** | **no** | **yes** |
| **`MessageLabelDelegate`** | **no** | **yes** |

Both missing ones exist purely to handle taps inside cells, and the library only ever calls them from UIKit classes that are already main-actor isolated (`MessageLabel`, `MessagesCollectionView`, `MessageContentCell`, `TextMessageCell`). Every consumer building in Swift 6 had to work around this with `@preconcurrency`.

I annotated the protocols rather than papering over it in the example — a `@preconcurrency` there would have hidden the exact problem that building the example in Swift 6 is meant to surface.

## The example app's own migration

- **`AlertService` and `SampleData` become `@MainActor`.** One presents alerts, the other holds `lazy var` state that only view controllers read.
- **InputBarAccessoryView conformances marked `@preconcurrency`,** matching the existing treatment of `AVAudioPlayerDelegate` in `BasicAudioController`. Those protocols carry no isolation of their own, so this is the right tool there — unlike MessageKit's own protocols, which I fixed at the source.
- **`DispatchQueue.global` → `DispatchQueue.main` hops become `Task`** in the three example view controllers. They were passing non-Sendable arrays between queues for no benefit: the mock data generator is synchronous, and the hops existed only to fake latency, which `Task.sleep` expresses without crossing an isolation boundary.
- **`ChatExampleTests` becomes `@MainActor`,** since it reads `SampleData`.

## The deployment target is deliberately left at 15.0

I tried lowering it to 14.0 to match `Package.swift`. It does not build:

```
The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 14.0,
but the range of supported deployment target versions is 15.0 to 27.0.x.
```

Dependencies are not the blocker — Kingfisher 8.11.0 supports iOS 13 and InputBarAccessoryView 7.0.6 supports iOS 14. The current Xcode simply will not build an app below iOS 15.

**This raises a question worth deciding separately:** `Package.swift` advertises `platforms: [.iOS(.v14)]`, but no app on a current toolchain can target iOS 14, so that claim cannot be exercised by the example or by CI. Whether to raise the package minimum to iOS 15 is a breaking change and your call — I have not touched it.

## Verification

Builds clean for testing, zero errors. The only warnings are two pre-existing XCTest linkage notes about iOS 15 vs 17, unrelated to this change and present before it. `make lint` passes.

## One cosmetic note

SwiftFormat's `markTypes` rule regenerates `// MARK:` headers from the conformance list, so `@preconcurrency` now leaks into four section comments, e.g. `// MARK: @preconcurrency AttachmentManagerDelegate`. That is the formatter's canonical output — hand-editing fails `make lint`. Suppressing it means changing the SwiftFormat config, which I left alone.