### PR TITLE
Add tests for MessageSizeCalculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 ### Added
 
 - Add tests for `MessageSizeCalculator`, which covers the avatar position resolution, the sender specific avatar sizes and paddings, the container maximum width and the cell height, and had no tests before by [@martinpucik](https://github.com/martinpucik)
+- Add tests for `TypingIndicator` and `TypingBubble`, which cover the dot layout and spacing, the animation state flags, the animation layers and the pulse layers, and had no tests before by [@martinpucik](https://github.com/martinpucik)
 ### Fixed
 
 - **Breaking Change** Annotate `MessageCellDelegate` and `MessageLabelDelegate` with `@MainActor`. Their sibling delegate protocols `MessagesDataSource`, `MessagesLayoutDelegate` and `MessagesDisplayDelegate` already carried the annotation, so consumers building in the Swift 6 language mode had to work around these two with `@preconcurrency` by [@martinpucik](https://github.com/martinpucik)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ### Added
 
+- Add tests for `MessageSizeCalculator`, which covers the avatar position resolution, the sender specific avatar sizes and paddings, the container maximum width and the cell height, and had no tests before by [@martinpucik](https://github.com/martinpucik)
 ### Fixed
 
 - **Breaking Change** Annotate `MessageCellDelegate` and `MessageLabelDelegate` with `@MainActor`. Their sibling delegate protocols `MessagesDataSource`, `MessagesLayoutDelegate` and `MessagesDisplayDelegate` already carried the annotation, so consumers building in the Swift 6 language mode had to work around these two with `@preconcurrency` by [@martinpucik](https://github.com/martinpucik)

--- a/Tests/MessageKitTests/Layout Tests/MessageSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/MessageSizeCalculatorTests.swift
@@ -1,0 +1,217 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 MessageKit
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+@testable import MessageKit
+
+// MARK: - MessageSizeCalculatorTests
+
+@MainActor
+final class MessageSizeCalculatorTests: XCTestCase {
+  // MARK: - Avatar position
+
+  func testNaturalAvatarPositionResolvesToTrailingForTheCurrentSender() {
+    let sut = makeSUT()
+
+    let position = sut.calculator.avatarPosition(for: sut.outgoingMessage)
+
+    XCTAssertEqual(position.horizontal, .cellTrailing)
+  }
+
+  func testNaturalAvatarPositionResolvesToLeadingForEveryOtherSender() {
+    let sut = makeSUT()
+
+    let position = sut.calculator.avatarPosition(for: sut.incomingMessage)
+
+    XCTAssertEqual(position.horizontal, .cellLeading)
+  }
+
+  func testAnExplicitAvatarPositionSurvivesTheNaturalResolution() {
+    let sut = makeSUT()
+    sut.calculator.incomingAvatarPosition = AvatarPosition(horizontal: .cellTrailing, vertical: .cellTop)
+
+    let position = sut.calculator.avatarPosition(for: sut.incomingMessage)
+
+    XCTAssertEqual(position.horizontal, .cellTrailing)
+    XCTAssertEqual(position.vertical, .cellTop)
+  }
+
+  // MARK: - Avatar size
+
+  func testAvatarSizeFallsBackToTheSenderSpecificSize() {
+    let sut = makeSUT()
+    sut.calculator.incomingAvatarSize = CGSize(width: 10, height: 20)
+    sut.calculator.outgoingAvatarSize = CGSize(width: 30, height: 40)
+
+    XCTAssertEqual(sut.calculator.avatarSize(for: sut.incomingMessage, at: sut.incomingIndexPath), CGSize(width: 10, height: 20))
+    XCTAssertEqual(sut.calculator.avatarSize(for: sut.outgoingMessage, at: sut.outgoingIndexPath), CGSize(width: 30, height: 40))
+  }
+
+  func testTheLayoutDelegateOverridesTheSenderSpecificAvatarSize() {
+    let sut = makeSUT()
+    sut.calculator.incomingAvatarSize = CGSize(width: 10, height: 20)
+    sut.layoutDelegate.stubbedAvatarSize = CGSize(width: 64, height: 64)
+
+    let size = sut.calculator.avatarSize(for: sut.incomingMessage, at: sut.incomingIndexPath)
+
+    XCTAssertEqual(size, CGSize(width: 64, height: 64))
+  }
+
+  // MARK: - Container
+
+  func testTheBaseCalculatorReportsAnEmptyContainer() {
+    let sut = makeSUT()
+
+    XCTAssertEqual(sut.calculator.messageContainerSize(for: sut.incomingMessage, at: sut.incomingIndexPath), .zero)
+  }
+
+  func testContainerPaddingFollowsTheSender() {
+    let sut = makeSUT()
+    sut.calculator.incomingMessagePadding = UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
+    sut.calculator.outgoingMessagePadding = UIEdgeInsets(top: 5, left: 6, bottom: 7, right: 8)
+
+    XCTAssertEqual(
+      sut.calculator.messageContainerPadding(for: sut.incomingMessage),
+      UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4))
+    XCTAssertEqual(
+      sut.calculator.messageContainerPadding(for: sut.outgoingMessage),
+      UIEdgeInsets(top: 5, left: 6, bottom: 7, right: 8))
+  }
+
+  func testTheContainerMaxWidthRemovesEverythingBesideTheContainer() {
+    let sut = makeSUT()
+    sut.calculator.incomingAvatarSize = CGSize(width: 30, height: 30)
+    sut.calculator.incomingMessagePadding = UIEdgeInsets(top: 0, left: 4, bottom: 0, right: 6)
+    sut.calculator.incomingAccessoryViewSize = CGSize(width: 20, height: 20)
+    sut.calculator.incomingAccessoryViewPadding = HorizontalEdgeInsets(left: 2, right: 3)
+    sut.calculator.avatarLeadingTrailingPadding = 5
+
+    let maxWidth = sut.calculator.messageContainerMaxWidth(for: sut.incomingMessage, at: sut.incomingIndexPath)
+
+    // itemWidth less the avatar, the container padding, the accessory view,
+    // the accessory padding and the avatar padding.
+    XCTAssertEqual(maxWidth, sut.layout.itemWidth - 30 - 10 - 20 - 5 - 5)
+  }
+
+  // MARK: - Cell height
+
+  func testTheCellIsAsTallAsTheAvatarWhenNothingElseIsTaller() {
+    let sut = makeSUT()
+    sut.calculator.incomingAvatarSize = CGSize(width: 30, height: 48)
+
+    let height = sut.calculator.cellContentHeight(for: sut.incomingMessage, at: sut.incomingIndexPath)
+
+    XCTAssertEqual(height, 48)
+  }
+
+  func testTheCellGrowsToTheAccessoryViewWhenItIsTheTallest() {
+    let sut = makeSUT()
+    sut.calculator.incomingAvatarSize = CGSize(width: 30, height: 30)
+    sut.calculator.incomingAccessoryViewSize = CGSize(width: 20, height: 120)
+
+    let height = sut.calculator.cellContentHeight(for: sut.incomingMessage, at: sut.incomingIndexPath)
+
+    XCTAssertEqual(height, 120)
+  }
+
+  func testTheCellCountsTheContainerPaddingInItsHeight() {
+    let sut = makeSUT()
+    sut.calculator.incomingAvatarSize = .zero
+    sut.calculator.incomingMessagePadding = UIEdgeInsets(top: 7, left: 0, bottom: 11, right: 0)
+
+    let height = sut.calculator.cellContentHeight(for: sut.incomingMessage, at: sut.incomingIndexPath)
+
+    XCTAssertEqual(height, 18)
+  }
+
+  // MARK: - Label alignment
+
+  func testCellLabelAlignmentFollowsTheSender() {
+    let sut = makeSUT()
+    let incoming = LabelAlignment(textAlignment: .left, textInsets: UIEdgeInsets(top: 0, left: 1, bottom: 0, right: 0))
+    let outgoing = LabelAlignment(textAlignment: .right, textInsets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 2))
+    sut.calculator.incomingCellTopLabelAlignment = incoming
+    sut.calculator.outgoingCellTopLabelAlignment = outgoing
+
+    XCTAssertEqual(sut.calculator.cellTopLabelAlignment(for: sut.incomingMessage), incoming)
+    XCTAssertEqual(sut.calculator.cellTopLabelAlignment(for: sut.outgoingMessage), outgoing)
+  }
+}
+
+// MARK: - Assistants
+
+extension MessageSizeCalculatorTests {
+  // MARK: Fileprivate
+
+  @MainActor
+  fileprivate struct SUT {
+    let controller: MessagesViewController
+    let dataSource: MockMessagesDataSource
+    let layoutDelegate: StubLayoutDelegate
+    let layout: MessagesCollectionViewFlowLayout
+    let calculator: MessageSizeCalculator
+
+    /// `MockMessagesDataSource` treats `senders[0]` as the current sender.
+    var outgoingMessage: MessageType { dataSource.messages[0] }
+    var incomingMessage: MessageType { dataSource.messages[1] }
+    var outgoingIndexPath: IndexPath { IndexPath(item: 0, section: 0) }
+    var incomingIndexPath: IndexPath { IndexPath(item: 0, section: 1) }
+  }
+
+  // MARK: Private
+
+  private func makeSUT() -> SUT {
+    let dataSource = MockMessagesDataSource()
+    dataSource.messages = [
+      MockMessage(text: "Outgoing", user: dataSource.senders[0], messageId: "001"),
+      MockMessage(text: "Incoming", user: dataSource.senders[1], messageId: "002"),
+    ]
+
+    let layoutDelegate = StubLayoutDelegate()
+    let controller = MessagesViewController()
+    controller.messagesCollectionView.messagesDataSource = dataSource
+    controller.messagesCollectionView.messagesLayoutDelegate = layoutDelegate
+    controller.messagesCollectionView.messagesDisplayDelegate = layoutDelegate
+    _ = controller.view
+    controller.beginAppearanceTransition(true, animated: false)
+    controller.endAppearanceTransition()
+    controller.view.layoutIfNeeded()
+
+    let layout = controller.messagesCollectionView.messagesCollectionViewFlowLayout
+    return SUT(
+      controller: controller,
+      dataSource: dataSource,
+      layoutDelegate: layoutDelegate,
+      layout: layout,
+      calculator: MessageSizeCalculator(layout: layout))
+  }
+}
+
+// MARK: - StubLayoutDelegate
+
+final class StubLayoutDelegate: MessagesLayoutDelegate, MessagesDisplayDelegate {
+  var stubbedAvatarSize: CGSize?
+
+  func avatarSize(for _: MessageType, at _: IndexPath, in _: MessagesCollectionView) -> CGSize? {
+    stubbedAvatarSize
+  }
+}

--- a/Tests/MessageKitTests/Views Tests/TypingIndicatorTests.swift
+++ b/Tests/MessageKitTests/Views Tests/TypingIndicatorTests.swift
@@ -1,0 +1,186 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 MessageKit
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+@testable import MessageKit
+
+// MARK: - TypingIndicatorTests
+
+@MainActor
+final class TypingIndicatorTests: XCTestCase {
+  // MARK: - Layout
+
+  func testTheIndicatorHoldsThreeDotsInAHorizontalStack() {
+    let sut = TypingIndicator()
+
+    XCTAssertEqual(sut.dots.count, 3)
+    XCTAssertEqual(sut.stackView.arrangedSubviews.count, 3)
+    XCTAssertEqual(sut.stackView.axis, .horizontal)
+    XCTAssertEqual(sut.stackView.alignment, .center)
+    XCTAssertEqual(sut.stackView.distribution, .fillEqually)
+    XCTAssertTrue(sut.stackView.isDescendant(of: sut))
+  }
+
+  func testChangingTheDotColourRepaintsEveryDot() {
+    let sut = TypingIndicator()
+
+    sut.dotColor = .red
+
+    XCTAssertEqual(sut.dots.map(\.backgroundColor), Array(repeating: UIColor.red, count: 3))
+  }
+
+  func testTheStackViewFillsTheIndicatorOnLayout() {
+    let sut = TypingIndicator(frame: CGRect(x: 0, y: 0, width: 60, height: 20))
+
+    sut.layoutIfNeeded()
+
+    XCTAssertEqual(sut.stackView.frame, sut.bounds)
+  }
+
+  func testTheDotsAreSpacedOnlyOnceTheIndicatorHasWidth() {
+    let collapsed = TypingIndicator(frame: .zero)
+    let expanded = TypingIndicator(frame: CGRect(x: 0, y: 0, width: 60, height: 20))
+
+    collapsed.layoutIfNeeded()
+    expanded.layoutIfNeeded()
+
+    XCTAssertEqual(collapsed.stackView.spacing, 0)
+    XCTAssertEqual(expanded.stackView.spacing, 5)
+  }
+
+  // MARK: - Animation state
+
+  func testTheIndicatorDoesNotAnimateUntilItIsStarted() {
+    XCTAssertFalse(TypingIndicator().isAnimating)
+  }
+
+  func testStartingAndStoppingFlipsTheAnimatingFlag() {
+    let sut = TypingIndicator()
+
+    sut.startAnimating()
+    XCTAssertTrue(sut.isAnimating)
+
+    sut.stopAnimating()
+    XCTAssertFalse(sut.isAnimating)
+  }
+
+  func testStoppingAnIndicatorThatNeverStartedLeavesItAlone() {
+    let sut = TypingIndicator()
+
+    sut.stopAnimating()
+
+    XCTAssertFalse(sut.isAnimating)
+    XCTAssertNil(sut.dots[0].layer.animationKeys())
+  }
+
+  // MARK: - Animation layers
+
+  func testTheFadeAnimationDimsTheDotAndRepeatsForever() {
+    let animation = TypingIndicator().opacityAnimationLayer
+
+    XCTAssertEqual(animation.keyPath, "opacity")
+    XCTAssertEqual((animation.fromValue as? NSNumber)?.doubleValue, 1)
+    XCTAssertEqual((animation.toValue as? NSNumber)?.doubleValue, 0.5)
+    XCTAssertEqual(animation.repeatCount, .infinity)
+    XCTAssertTrue(animation.autoreverses)
+  }
+
+  func testTheBounceAnimationsFollowTheBounceOffset() {
+    let sut = TypingIndicator()
+    sut.bounceOffset = 10
+
+    let bounce = sut.bounceAnimationLayer
+    let initialOffset = sut.initialOffsetAnimationLayer
+
+    XCTAssertEqual(bounce.keyPath, "transform.translation.y")
+    XCTAssertEqual((bounce.fromValue as? NSNumber)?.doubleValue, 10)
+    XCTAssertEqual((bounce.toValue as? NSNumber)?.doubleValue, -10)
+    XCTAssertEqual(bounce.repeatCount, .infinity)
+    XCTAssertTrue(bounce.autoreverses)
+
+    XCTAssertEqual((initialOffset.byValue as? NSNumber)?.doubleValue, -10)
+    XCTAssertTrue(initialOffset.isRemovedOnCompletion)
+  }
+}
+
+// MARK: - TypingBubbleTests
+
+@MainActor
+final class TypingBubbleTests: XCTestCase {
+  func testTheBubbleKeepsTheIndicatorInsideTheContentBubble() {
+    let sut = TypingBubble()
+
+    XCTAssertTrue(sut.typingIndicator.isDescendant(of: sut.contentBubble))
+    XCTAssertTrue(sut.contentBubble.isDescendant(of: sut))
+    XCTAssertTrue(sut.cornerBubble.isDescendant(of: sut))
+    XCTAssertTrue(sut.tinyBubble.isDescendant(of: sut))
+  }
+
+  func testTheBubbleDoesNotAnimateUntilItIsStarted() {
+    XCTAssertFalse(TypingBubble().isAnimating)
+  }
+
+  func testStartingPulsesEveryBubbleAndStartsTheIndicator() {
+    let sut = TypingBubble()
+
+    sut.startAnimating()
+
+    XCTAssertTrue(sut.isAnimating)
+    XCTAssertTrue(sut.typingIndicator.isAnimating)
+    XCTAssertEqual(sut.contentBubble.layer.animationKeys()?.isEmpty, false)
+    XCTAssertEqual(sut.cornerBubble.layer.animationKeys()?.isEmpty, false)
+    XCTAssertEqual(sut.tinyBubble.layer.animationKeys()?.isEmpty, false)
+  }
+
+  func testDisablingThePulseStillStartsTheIndicator() {
+    let sut = TypingBubble()
+    sut.isPulseEnabled = false
+
+    sut.startAnimating()
+
+    XCTAssertTrue(sut.typingIndicator.isAnimating)
+    XCTAssertNil(sut.contentBubble.layer.animationKeys())
+    XCTAssertNil(sut.cornerBubble.layer.animationKeys())
+    XCTAssertNil(sut.tinyBubble.layer.animationKeys())
+  }
+
+  func testStoppingRemovesEveryPulseLayer() {
+    let sut = TypingBubble()
+    sut.startAnimating()
+
+    sut.stopAnimating()
+
+    XCTAssertFalse(sut.isAnimating)
+    XCTAssertFalse(sut.typingIndicator.isAnimating)
+    XCTAssertEqual(sut.contentBubble.layer.animationKeys() ?? [], [])
+    XCTAssertEqual(sut.cornerBubble.layer.animationKeys() ?? [], [])
+    XCTAssertEqual(sut.tinyBubble.layer.animationKeys() ?? [], [])
+  }
+
+  func testStoppingABubbleThatNeverStartedLeavesItAlone() {
+    let sut = TypingBubble()
+
+    sut.stopAnimating()
+
+    XCTAssertFalse(sut.isAnimating)
+  }
+}


### PR DESCRIPTION
> Stacked on #1915 → #1914 → #1913 → #1911 → #1910 → #1909. Base is `chore/example-matches-library`.

## Summary

`MessageSizeCalculator` (356 lines) decides how tall every cell is and how wide its container may be, and **no test referred to it**. A change to that arithmetic could only be caught by looking at the example app.

This is the first slice of the test-coverage item, aimed at the largest untested area rather than at raising a coverage number.

## What is covered

Only the parts that branch — not the parts that read back a stored property:

- **Natural avatar position resolution.** Resolves to trailing for the current sender, leading for everyone else, and an explicit horizontal position survives the resolution untouched.
- **Avatar size precedence.** Falls back to the incoming or outgoing size by sender, and the layout delegate overrides both.
- **Container maximum width.** Subtracts the avatar, container padding, accessory view, accessory padding and avatar padding from the item width.
- **Cell height.** Takes the tallest of avatar, labels and accessory view, and counts the vertical container padding.
- Container padding and cell label alignment follow the sender; the base calculator reports an empty container.

## These tests were checked for detection power

A passing test proves nothing on its own, so I ran them against a deliberately broken calculator:

| Mutation | Result |
| --- | --- |
| Invert the natural position resolution (`isFromCurrentSender ? .cellLeading : .cellTrailing`) | 2 tests fail |
| Drop `avatarLeadingTrailingPadding` from the max-width sum | 1 test fails |

Both mutations were caught, then reverted. The assertions detect regressions rather than only describing current behaviour.

## Verification

Full suite passes: **72 tests, 0 failures**, up from 60. `make lint` passes.

## Note on the fixtures

`StubLayoutDelegate` only stubs `avatarSize`; everything else comes from the protocol's own defaults, so the tests exercise the real fallback paths rather than a fully mocked delegate. `SUT` is a `@MainActor` struct because `MockMessagesDataSource` is main-actor isolated.

## Still uncovered

`TypingIndicator` (162 lines) also has no tests, and the other calculators (`Text`, `Media`, `Location`, `Audio`) inherit from this one without direct coverage. Worth a follow-up if you want to keep going.