### PR TITLE
Add tests for the cell size calculators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 - Add tests for `MessageSizeCalculator`, which covers the avatar position resolution, the sender specific avatar sizes and paddings, the container maximum width and the cell height, and had no tests before by [@martinpucik](https://github.com/martinpucik)
 - Add tests for `TypingIndicator` and `TypingBubble`, which cover the dot layout and spacing, the animation state flags, the animation layers and the pulse layers, and had no tests before by [@martinpucik](https://github.com/martinpucik)
+- Add tests for the eight cell size calculators, which cover the text, media, audio, location, contact, link preview and typing indicator container sizes, the sender specific label insets and the layout attributes each one fills in, and had no tests before by [@martinpucik](https://github.com/martinpucik)
 ### Fixed
 
 - **Breaking Change** Annotate `MessageCellDelegate` and `MessageLabelDelegate` with `@MainActor`. Their sibling delegate protocols `MessagesDataSource`, `MessagesLayoutDelegate` and `MessagesDisplayDelegate` already carried the annotation, so consumers building in the Swift 6 language mode had to work around these two with `@preconcurrency` by [@martinpucik](https://github.com/martinpucik)

--- a/Tests/MessageKitTests/Layout Tests/AudioMessageSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/AudioMessageSizeCalculatorTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2020 MessageKit
+// Copyright (c) 2017-2026 MessageKit
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/MessageKitTests/Layout Tests/AudioMessageSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/AudioMessageSizeCalculatorTests.swift
@@ -1,0 +1,99 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 MessageKit
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+import XCTest
+@testable import MessageKit
+
+// MARK: - AudioMessageSizeCalculatorTests
+
+@MainActor
+final class AudioMessageSizeCalculatorTests: XCTestCase {
+  func testAnAudioItemThatFitsKeepsItsOwnSize() {
+    let sut = makeSUT(size: CGSize(width: 160, height: 35))
+
+    let size = sut.calculator.messageContainerSize(for: sut.message, at: sut.indexPath)
+
+    XCTAssertEqual(size, CGSize(width: 160, height: 35))
+  }
+
+  func testAnOversizedAudioItemIsClampedToTheMaxWidth() {
+    let sut = makeSUT(size: CGSize(width: 4000, height: 400))
+
+    let size = sut.calculator.messageContainerSize(for: sut.message, at: sut.indexPath)
+
+    let maxWidth = sut.calculator.messageContainerMaxWidth(for: sut.message, at: sut.indexPath)
+    XCTAssertEqual(size.width, maxWidth)
+  }
+
+  func testAnOversizedAudioItemKeepsItsAspectRatio() {
+    let sut = makeSUT(size: CGSize(width: 4000, height: 400))
+
+    let size = sut.calculator.messageContainerSize(for: sut.message, at: sut.indexPath)
+
+    // The item is 10:1, so the clamped width decides the height.
+    let maxWidth = sut.calculator.messageContainerMaxWidth(for: sut.message, at: sut.indexPath)
+    XCTAssertEqual(size.height, maxWidth / 10, accuracy: 0.001)
+  }
+
+  func testTheDurationDoesNotChangeTheContainerSize() {
+    let brief = makeSUT(size: CGSize(width: 160, height: 35), duration: 1)
+    let lengthy = makeSUT(size: CGSize(width: 160, height: 35), duration: 600)
+
+    XCTAssertEqual(
+      brief.calculator.messageContainerSize(for: brief.message, at: brief.indexPath),
+      lengthy.calculator.messageContainerSize(for: lengthy.message, at: lengthy.indexPath))
+  }
+}
+
+// MARK: - StubAudioItem
+
+private struct StubAudioItem: AudioItem {
+  var url = URL(fileURLWithPath: "/dev/null")
+  var size: CGSize
+  var duration: Float
+}
+
+// MARK: - Assistants
+
+extension AudioMessageSizeCalculatorTests {
+  // MARK: Fileprivate
+
+  @MainActor
+  fileprivate struct SUT {
+    let harness: CalculatorHarness
+    let calculator: AudioMessageSizeCalculator
+
+    var message: MessageType { harness.dataSource.messages[0] }
+    var indexPath: IndexPath { harness.indexPath(forMessageAt: 0) }
+  }
+
+  // MARK: Private
+
+  private func makeSUT(size: CGSize, duration: Float = 10) -> SUT {
+    let item = StubAudioItem(size: size, duration: duration)
+    let harness = CalculatorHarness(messages: [
+      MockMessage(kind: .audio(item), user: MockMessagesDataSource.incomingSender, messageId: "audio"),
+    ])
+    return SUT(harness: harness, calculator: AudioMessageSizeCalculator(layout: harness.layout))
+  }
+}

--- a/Tests/MessageKitTests/Layout Tests/CellSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/CellSizeCalculatorTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2020 MessageKit
+// Copyright (c) 2017-2026 MessageKit
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/MessageKitTests/Layout Tests/CellSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/CellSizeCalculatorTests.swift
@@ -1,0 +1,73 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 MessageKit
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+@testable import MessageKit
+
+// MARK: - CellSizeCalculatorTests
+
+@MainActor
+final class CellSizeCalculatorTests: XCTestCase {
+  func testTheBaseCalculatorSizesEveryItemToZero() {
+    let sut = CellSizeCalculator()
+
+    XCTAssertEqual(sut.sizeForItem(at: IndexPath(item: 0, section: 0)), .zero)
+    XCTAssertEqual(sut.sizeForItem(at: IndexPath(item: 3, section: 7)), .zero)
+  }
+
+  func testTheBaseCalculatorLeavesTheAttributesAlone() {
+    let sut = CellSizeCalculator()
+    let attributes = MessagesCollectionViewLayoutAttributes(forCellWith: IndexPath(item: 0, section: 0))
+    attributes.frame = CGRect(x: 1, y: 2, width: 3, height: 4)
+
+    sut.configure(attributes: attributes)
+
+    XCTAssertEqual(attributes.frame, CGRect(x: 1, y: 2, width: 3, height: 4))
+    XCTAssertEqual(attributes.messageContainerSize, .zero)
+  }
+
+  func testTheCalculatorStartsWithoutALayout() {
+    XCTAssertNil(CellSizeCalculator().layout)
+  }
+
+  /// The calculator must not keep the layout alive, because every layout owns
+  /// its calculators and would otherwise form a cycle.
+  func testTheCalculatorHoldsItsLayoutWeakly() {
+    let sut = CellSizeCalculator()
+    var layout: MessagesCollectionViewFlowLayout? = MessagesCollectionViewFlowLayout()
+    sut.layout = layout
+    XCTAssertNotNil(sut.layout)
+
+    layout = nil
+
+    XCTAssertNil(sut.layout)
+  }
+
+  func testTheMessageCalculatorTakesItsLayoutFromTheInitializer() {
+    let layout = MessagesCollectionViewFlowLayout()
+
+    let sut = MessageSizeCalculator(layout: layout)
+
+    XCTAssertIdentical(sut.layout, layout)
+    XCTAssertIdentical(sut.messagesLayout, layout)
+  }
+}

--- a/Tests/MessageKitTests/Layout Tests/ContactMessageSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/ContactMessageSizeCalculatorTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2020 MessageKit
+// Copyright (c) 2017-2026 MessageKit
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/MessageKitTests/Layout Tests/ContactMessageSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/ContactMessageSizeCalculatorTests.swift
@@ -1,0 +1,165 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 MessageKit
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+@testable import MessageKit
+
+// MARK: - ContactMessageSizeCalculatorTests
+
+@MainActor
+final class ContactMessageSizeCalculatorTests: XCTestCase {
+  // MARK: - Label insets
+
+  func testTheNameLabelInsetsFollowTheSender() {
+    let sut = makeSUT()
+    sut.calculator.incomingMessageNameLabelInsets = UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
+    sut.calculator.outgoingMessageNameLabelInsets = UIEdgeInsets(top: 5, left: 6, bottom: 7, right: 8)
+
+    XCTAssertEqual(
+      sut.calculator.contactLabelInsets(for: sut.incomingMessage),
+      UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4))
+    XCTAssertEqual(
+      sut.calculator.contactLabelInsets(for: sut.outgoingMessage),
+      UIEdgeInsets(top: 5, left: 6, bottom: 7, right: 8))
+  }
+
+  func testTheContainerMaxWidthRemovesTheNameLabelInsets() {
+    let sut = makeSUT()
+    let base = MessageSizeCalculator(layout: sut.harness.layout)
+      .messageContainerMaxWidth(for: sut.incomingMessage, at: sut.incomingIndexPath)
+    sut.calculator.incomingMessageNameLabelInsets = UIEdgeInsets(top: 7, left: 46, bottom: 7, right: 30)
+
+    let maxWidth = sut.calculator.messageContainerMaxWidth(for: sut.incomingMessage, at: sut.incomingIndexPath)
+
+    XCTAssertEqual(maxWidth, base - 76)
+  }
+
+  // MARK: - Container size
+
+  func testTheContainerAddsTheNameLabelInsetsToTheMeasuredName() {
+    let sut = makeSUT()
+    sut.calculator.incomingMessageNameLabelInsets = .zero
+    let bare = sut.calculator.messageContainerSize(for: sut.incomingMessage, at: sut.incomingIndexPath)
+
+    sut.calculator.incomingMessageNameLabelInsets = UIEdgeInsets(top: 3, left: 5, bottom: 4, right: 6)
+    let padded = sut.calculator.messageContainerSize(for: sut.incomingMessage, at: sut.incomingIndexPath)
+
+    XCTAssertEqual(padded.height, bare.height + 7)
+    XCTAssertEqual(padded.width, bare.width + 11)
+  }
+
+  func testALongerDisplayNameNeedsAWiderContainer() {
+    let sut = makeSUT()
+
+    let short = sut.calculator.messageContainerSize(for: sut.incomingMessage, at: sut.incomingIndexPath)
+    let long = sut.calculator.messageContainerSize(for: sut.longNameMessage, at: sut.harness.indexPath(forMessageAt: 2))
+
+    XCTAssertGreaterThan(long.width, short.width)
+  }
+
+  func testOnlyTheDisplayNameDecidesTheContainerSize() {
+    let sut = makeSUT()
+
+    let plain = sut.calculator.messageContainerSize(for: sut.incomingMessage, at: sut.incomingIndexPath)
+    let detailed = sut.calculator.messageContainerSize(for: sut.detailedMessage, at: sut.harness.indexPath(forMessageAt: 3))
+
+    // The phone numbers, the emails and the initials do not take up any room.
+    XCTAssertEqual(plain, detailed)
+  }
+
+  func testABiggerContactFontNeedsATallerContainer() {
+    let sut = makeSUT()
+    let regular = sut.calculator.messageContainerSize(for: sut.incomingMessage, at: sut.incomingIndexPath)
+
+    sut.calculator.contactLabelFont = .systemFont(ofSize: sut.calculator.contactLabelFont.pointSize * 2)
+    let doubled = sut.calculator.messageContainerSize(for: sut.incomingMessage, at: sut.incomingIndexPath)
+
+    XCTAssertGreaterThan(doubled.height, regular.height)
+  }
+
+  // MARK: - Attributes
+
+  func testConfigureCopiesTheContactFontOntoTheAttributes() {
+    let sut = makeSUT()
+    sut.calculator.contactLabelFont = .systemFont(ofSize: 23)
+    let attributes = sut.harness.attributes(forMessageAt: 1)
+
+    sut.calculator.configure(attributes: attributes)
+
+    XCTAssertEqual(attributes.messageLabelFont, .systemFont(ofSize: 23))
+  }
+}
+
+// MARK: - StubContactItem
+
+private struct StubContactItem: ContactItem {
+  var displayName: String
+  var initials = ""
+  var phoneNumbers: [String] = []
+  var emails: [String] = []
+}
+
+// MARK: - Assistants
+
+extension ContactMessageSizeCalculatorTests {
+  // MARK: Fileprivate
+
+  @MainActor
+  fileprivate struct SUT {
+    let harness: CalculatorHarness
+    let calculator: ContactMessageSizeCalculator
+
+    var outgoingMessage: MessageType { harness.dataSource.messages[0] }
+    var incomingMessage: MessageType { harness.dataSource.messages[1] }
+    var longNameMessage: MessageType { harness.dataSource.messages[2] }
+    var detailedMessage: MessageType { harness.dataSource.messages[3] }
+    var incomingIndexPath: IndexPath { harness.indexPath(forMessageAt: 1) }
+  }
+
+  // MARK: Private
+
+  private func makeSUT() -> SUT {
+    let harness = CalculatorHarness(messages: [
+      MockMessage(
+        kind: .contact(StubContactItem(displayName: "Ada")),
+        user: MockMessagesDataSource.outgoingSender,
+        messageId: "outgoing"),
+      MockMessage(
+        kind: .contact(StubContactItem(displayName: "Ada")),
+        user: MockMessagesDataSource.incomingSender,
+        messageId: "incoming"),
+      MockMessage(
+        kind: .contact(StubContactItem(displayName: "Ada Lovelace of Marylebone")),
+        user: MockMessagesDataSource.incomingSender,
+        messageId: "longName"),
+      MockMessage(
+        kind: .contact(StubContactItem(
+          displayName: "Ada",
+          initials: "AL",
+          phoneNumbers: ["+421 000 000 000", "+421 111 111 111"],
+          emails: ["ada@example.com"])),
+        user: MockMessagesDataSource.incomingSender,
+        messageId: "detailed"),
+    ])
+    return SUT(harness: harness, calculator: ContactMessageSizeCalculator(layout: harness.layout))
+  }
+}

--- a/Tests/MessageKitTests/Layout Tests/LinkPreviewMessageSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/LinkPreviewMessageSizeCalculatorTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2020 MessageKit
+// Copyright (c) 2017-2026 MessageKit
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/MessageKitTests/Layout Tests/LinkPreviewMessageSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/LinkPreviewMessageSizeCalculatorTests.swift
@@ -1,0 +1,174 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 MessageKit
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+import XCTest
+@testable import MessageKit
+
+// MARK: - LinkPreviewMessageSizeCalculatorTests
+
+@MainActor
+final class LinkPreviewMessageSizeCalculatorTests: XCTestCase {
+  // MARK: - Max width
+
+  func testTheContainerIsNeverNarrowerThanThreeQuartersOfTheCollectionView() {
+    let sut = makeSUT()
+    // A wide avatar would otherwise squeeze the container below the floor.
+    sut.calculator.incomingAvatarSize = CGSize(width: 260, height: 30)
+
+    let maxWidth = sut.calculator.messageContainerMaxWidth(for: sut.linkMessage, at: sut.linkIndexPath)
+
+    let collectionViewWidth = sut.harness.controller.messagesCollectionView.bounds.width
+    XCTAssertEqual(maxWidth, collectionViewWidth * 0.75)
+  }
+
+  func testAPlainTextMessageKeepsTheInheritedMaxWidth() {
+    let sut = makeSUT()
+    let text = TextMessageSizeCalculator(layout: sut.harness.layout)
+    text.incomingMessageLabelInsets = sut.calculator.incomingMessageLabelInsets
+
+    let maxWidth = sut.calculator.messageContainerMaxWidth(for: sut.textMessage, at: sut.textIndexPath)
+
+    XCTAssertEqual(maxWidth, text.messageContainerMaxWidth(for: sut.textMessage, at: sut.textIndexPath))
+  }
+
+  // MARK: - Container size
+
+  func testTheContainerFillsTheAvailableMaxWidth() {
+    let sut = makeSUT()
+    let indexPath = sut.linkIndexPath
+
+    let size = sut.calculator.messageContainerSize(for: sut.linkMessage, at: indexPath)
+
+    XCTAssertEqual(size.width, sut.calculator.messageContainerMaxWidth(for: sut.linkMessage, at: indexPath))
+  }
+
+  func testTheContainerLeavesRoomForTheThumbnailBesideTheText() {
+    let sut = makeSUT()
+
+    let size = sut.calculator.messageContainerSize(for: sut.linkMessage, at: sut.linkIndexPath)
+
+    let insets = sut.calculator.messageLabelInsets(for: sut.linkMessage)
+    XCTAssertGreaterThanOrEqual(size.height, LinkPreviewMessageSizeCalculator.imageViewSize + insets.vertical)
+  }
+
+  func testALongerTeaserNeedsATallerContainer() {
+    let sut = makeSUT()
+
+    let brief = sut.calculator.messageContainerSize(for: sut.linkMessage, at: sut.linkIndexPath)
+    let verbose = sut.calculator.messageContainerSize(
+      for: sut.longTeaserMessage,
+      at: sut.harness.indexPath(forMessageAt: 2))
+
+    XCTAssertGreaterThan(verbose.height, brief.height)
+  }
+
+  func testAnEmptyTitleAndTeaserStillLeaveTheThumbnailRoom() {
+    let sut = makeSUT()
+
+    let size = sut.calculator.messageContainerSize(for: sut.bareMessage, at: sut.harness.indexPath(forMessageAt: 3))
+
+    let insets = sut.calculator.messageLabelInsets(for: sut.bareMessage)
+    XCTAssertGreaterThanOrEqual(size.height, LinkPreviewMessageSizeCalculator.imageViewSize + insets.vertical)
+  }
+
+  // MARK: - Attributes
+
+  func testConfigureCopiesThePreviewFontsOntoTheAttributes() {
+    let sut = makeSUT()
+    sut.calculator.titleFont = .systemFont(ofSize: 17)
+    sut.calculator.teaserFont = .systemFont(ofSize: 15)
+    sut.calculator.domainFont = .systemFont(ofSize: 13)
+    let attributes = sut.harness.attributes(forMessageAt: 0)
+
+    sut.calculator.configure(attributes: attributes)
+
+    XCTAssertEqual(
+      attributes.linkPreviewFonts,
+      LinkPreviewFonts(
+        titleFont: .systemFont(ofSize: 17),
+        teaserFont: .systemFont(ofSize: 15),
+        domainFont: .systemFont(ofSize: 13)))
+  }
+
+  func testTheDefaultPreviewFontsScaleWithTheContentSize() {
+    let sut = makeSUT()
+
+    // The initializer runs each default font through a `UIFontMetrics`, so the
+    // sizes stay in the footnote and caption ranges rather than the raw values.
+    XCTAssertGreaterThan(sut.calculator.titleFont.pointSize, 0)
+    XCTAssertGreaterThan(sut.calculator.domainFont.pointSize, 0)
+    XCTAssertNotEqual(sut.calculator.titleFont, sut.calculator.domainFont)
+  }
+}
+
+// MARK: - Assistants
+
+extension LinkPreviewMessageSizeCalculatorTests {
+  // MARK: Fileprivate
+
+  @MainActor
+  fileprivate struct SUT {
+    let harness: CalculatorHarness
+    let calculator: LinkPreviewMessageSizeCalculator
+
+    var linkMessage: MessageType { harness.dataSource.messages[0] }
+    var textMessage: MessageType { harness.dataSource.messages[1] }
+    var longTeaserMessage: MessageType { harness.dataSource.messages[2] }
+    var bareMessage: MessageType { harness.dataSource.messages[3] }
+    var linkIndexPath: IndexPath { harness.indexPath(forMessageAt: 0) }
+    var textIndexPath: IndexPath { harness.indexPath(forMessageAt: 1) }
+  }
+
+  // MARK: Private
+
+  private func makeSUT() -> SUT {
+    let harness = CalculatorHarness(messages: [
+      MockMessage(
+        linkItem: makeLinkItem(title: "MessageKit", teaser: "An elegant messages UI library for iOS."),
+        user: MockMessagesDataSource.incomingSender,
+        messageId: "link"),
+      MockMessage(text: "Plain text", user: MockMessagesDataSource.incomingSender, messageId: "text"),
+      MockMessage(
+        linkItem: makeLinkItem(
+          title: "MessageKit",
+          teaser: String(repeating: "A teaser that runs on over several lines. ", count: 6)),
+        user: MockMessagesDataSource.incomingSender,
+        messageId: "longTeaser"),
+      MockMessage(
+        linkItem: makeLinkItem(title: "", teaser: ""),
+        user: MockMessagesDataSource.incomingSender,
+        messageId: "bare"),
+    ])
+    return SUT(harness: harness, calculator: LinkPreviewMessageSizeCalculator(layout: harness.layout))
+  }
+
+  private func makeLinkItem(title: String, teaser: String) -> MockLinkItem {
+    MockLinkItem(
+      text: "https://github.com/MessageKit/MessageKit",
+      attributedText: nil,
+      url: URL(string: "https://github.com/MessageKit/MessageKit")!,
+      title: title,
+      teaser: teaser,
+      thumbnailImage: UIImage())
+  }
+}

--- a/Tests/MessageKitTests/Layout Tests/LocationMessageSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/LocationMessageSizeCalculatorTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2020 MessageKit
+// Copyright (c) 2017-2026 MessageKit
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/MessageKitTests/Layout Tests/LocationMessageSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/LocationMessageSizeCalculatorTests.swift
@@ -1,0 +1,99 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 MessageKit
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import CoreLocation
+import XCTest
+@testable import MessageKit
+
+// MARK: - LocationMessageSizeCalculatorTests
+
+@MainActor
+final class LocationMessageSizeCalculatorTests: XCTestCase {
+  func testALocationItemThatFitsKeepsItsOwnSize() {
+    let sut = makeSUT(size: CGSize(width: 240, height: 240))
+
+    let size = sut.calculator.messageContainerSize(for: sut.message, at: sut.indexPath)
+
+    XCTAssertEqual(size, CGSize(width: 240, height: 240))
+  }
+
+  func testAnOversizedLocationItemIsClampedToTheMaxWidth() {
+    let sut = makeSUT(size: CGSize(width: 4000, height: 4000))
+
+    let size = sut.calculator.messageContainerSize(for: sut.message, at: sut.indexPath)
+
+    let maxWidth = sut.calculator.messageContainerMaxWidth(for: sut.message, at: sut.indexPath)
+    XCTAssertEqual(size.width, maxWidth)
+  }
+
+  func testAnOversizedLocationItemKeepsItsAspectRatio() {
+    let sut = makeSUT(size: CGSize(width: 4000, height: 1000))
+
+    let size = sut.calculator.messageContainerSize(for: sut.message, at: sut.indexPath)
+
+    // The item is 4:1, so the clamped width decides the height.
+    let maxWidth = sut.calculator.messageContainerMaxWidth(for: sut.message, at: sut.indexPath)
+    XCTAssertEqual(size.height, maxWidth / 4, accuracy: 0.001)
+  }
+
+  func testTheCoordinateDoesNotChangeTheContainerSize() {
+    let size = CGSize(width: 240, height: 240)
+    let equator = makeSUT(size: size, location: CLLocation(latitude: 0, longitude: 0))
+    let arctic = makeSUT(size: size, location: CLLocation(latitude: 78.22, longitude: 15.65))
+
+    XCTAssertEqual(
+      equator.calculator.messageContainerSize(for: equator.message, at: equator.indexPath),
+      arctic.calculator.messageContainerSize(for: arctic.message, at: arctic.indexPath))
+  }
+}
+
+// MARK: - StubLocationItem
+
+private struct StubLocationItem: LocationItem {
+  var location: CLLocation
+  var size: CGSize
+}
+
+// MARK: - Assistants
+
+extension LocationMessageSizeCalculatorTests {
+  // MARK: Fileprivate
+
+  @MainActor
+  fileprivate struct SUT {
+    let harness: CalculatorHarness
+    let calculator: LocationMessageSizeCalculator
+
+    var message: MessageType { harness.dataSource.messages[0] }
+    var indexPath: IndexPath { harness.indexPath(forMessageAt: 0) }
+  }
+
+  // MARK: Private
+
+  private func makeSUT(size: CGSize, location: CLLocation = CLLocation(latitude: 48.14, longitude: 17.10)) -> SUT {
+    let item = StubLocationItem(location: location, size: size)
+    let harness = CalculatorHarness(messages: [
+      MockMessage(kind: .location(item), user: MockMessagesDataSource.incomingSender, messageId: "location"),
+    ])
+    return SUT(harness: harness, calculator: LocationMessageSizeCalculator(layout: harness.layout))
+  }
+}

--- a/Tests/MessageKitTests/Layout Tests/MediaMessageSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/MediaMessageSizeCalculatorTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2020 MessageKit
+// Copyright (c) 2017-2026 MessageKit
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/MessageKitTests/Layout Tests/MediaMessageSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/MediaMessageSizeCalculatorTests.swift
@@ -1,0 +1,119 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 MessageKit
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+import XCTest
+@testable import MessageKit
+
+// MARK: - MediaMessageSizeCalculatorTests
+
+@MainActor
+final class MediaMessageSizeCalculatorTests: XCTestCase {
+  // MARK: - Photo
+
+  func testAPhotoThatFitsKeepsItsOwnSize() {
+    let sut = makeSUT(size: CGSize(width: 120, height: 90))
+
+    let size = sut.calculator.messageContainerSize(for: sut.photoMessage, at: sut.photoIndexPath)
+
+    XCTAssertEqual(size, CGSize(width: 120, height: 90))
+  }
+
+  func testAnOversizedPhotoIsClampedToTheMaxWidth() {
+    let sut = makeSUT(size: CGSize(width: 4000, height: 2000))
+
+    let size = sut.calculator.messageContainerSize(for: sut.photoMessage, at: sut.photoIndexPath)
+
+    let maxWidth = sut.calculator.messageContainerMaxWidth(for: sut.photoMessage, at: sut.photoIndexPath)
+    XCTAssertEqual(size.width, maxWidth)
+  }
+
+  func testAnOversizedPhotoKeepsItsAspectRatio() {
+    let sut = makeSUT(size: CGSize(width: 4000, height: 2000))
+
+    let size = sut.calculator.messageContainerSize(for: sut.photoMessage, at: sut.photoIndexPath)
+
+    // The item is 2:1, so the clamped width decides the height.
+    let maxWidth = sut.calculator.messageContainerMaxWidth(for: sut.photoMessage, at: sut.photoIndexPath)
+    XCTAssertEqual(size.height, maxWidth / 2, accuracy: 0.001)
+  }
+
+  // MARK: - Video
+
+  func testAVideoIsSizedTheSameWayAsAPhoto() {
+    let sut = makeSUT(size: CGSize(width: 4000, height: 2000))
+
+    let photo = sut.calculator.messageContainerSize(for: sut.photoMessage, at: sut.photoIndexPath)
+    let video = sut.calculator.messageContainerSize(for: sut.videoMessage, at: sut.videoIndexPath)
+
+    XCTAssertEqual(photo, video)
+  }
+
+  // MARK: - Max width
+
+  func testAWiderAvatarLeavesLessRoomForThePhoto() {
+    let sut = makeSUT(size: CGSize(width: 4000, height: 2000))
+    let roomy = sut.calculator.messageContainerSize(for: sut.photoMessage, at: sut.photoIndexPath)
+
+    sut.calculator.incomingAvatarSize = CGSize(width: 90, height: 90)
+    let tight = sut.calculator.messageContainerSize(for: sut.photoMessage, at: sut.photoIndexPath)
+
+    XCTAssertEqual(tight.width, roomy.width - 60)
+  }
+}
+
+// MARK: - StubMediaItem
+
+private struct StubMediaItem: MediaItem {
+  var url: URL?
+  var image: UIImage?
+  var placeholderImage = UIImage()
+  var size: CGSize
+}
+
+// MARK: - Assistants
+
+extension MediaMessageSizeCalculatorTests {
+  // MARK: Fileprivate
+
+  @MainActor
+  fileprivate struct SUT {
+    let harness: CalculatorHarness
+    let calculator: MediaMessageSizeCalculator
+
+    var photoMessage: MessageType { harness.dataSource.messages[0] }
+    var videoMessage: MessageType { harness.dataSource.messages[1] }
+    var photoIndexPath: IndexPath { harness.indexPath(forMessageAt: 0) }
+    var videoIndexPath: IndexPath { harness.indexPath(forMessageAt: 1) }
+  }
+
+  // MARK: Private
+
+  private func makeSUT(size: CGSize) -> SUT {
+    let item = StubMediaItem(size: size)
+    let harness = CalculatorHarness(messages: [
+      MockMessage(kind: .photo(item), user: MockMessagesDataSource.incomingSender, messageId: "photo"),
+      MockMessage(kind: .video(item), user: MockMessagesDataSource.incomingSender, messageId: "video"),
+    ])
+    return SUT(harness: harness, calculator: MediaMessageSizeCalculator(layout: harness.layout))
+  }
+}

--- a/Tests/MessageKitTests/Layout Tests/MessageSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/MessageSizeCalculatorTests.swift
@@ -164,54 +164,33 @@ extension MessageSizeCalculatorTests {
 
   @MainActor
   fileprivate struct SUT {
-    let controller: MessagesViewController
-    let dataSource: MockMessagesDataSource
+    let harness: CalculatorHarness
     let layoutDelegate: StubLayoutDelegate
-    let layout: MessagesCollectionViewFlowLayout
     let calculator: MessageSizeCalculator
 
+    var layout: MessagesCollectionViewFlowLayout { harness.layout }
+
     /// `MockMessagesDataSource` treats `senders[0]` as the current sender.
-    var outgoingMessage: MessageType { dataSource.messages[0] }
-    var incomingMessage: MessageType { dataSource.messages[1] }
-    var outgoingIndexPath: IndexPath { IndexPath(item: 0, section: 0) }
-    var incomingIndexPath: IndexPath { IndexPath(item: 0, section: 1) }
+    var outgoingMessage: MessageType { harness.dataSource.messages[0] }
+    var incomingMessage: MessageType { harness.dataSource.messages[1] }
+    var outgoingIndexPath: IndexPath { harness.indexPath(forMessageAt: 0) }
+    var incomingIndexPath: IndexPath { harness.indexPath(forMessageAt: 1) }
   }
 
   // MARK: Private
 
   private func makeSUT() -> SUT {
-    let dataSource = MockMessagesDataSource()
-    dataSource.messages = [
-      MockMessage(text: "Outgoing", user: dataSource.senders[0], messageId: "001"),
-      MockMessage(text: "Incoming", user: dataSource.senders[1], messageId: "002"),
-    ]
-
     let layoutDelegate = StubLayoutDelegate()
-    let controller = MessagesViewController()
-    controller.messagesCollectionView.messagesDataSource = dataSource
-    controller.messagesCollectionView.messagesLayoutDelegate = layoutDelegate
-    controller.messagesCollectionView.messagesDisplayDelegate = layoutDelegate
-    _ = controller.view
-    controller.beginAppearanceTransition(true, animated: false)
-    controller.endAppearanceTransition()
-    controller.view.layoutIfNeeded()
+    let harness = CalculatorHarness(
+      messages: [
+        MockMessage(text: "Outgoing", user: MockMessagesDataSource.outgoingSender, messageId: "001"),
+        MockMessage(text: "Incoming", user: MockMessagesDataSource.incomingSender, messageId: "002"),
+      ],
+      layoutDelegate: layoutDelegate)
 
-    let layout = controller.messagesCollectionView.messagesCollectionViewFlowLayout
     return SUT(
-      controller: controller,
-      dataSource: dataSource,
+      harness: harness,
       layoutDelegate: layoutDelegate,
-      layout: layout,
-      calculator: MessageSizeCalculator(layout: layout))
-  }
-}
-
-// MARK: - StubLayoutDelegate
-
-final class StubLayoutDelegate: MessagesLayoutDelegate, MessagesDisplayDelegate {
-  var stubbedAvatarSize: CGSize?
-
-  func avatarSize(for _: MessageType, at _: IndexPath, in _: MessagesCollectionView) -> CGSize? {
-    stubbedAvatarSize
+      calculator: MessageSizeCalculator(layout: harness.layout))
   }
 }

--- a/Tests/MessageKitTests/Layout Tests/TextMessageSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/TextMessageSizeCalculatorTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2020 MessageKit
+// Copyright (c) 2017-2026 MessageKit
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/MessageKitTests/Layout Tests/TextMessageSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/TextMessageSizeCalculatorTests.swift
@@ -1,0 +1,210 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 MessageKit
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+@testable import MessageKit
+
+// MARK: - TextMessageSizeCalculatorTests
+
+@MainActor
+final class TextMessageSizeCalculatorTests: XCTestCase {
+  // MARK: - Label insets
+
+  func testTheLabelInsetsFollowTheSender() {
+    let sut = makeSUT()
+    sut.calculator.incomingMessageLabelInsets = UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
+    sut.calculator.outgoingMessageLabelInsets = UIEdgeInsets(top: 5, left: 6, bottom: 7, right: 8)
+
+    XCTAssertEqual(
+      sut.calculator.messageLabelInsets(for: sut.incomingMessage),
+      UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4))
+    XCTAssertEqual(
+      sut.calculator.messageLabelInsets(for: sut.outgoingMessage),
+      UIEdgeInsets(top: 5, left: 6, bottom: 7, right: 8))
+  }
+
+  func testTheContainerMaxWidthRemovesTheLabelInsets() {
+    let sut = makeSUT()
+    let base = MessageSizeCalculator(layout: sut.harness.layout)
+      .messageContainerMaxWidth(for: sut.incomingMessage, at: sut.incomingIndexPath)
+    sut.calculator.incomingMessageLabelInsets = UIEdgeInsets(top: 7, left: 18, bottom: 7, right: 14)
+
+    let maxWidth = sut.calculator.messageContainerMaxWidth(for: sut.incomingMessage, at: sut.incomingIndexPath)
+
+    XCTAssertEqual(maxWidth, base - 32)
+  }
+
+  // MARK: - Container size
+
+  func testTheContainerAddsTheLabelInsetsToTheMeasuredText() {
+    let sut = makeSUT()
+    sut.calculator.incomingMessageLabelInsets = .zero
+    let bare = sut.calculator.messageContainerSize(for: sut.incomingMessage, at: sut.incomingIndexPath)
+
+    sut.calculator.incomingMessageLabelInsets = UIEdgeInsets(top: 3, left: 5, bottom: 4, right: 6)
+    let padded = sut.calculator.messageContainerSize(for: sut.incomingMessage, at: sut.incomingIndexPath)
+
+    // A short text fits on one line either way, so the container grows by
+    // exactly the insets.
+    XCTAssertEqual(padded.height, bare.height + 7)
+    XCTAssertEqual(padded.width, bare.width + 11)
+  }
+
+  func testALongerTextNeedsATallerContainer() {
+    let sut = makeSUT()
+    let short = sut.calculator.messageContainerSize(for: sut.shortMessage, at: sut.harness.indexPath(forMessageAt: 2))
+    let long = sut.calculator.messageContainerSize(for: sut.longMessage, at: sut.harness.indexPath(forMessageAt: 3))
+
+    XCTAssertGreaterThan(long.height, short.height)
+  }
+
+  func testALongTextWrapsInsteadOfOverflowingTheContainer() {
+    let sut = makeSUT()
+    let indexPath = sut.harness.indexPath(forMessageAt: 3)
+
+    let size = sut.calculator.messageContainerSize(for: sut.longMessage, at: indexPath)
+
+    let maxWidth = sut.calculator.messageContainerMaxWidth(for: sut.longMessage, at: indexPath)
+    let insets = sut.calculator.messageLabelInsets(for: sut.longMessage)
+    XCTAssertLessThanOrEqual(size.width, maxWidth + insets.horizontal)
+  }
+
+  func testABiggerLabelFontNeedsATallerContainer() {
+    let sut = makeSUT()
+    let indexPath = sut.harness.indexPath(forMessageAt: 2)
+    let regular = sut.calculator.messageContainerSize(for: sut.shortMessage, at: indexPath)
+
+    sut.calculator.messageLabelFont = .systemFont(ofSize: sut.calculator.messageLabelFont.pointSize * 2)
+    let doubled = sut.calculator.messageContainerSize(for: sut.shortMessage, at: indexPath)
+
+    XCTAssertGreaterThan(doubled.height, regular.height)
+  }
+
+  func testAnAttributedTextIsMeasuredWithItsOwnAttributes() {
+    let sut = makeSUT()
+    let small = MockMessage(
+      attributedText: NSAttributedString(string: "Attributed", attributes: [.font: UIFont.systemFont(ofSize: 12)]),
+      user: MockMessagesDataSource.incomingSender,
+      messageId: "small")
+    let large = MockMessage(
+      attributedText: NSAttributedString(string: "Attributed", attributes: [.font: UIFont.systemFont(ofSize: 36)]),
+      user: MockMessagesDataSource.incomingSender,
+      messageId: "large")
+    let indexPath = sut.harness.indexPath(forMessageAt: 1)
+
+    let smallSize = sut.calculator.messageContainerSize(for: small, at: indexPath)
+    let largeSize = sut.calculator.messageContainerSize(for: large, at: indexPath)
+
+    XCTAssertGreaterThan(largeSize.height, smallSize.height)
+    XCTAssertGreaterThan(largeSize.width, smallSize.width)
+  }
+
+  func testAnEmojiIsMeasuredLikeText() {
+    let sut = makeSUT()
+    let emoji = MockMessage(emoji: "👍", user: MockMessagesDataSource.incomingSender, messageId: "emoji")
+
+    let size = sut.calculator.messageContainerSize(for: emoji, at: sut.harness.indexPath(forMessageAt: 1))
+
+    XCTAssertGreaterThan(size.width, 0)
+    XCTAssertGreaterThan(size.height, 0)
+  }
+
+  // MARK: - Attributes
+
+  func testConfigureCopiesTheLabelInsetsAndTheFontOntoTheAttributes() {
+    let sut = makeSUT()
+    sut.calculator.incomingMessageLabelInsets = UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
+    sut.calculator.messageLabelFont = .systemFont(ofSize: 21)
+    let attributes = sut.harness.attributes(forMessageAt: 1)
+
+    sut.calculator.configure(attributes: attributes)
+
+    XCTAssertEqual(attributes.messageLabelInsets, UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4))
+    XCTAssertEqual(attributes.messageLabelFont, .systemFont(ofSize: 21))
+  }
+
+  func testConfigureTakesTheFontFromAnAttributedText() {
+    let font = UIFont.systemFont(ofSize: 27)
+    let sut = makeSUT(extraMessages: [
+      MockMessage(
+        attributedText: NSAttributedString(string: "Attributed", attributes: [.font: font]),
+        user: MockMessagesDataSource.incomingSender,
+        messageId: "attributed"),
+    ])
+    sut.calculator.messageLabelFont = .systemFont(ofSize: 21)
+    let attributes = sut.harness.attributes(forMessageAt: 4)
+
+    sut.calculator.configure(attributes: attributes)
+
+    XCTAssertEqual(attributes.messageLabelFont, font)
+  }
+
+  func testConfigureKeepsTheCalculatorFontForAnEmptyAttributedText() {
+    let sut = makeSUT(extraMessages: [
+      MockMessage(
+        attributedText: NSAttributedString(string: ""),
+        user: MockMessagesDataSource.incomingSender,
+        messageId: "empty"),
+    ])
+    sut.calculator.messageLabelFont = .systemFont(ofSize: 21)
+    let attributes = sut.harness.attributes(forMessageAt: 4)
+
+    sut.calculator.configure(attributes: attributes)
+
+    XCTAssertEqual(attributes.messageLabelFont, .systemFont(ofSize: 21))
+  }
+}
+
+// MARK: - Assistants
+
+extension TextMessageSizeCalculatorTests {
+  // MARK: Fileprivate
+
+  @MainActor
+  fileprivate struct SUT {
+    let harness: CalculatorHarness
+    let calculator: TextMessageSizeCalculator
+
+    var outgoingMessage: MessageType { harness.dataSource.messages[0] }
+    var incomingMessage: MessageType { harness.dataSource.messages[1] }
+    var shortMessage: MessageType { harness.dataSource.messages[2] }
+    var longMessage: MessageType { harness.dataSource.messages[3] }
+    var outgoingIndexPath: IndexPath { harness.indexPath(forMessageAt: 0) }
+    var incomingIndexPath: IndexPath { harness.indexPath(forMessageAt: 1) }
+  }
+
+  // MARK: Private
+
+  private func makeSUT(extraMessages: [MessageType] = []) -> SUT {
+    let messages: [MessageType] = [
+      MockMessage(text: "Outgoing", user: MockMessagesDataSource.outgoingSender, messageId: "001"),
+      MockMessage(text: "Incoming", user: MockMessagesDataSource.incomingSender, messageId: "002"),
+      MockMessage(text: "Short", user: MockMessagesDataSource.incomingSender, messageId: "003"),
+      MockMessage(
+        text: String(repeating: "A long message that has to wrap over several lines. ", count: 8),
+        user: MockMessagesDataSource.incomingSender,
+        messageId: "004"),
+    ]
+    let harness = CalculatorHarness(messages: messages + extraMessages)
+    return SUT(harness: harness, calculator: TextMessageSizeCalculator(layout: harness.layout))
+  }
+}

--- a/Tests/MessageKitTests/Layout Tests/TypingCellSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/TypingCellSizeCalculatorTests.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2020 MessageKit
+// Copyright (c) 2017-2026 MessageKit
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/MessageKitTests/Layout Tests/TypingCellSizeCalculatorTests.swift
+++ b/Tests/MessageKitTests/Layout Tests/TypingCellSizeCalculatorTests.swift
@@ -1,0 +1,90 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 MessageKit
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+import XCTest
+@testable import MessageKit
+
+// MARK: - TypingCellSizeCalculatorTests
+
+@MainActor
+final class TypingCellSizeCalculatorTests: XCTestCase {
+  func testTheCalculatorSizesTheCellToZeroWithoutALayout() {
+    let sut = TypingCellSizeCalculator()
+
+    XCTAssertEqual(sut.sizeForItem(at: IndexPath(item: 0, section: 0)), .zero)
+  }
+
+  func testTheCalculatorSizesTheCellToZeroForAPlainFlowLayout() {
+    let sut = TypingCellSizeCalculator()
+    let layout = UICollectionViewFlowLayout()
+    sut.layout = layout
+
+    XCTAssertEqual(sut.sizeForItem(at: IndexPath(item: 0, section: 0)), .zero)
+  }
+
+  func testTheCalculatorTakesTheSizeFromTheLayoutDelegate() {
+    let delegate = StubTypingLayoutDelegate()
+    delegate.stubbedTypingIndicatorViewSize = CGSize(width: 123, height: 45)
+    let harness = CalculatorHarness(messages: [], layoutDelegate: delegate)
+    let sut = TypingCellSizeCalculator(layout: harness.layout)
+
+    let size = sut.sizeForItem(at: IndexPath(item: 0, section: 0))
+
+    XCTAssertEqual(size, CGSize(width: 123, height: 45))
+  }
+
+  func testTheIndexPathDoesNotChangeTheSize() {
+    let delegate = StubTypingLayoutDelegate()
+    delegate.stubbedTypingIndicatorViewSize = CGSize(width: 123, height: 45)
+    let harness = CalculatorHarness(messages: [], layoutDelegate: delegate)
+    let sut = TypingCellSizeCalculator(layout: harness.layout)
+
+    XCTAssertEqual(
+      sut.sizeForItem(at: IndexPath(item: 0, section: 0)),
+      sut.sizeForItem(at: IndexPath(item: 4, section: 9)))
+  }
+
+  func testTheDefaultSizeSpansTheCollectionViewLessItsInsets() {
+    let harness = CalculatorHarness(messages: [])
+    let sut = TypingCellSizeCalculator(layout: harness.layout)
+
+    let size = sut.sizeForItem(at: IndexPath(item: 0, section: 0))
+
+    let collectionView = harness.controller.messagesCollectionView
+    let inset = harness.layout.sectionInset.horizontal + collectionView.contentInset.horizontal
+    XCTAssertEqual(size.width, collectionView.bounds.width - inset)
+    XCTAssertEqual(size.height, 62)
+  }
+}
+
+// MARK: - StubTypingLayoutDelegate
+
+/// A layout delegate that answers with a fixed typing indicator size, so the
+/// calculator can be checked without the framework default getting in the way.
+private final class StubTypingLayoutDelegate: MessagesLayoutDelegate, MessagesDisplayDelegate {
+  var stubbedTypingIndicatorViewSize = CGSize.zero
+
+  func typingIndicatorViewSize(for _: MessagesCollectionViewFlowLayout) -> CGSize {
+    stubbedTypingIndicatorViewSize
+  }
+}

--- a/Tests/MessageKitTests/Mocks/CalculatorHarness.swift
+++ b/Tests/MessageKitTests/Mocks/CalculatorHarness.swift
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2020 MessageKit
+// Copyright (c) 2017-2026 MessageKit
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/MessageKitTests/Mocks/CalculatorHarness.swift
+++ b/Tests/MessageKitTests/Mocks/CalculatorHarness.swift
@@ -1,0 +1,89 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 MessageKit
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+@testable import MessageKit
+
+// MARK: - CalculatorHarness
+
+/// A live `MessagesViewController` that gives a cell size calculator a real
+/// collection view to measure against.
+///
+/// `MessagesCollectionView` keeps its data source and its delegates weakly, so
+/// the harness holds them for the length of a test.
+@MainActor
+final class CalculatorHarness {
+  // MARK: Lifecycle
+
+  init(
+    messages: [MessageType],
+    layoutDelegate: MessagesLayoutDelegate & MessagesDisplayDelegate = StubLayoutDelegate())
+  {
+    let dataSource = MockMessagesDataSource()
+    dataSource.messages = messages
+    self.dataSource = dataSource
+    self.layoutDelegate = layoutDelegate
+
+    let controller = MessagesViewController()
+    controller.messagesCollectionView.messagesDataSource = dataSource
+    controller.messagesCollectionView.messagesLayoutDelegate = layoutDelegate
+    controller.messagesCollectionView.messagesDisplayDelegate = layoutDelegate
+    _ = controller.view
+    controller.beginAppearanceTransition(true, animated: false)
+    controller.endAppearanceTransition()
+    controller.view.layoutIfNeeded()
+    self.controller = controller
+  }
+
+  // MARK: Internal
+
+  let controller: MessagesViewController
+  let dataSource: MockMessagesDataSource
+  let layoutDelegate: MessagesLayoutDelegate & MessagesDisplayDelegate
+
+  var layout: MessagesCollectionViewFlowLayout {
+    controller.messagesCollectionView.messagesCollectionViewFlowLayout
+  }
+
+  /// `MockMessagesDataSource` puts one message in each section, so the message
+  /// index is also the section index.
+  func indexPath(forMessageAt index: Int) -> IndexPath {
+    IndexPath(item: 0, section: index)
+  }
+
+  /// Layout attributes an `open func configure(attributes:)` can fill in.
+  func attributes(forMessageAt index: Int) -> MessagesCollectionViewLayoutAttributes {
+    MessagesCollectionViewLayoutAttributes(forCellWith: indexPath(forMessageAt: index))
+  }
+}
+
+// MARK: - StubLayoutDelegate
+
+/// A layout delegate that answers with the framework defaults until a test
+/// stubs a value.
+final class StubLayoutDelegate: MessagesLayoutDelegate, MessagesDisplayDelegate {
+  var stubbedAvatarSize: CGSize?
+
+  func avatarSize(for _: MessageType, at _: IndexPath, in _: MessagesCollectionView) -> CGSize? {
+    stubbedAvatarSize
+  }
+}

--- a/Tests/MessageKitTests/Mocks/MockMessage.swift
+++ b/Tests/MessageKitTests/Mocks/MockMessage.swift
@@ -83,7 +83,7 @@ struct MockLinkItem: LinkItem {
 struct MockMessage: MessageType {
   // MARK: Lifecycle
 
-  private init(kind: MessageKind, user: MockUser, messageId: String) {
+  init(kind: MessageKind, user: MockUser, messageId: String) {
     self.kind = kind
     self.user = user
     self.messageId = messageId

--- a/Tests/MessageKitTests/Mocks/MockMessagesDataSource.swift
+++ b/Tests/MessageKitTests/Mocks/MockMessagesDataSource.swift
@@ -25,11 +25,13 @@ import Foundation
 
 @MainActor
 class MockMessagesDataSource: MessagesDataSource {
+  /// The current sender, so a message built from it counts as outgoing.
+  nonisolated static let outgoingSender = MockUser(senderId: "sender_1", displayName: "Sender 1")
+  /// Any other sender, so a message built from it counts as incoming.
+  nonisolated static let incomingSender = MockUser(senderId: "sender_2", displayName: "Sender 2")
+
   var messages: [MessageType] = []
-  let senders: [MockUser] = [
-    MockUser(senderId: "sender_1", displayName: "Sender 1"),
-    MockUser(senderId: "sender_2", displayName: "Sender 2"),
-  ]
+  let senders: [MockUser] = [outgoingSender, incomingSender]
 
   var currentUser: MockUser {
     senders[0]


### PR DESCRIPTION
## Summary

#1917 covered `MessageSizeCalculator`, but the eight calculators that actually size a cell had **no tests at all**. Every message kind reaches the screen through one of them, so a change to the clamping arithmetic or to the label insets could only be caught by looking at the example app.

This is the follow-up that #1917 pointed at in its "Still uncovered" note.

## What is covered

Only the parts that branch — not the parts that read back a stored property.

| Calculator | Tests | Covered behaviour |
| --- | --- | --- |
| `CellSizeCalculator` | 5 | Sizes every item to zero, leaves the attributes alone, and holds its layout **weakly** so a layout and its calculators do not form a cycle |
| `TextMessageSizeCalculator` | 11 | Label insets follow the sender, come off the container maximum width and go back onto the measured text; a long text wraps rather than overflowing; a bigger font needs a taller container; `.attributedText` and `.emoji` |
| `MediaMessageSizeCalculator` | 5 | `.photo` and `.video` keep an item that fits, clamp an oversized one, hold the aspect ratio |
| `AudioMessageSizeCalculator` | 4 | Same clamping, and the duration does not change the size |
| `LocationMessageSizeCalculator` | 4 | Same clamping, and the coordinate does not change the size |
| `ContactMessageSizeCalculator` | 7 | Name label insets follow the sender; the container comes from the display name **alone**, so the initials, the phone numbers and the emails take up no room |
| `LinkPreviewMessageSizeCalculator` | 8 | Never falls below three quarters of the collection view, leaves the thumbnail its room even with an empty title and teaser, keeps the inherited maximum width for a plain text message |
| `TypingCellSizeCalculator` | 5 | Takes its size from the layout delegate, reports zero without a `MessagesCollectionViewFlowLayout` |

Each calculator's `configure(attributes:)` is checked where it writes something — the label insets and font, the contact font, the link preview fonts.

## These tests were checked for detection power

A passing test proves nothing on its own, so I ran them against a deliberately broken calculator.

| Mutation | Result |
| --- | --- |
| Disable the clamp in `MediaMessageSizeCalculator` (`if false, maxWidth < item.size.width`) | 3 tests fail |

**It first caught only 2.** `testAnOversizedPhotoKeepsItsAspectRatio` asserted `size.height == size.width / 2`, which a 4000x2000 item satisfies whether it is clamped or not — the test was vacuous. The same flaw was in the audio and location versions. All three now anchor on the clamped width (`maxWidth / ratio`) instead of on the returned width, and the mutation was re-run to confirm they fail. Then reverted; `git status Sources/` is clean.

## Fixtures

The eight files all need a live `MessagesViewController` for the layout to measure against, so that setup moves into `CalculatorHarness`. It holds the data source and the delegates, because `MessagesCollectionView` keeps them weakly.

- `MessageSizeCalculatorTests` now uses the harness. **Its assertions are untouched** — only its own setup goes away (-30 lines). `StubLayoutDelegate` moved to the harness file.
- `MockMessagesDataSource` gains static `outgoingSender` / `incomingSender`, because the harness builds the data source itself and the tests need the senders first.
- `MockMessage`'s `init(kind:user:messageId:)` is no longer private. The existing stub items hardcode their sizes, so the clamping tests need items of their own size, and there was no way to build a `.contact` message at all.

Each test file declares its own stub item rather than widening the shared mocks.

## Verification

Full suite passes: **136 tests, 0 failures**, up from 87. `make lint` passes. No file under `Sources/` is touched.

## Still uncovered

`MessagesCollectionViewFlowLayout` itself, every file in `Sources/Extensions/`, and the `MessagesViewController+Keyboard` extension behind the largest cluster of open issues.
