### PR TITLE
Rename numberOfSections to numberOfMessageSections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ### Added
 
+- Rename `MessagesDataSource.numberOfSections(in:)` to `numberOfMessageSections(in:)`, which says what it counts. The old name is deprecated but keeps working, so this is not a breaking change. See the [migration guide](https://github.com/MessageKit/MessageKit/blob/main/Documentation/MIGRATION_GUIDE.md) by [@martinpucik](https://github.com/martinpucik)
 - Add tests for `MessageSizeCalculator`, which covers the avatar position resolution, the sender specific avatar sizes and paddings, the container maximum width and the cell height, and had no tests before by [@martinpucik](https://github.com/martinpucik)
 - Add tests for `TypingIndicator` and `TypingBubble`, which cover the dot layout and spacing, the animation state flags, the animation layers and the pulse layers, and had no tests before by [@martinpucik](https://github.com/martinpucik)
 ### Fixed

--- a/Documentation/CUSTOM_CELLS.md
+++ b/Documentation/CUSTOM_CELLS.md
@@ -61,7 +61,7 @@ open class MyCustomMessagesFlowLayout: MessagesCollectionViewFlowLayout {
 > **Note on the typing indicator**
 >
 > `setTypingIndicatorViewHidden(_:animated:)` reserves a section of its own for
-> the indicator. Keep `numberOfSections(in:)` returning the number of messages.
+> the indicator. Keep `numberOfMessageSections(in:)` returning the number of messages.
 > Adding one there for the indicator counts that section twice, and the next
 > reload asks the data source for a message that does not exist, which is the
 > `Index out of range` and `Invalid number of sections` pair reported in

--- a/Documentation/MIGRATION_GUIDE.md
+++ b/Documentation/MIGRATION_GUIDE.md
@@ -1,3 +1,54 @@
+## MessageKit 5.0 Migration Guide
+
+### Migration
+
+- DEPRECATION:
+    ```swift
+    MessagesDataSource.numberOfSections(in messagesCollectionView: MessagesCollectionView) -> Int
+    ```
+    is renamed to
+    ```swift
+    MessagesDataSource.numberOfMessageSections(in messagesCollectionView: MessagesCollectionView) -> Int
+    ```
+    The old name still compiles and still works, so this is not a breaking
+    change. You will see a deprecation warning until you rename it.
+
+    The old name read as the total number of sections, and it never was: it
+    counts the sections that hold messages. `MessagesViewController` reserves
+    the typing indicator's section on top of whatever you return, in its own
+    `UICollectionViewDataSource` conformance:
+
+    ```swift
+    let sections = messagesDataSource.numberOfMessageSections(in: collectionView)
+    return collectionView.isTypingIndicatorHidden ? sections : sections + 1
+    ```
+
+    Adding one for the indicator yourself therefore counts that section twice,
+    and the collection view then asks the data source for a message past the end
+    of your array. That is the `Index out of range` and `Invalid number of
+    sections` pair in [#1788](https://github.com/MessageKit/MessageKit/issues/1788),
+    [#1787](https://github.com/MessageKit/MessageKit/issues/1787) and
+    [#1387](https://github.com/MessageKit/MessageKit/issues/1387).
+
+    The old name also collided with `UICollectionViewDataSource`'s
+    `numberOfSections(in:)`, which `MessagesViewController` implements. The two
+    differed only in the parameter type, so the `+ 1` above looked like
+    something you were overriding rather than something already done for you.
+
+    Rename the method and return the message count, unchanged:
+
+    ```swift
+    // before
+    func numberOfSections(in messagesCollectionView: MessagesCollectionView) -> Int {
+      messages.count
+    }
+
+    // after
+    func numberOfMessageSections(in messagesCollectionView: MessagesCollectionView) -> Int {
+      messages.count
+    }
+    ```
+
 ## MessageKit 4.0 Migration Guide
 
 Version 4.0 contains some breaking changes if you want to upgrade from the previous version. In this documentation, we will cover most of the noticeable API changes.

--- a/Documentation/QuickStart.md
+++ b/Documentation/QuickStart.md
@@ -111,7 +111,7 @@ extension ChatViewController: MessagesDataSource {
 
 	// Return the message sections only. If you show the typing indicator,
 	// MessageKit reserves its section itself, so do not add one here.
-	func numberOfSections(in messagesCollectionView: MessagesCollectionView) -> Int {
+	func numberOfMessageSections(in messagesCollectionView: MessagesCollectionView) -> Int {
 		return messages.count
 	}
 

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -142,7 +142,7 @@ class ChatViewController: MessagesViewController, MessagesDataSource {
     return messagesCollectionView.indexPathsForVisibleItems.contains(lastIndexPath)
   }
 
-  func numberOfSections(in _: MessagesCollectionView) -> Int {
+  func numberOfMessageSections(in _: MessagesCollectionView) -> Int {
     messageList.count
   }
 

--- a/Example/Sources/Views/SwiftUI/MessagesView.swift
+++ b/Example/Sources/Views/SwiftUI/MessagesView.swift
@@ -108,7 +108,7 @@ extension MessagesView.Coordinator: MessagesDataSource {
     messages.wrappedValue[indexPath.section]
   }
 
-  func numberOfSections(in _: MessagesCollectionView) -> Int {
+  func numberOfMessageSections(in _: MessagesCollectionView) -> Int {
     messages.wrappedValue.count
   }
 

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -96,7 +96,7 @@ open class MessagesViewController: UIViewController, UICollectionViewDelegateFlo
     guard let collectionView = collectionView as? MessagesCollectionView else {
       fatalError(MessageKitError.notMessagesCollectionView)
     }
-    let sections = collectionView.messagesDataSource?.numberOfSections(in: collectionView) ?? 0
+    let sections = collectionView.messagesDataSource?.numberOfMessageSections(in: collectionView) ?? 0
     return collectionView.isTypingIndicatorHidden ? sections : sections + 1
   }
 

--- a/Sources/Protocols/MessagesDataSource.swift
+++ b/Sources/Protocols/MessagesDataSource.swift
@@ -58,6 +58,17 @@ public protocol MessagesDataSource: AnyObject {
   ///   `messages.count + 1` while the indicator is visible reports one section
   ///   more than there are messages, and the next reload asks this data source
   ///   for a message that does not exist.
+  func numberOfMessageSections(in messagesCollectionView: MessagesCollectionView) -> Int
+
+  /// The number of sections that hold messages.
+  ///
+  /// - Parameters:
+  ///   - messagesCollectionView: The `MessagesCollectionView` in which the messages will be displayed.
+  @available(
+    *,
+    deprecated,
+    renamed: "numberOfMessageSections(in:)",
+    message: "Renamed to numberOfMessageSections(in:), which says what it counts. Return the message sections only: the typing indicator's section is reserved by MessagesViewController, so adding one for it here counts that section twice.")
   func numberOfSections(in messagesCollectionView: MessagesCollectionView) -> Int
 
   /// The number of cells to be displayed in the `MessagesCollectionView`.
@@ -204,6 +215,29 @@ public protocol MessagesDataSource: AnyObject {
 extension MessagesDataSource {
   public func isFromCurrentSender(message: MessageType) -> Bool {
     message.sender.senderId == currentSender.senderId
+  }
+
+  /// Bridges a data source written before the rename, so one that implements
+  /// only `numberOfSections(in:)` keeps working untouched.
+  ///
+  /// - Note:
+  ///   Calling the deprecated name here warns while compiling MessageKit
+  ///   itself, and that warning is expected. Silencing it means deprecating
+  ///   this bridge, which makes every data source that has not migrated report
+  ///   a deprecated default implementation of `numberOfMessageSections(in:)`
+  ///   instead, pointing at the new name rather than the old one.
+  public func numberOfMessageSections(in messagesCollectionView: MessagesCollectionView) -> Int {
+    numberOfSections(in: messagesCollectionView)
+  }
+
+  /// - Note:
+  ///   This returns zero rather than calling `numberOfMessageSections(in:)`.
+  ///   Two defaults that called each other would recurse until the stack ran
+  ///   out for a data source that implements neither, and a chat with no
+  ///   sections beats a crash. The framework only ever calls
+  ///   `numberOfMessageSections(in:)`, so this stays a leaf.
+  public func numberOfSections(in _: MessagesCollectionView) -> Int {
+    0
   }
 
   public func numberOfItems(inSection _: Int, in _: MessagesCollectionView) -> Int {

--- a/Tests/MessageKitTests/Controllers Test/MessagesViewControllerTests.swift
+++ b/Tests/MessageKitTests/Controllers Test/MessagesViewControllerTests.swift
@@ -49,7 +49,7 @@ final class MessagesViewControllerTests: XCTestCase {
     sut.messagesCollectionView.reloadData()
 
     let count = sut.messagesCollectionView.numberOfSections
-    let expectedCount = messagesDataSource.numberOfSections(in: sut.messagesCollectionView)
+    let expectedCount = messagesDataSource.numberOfMessageSections(in: sut.messagesCollectionView)
 
     XCTAssertEqual(count, expectedCount)
   }

--- a/Tests/MessageKitTests/Controllers Test/TypingIndicatorSectionTests.swift
+++ b/Tests/MessageKitTests/Controllers Test/TypingIndicatorSectionTests.swift
@@ -177,7 +177,7 @@ private final class SelfSourcingController: MessagesViewController, MessagesData
     MockUser(senderId: "sender_1", displayName: "Sender 1")
   }
 
-  func numberOfSections(in _: MessagesCollectionView) -> Int {
+  func numberOfMessageSections(in _: MessagesCollectionView) -> Int {
     messages.count
   }
 

--- a/Tests/MessageKitTests/Mocks/MockMessagesDataSource.swift
+++ b/Tests/MessageKitTests/Mocks/MockMessagesDataSource.swift
@@ -39,7 +39,7 @@ class MockMessagesDataSource: MessagesDataSource {
     currentUser
   }
 
-  func numberOfSections(in _: MessagesCollectionView) -> Int {
+  func numberOfMessageSections(in _: MessagesCollectionView) -> Int {
     messages.count
   }
 

--- a/Tests/MessageKitTests/Protocols Tests/MessagesDataSourceSectionCountTests.swift
+++ b/Tests/MessageKitTests/Protocols Tests/MessagesDataSourceSectionCountTests.swift
@@ -1,0 +1,154 @@
+// MIT License
+//
+// Copyright (c) 2017-2019 MessageKit
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+import XCTest
+@testable import MessageKit
+
+// MARK: - MessagesDataSourceSectionCountTests
+
+/// `numberOfSections(in:)` was renamed to `numberOfMessageSections(in:)`, and
+/// both names still resolve. These pin down all three conformance shapes,
+/// including the one that implements neither.
+@MainActor
+final class MessagesDataSourceSectionCountTests: XCTestCase {
+  // MARK: Internal
+
+  func testADataSourceOnTheNewNameReportsItsOwnCount() {
+    let dataSource = ModernDataSource()
+    dataSource.count = 7
+
+    XCTAssertEqual(dataSource.numberOfMessageSections(in: makeCollectionView()), 7)
+  }
+
+  /// The point of the deprecation: a data source written before the rename
+  /// keeps working through the bridging default.
+  func testADataSourceOnTheOldNameStillReachesTheFramework() {
+    let dataSource = LegacyDataSource()
+    dataSource.count = 4
+
+    XCTAssertEqual(dataSource.numberOfMessageSections(in: makeCollectionView()), 4)
+  }
+
+  /// Two defaults that called each other would recurse until the stack ran out.
+  /// The deprecated default is a leaf instead, so this returns rather than
+  /// crashing.
+  func testADataSourceOnNeitherNameReportsNoSectionsInsteadOfRecursing() {
+    let dataSource = EmptyDataSource()
+
+    XCTAssertEqual(dataSource.numberOfMessageSections(in: makeCollectionView()), 0)
+  }
+
+  func testTheControllerCountsTheMessageSectionsOfALegacyDataSource() {
+    let dataSource = LegacyDataSource()
+    dataSource.count = 4
+    let controller = makeController(dataSource: dataSource)
+
+    XCTAssertEqual(controller.numberOfSections(in: controller.messagesCollectionView), 4)
+  }
+
+  func testTheControllerAddsTheIndicatorSectionForALegacyDataSource() {
+    let dataSource = LegacyDataSource()
+    dataSource.count = 4
+    let controller = makeController(dataSource: dataSource)
+
+    controller.messagesCollectionView.setTypingIndicatorViewHidden(false)
+
+    XCTAssertEqual(controller.numberOfSections(in: controller.messagesCollectionView), 5)
+  }
+
+  // MARK: Private
+
+  /// `MessagesCollectionView` keeps its data source and delegates weakly.
+  private var retained: [Any] = []
+
+  private func makeCollectionView() -> MessagesCollectionView {
+    MessagesCollectionView()
+  }
+
+  private func makeController(dataSource: some MessagesDataSource) -> MessagesViewController {
+    let controller = MessagesViewController()
+    let layoutDelegate = SectionCountLayoutDelegate()
+    retained.append(layoutDelegate)
+    retained.append(dataSource)
+    controller.messagesCollectionView.messagesDataSource = dataSource
+    controller.messagesCollectionView.messagesLayoutDelegate = layoutDelegate
+    controller.messagesCollectionView.messagesDisplayDelegate = layoutDelegate
+    _ = controller.view
+    return controller
+  }
+}
+
+// MARK: - ModernDataSource
+
+/// Implements only the new name.
+private final class ModernDataSource: MessagesDataSource {
+  var count = 0
+
+  var currentSender: SenderType {
+    MockUser(senderId: "sender_1", displayName: "Sender 1")
+  }
+
+  func numberOfMessageSections(in _: MessagesCollectionView) -> Int {
+    count
+  }
+
+  func messageForItem(at indexPath: IndexPath, in _: MessagesCollectionView) -> MessageType {
+    MockMessage(text: "Message", user: MockUser(senderId: "sender_1", displayName: "Sender 1"), messageId: "\(indexPath.section)")
+  }
+}
+
+// MARK: - LegacyDataSource
+
+/// Implements only the deprecated name, the way every data source written
+/// before the rename does.
+private final class LegacyDataSource: MessagesDataSource {
+  var count = 0
+
+  var currentSender: SenderType {
+    MockUser(senderId: "sender_1", displayName: "Sender 1")
+  }
+
+  @available(*, deprecated)
+  func numberOfSections(in _: MessagesCollectionView) -> Int {
+    count
+  }
+
+  func messageForItem(at indexPath: IndexPath, in _: MessagesCollectionView) -> MessageType {
+    MockMessage(text: "Message", user: MockUser(senderId: "sender_1", displayName: "Sender 1"), messageId: "\(indexPath.section)")
+  }
+}
+
+// MARK: - EmptyDataSource
+
+/// Implements neither name, which is the shape that would recurse.
+private final class EmptyDataSource: MessagesDataSource {
+  var currentSender: SenderType {
+    MockUser(senderId: "sender_1", displayName: "Sender 1")
+  }
+
+  func messageForItem(at indexPath: IndexPath, in _: MessagesCollectionView) -> MessageType {
+    MockMessage(text: "Message", user: MockUser(senderId: "sender_1", displayName: "Sender 1"), messageId: "\(indexPath.section)")
+  }
+}
+
+// MARK: - SectionCountLayoutDelegate
+
+private final class SectionCountLayoutDelegate: MessagesLayoutDelegate, MessagesDisplayDelegate { }


### PR DESCRIPTION
> Stacked on #1921. Base is `fix/typing-indicator-sections`, so review that one first.

## Summary

#1921 documented the contract behind #1788, #1787 and #1387. This removes the reason the contract needed documenting.

`MessagesDataSource.numberOfSections(in:)` read as the **total** number of sections, and it never was — it counts the sections that hold messages. `MessagesViewController` reserves the typing indicator's section on top of whatever it returns, so adding one yourself counts that section twice.

It also collided with `UICollectionViewDataSource.numberOfSections(in:)`, which `MessagesViewController` implements. The two differed only in the parameter type, so the framework's own `+ 1` looked like something a subclass was overriding rather than something already done for it.

`numberOfMessageSections(in:)` cannot be read as the total, and no longer collides.

```swift
// before
func numberOfSections(in messagesCollectionView: MessagesCollectionView) -> Int {
  messages.count
}

// after
func numberOfMessageSections(in messagesCollectionView: MessagesCollectionView) -> Int {
  messages.count
}
```

## Not a breaking change

The old name is deprecated, not removed. A data source that implements only `numberOfSections(in:)` keeps working through a bridging default and gets a rename warning.

## The recursion hazard, and how it is closed

The obvious shape is two defaults that forward to each other. That compiles, and then a data source implementing **neither** recurses until the stack runs out — a worse failure than the one being fixed.

So the deprecated default is a **leaf**: it returns zero rather than calling the new name, and the framework only ever calls the new name.

| Data source implements | Result |
| --- | --- |
| the new name | its own count |
| the old name | its own count, via the bridge |
| neither | `0` — an empty chat, not a crash |

All three are tested, including through the controller with and without the indicator visible.

## One warning inside MessageKit, on purpose

The bridge calls the deprecated name, so compiling MessageKit emits one deprecation warning. I tried silencing it by marking the bridge deprecated — **rejected**, because it moves the warning to every unmigrated data source as:

> deprecated default implementation is used to satisfy instance method 'numberOfMessageSections(in:)'

That points at the *new* name and reads as though the new name were the problem. One warning inside MessageKit is the better trade. A note on the bridge records the reasoning so nobody "fixes" it later.

## Also updated

The example app, the test mocks, `QuickStart.md`, `CUSTOM_CELLS.md`, and a new `MessageKit 5.0 Migration Guide` section in `MIGRATION_GUIDE.md` explaining the rename and why the count never included the indicator.

## Verification

102 tests pass, up from 97. `make lint` passes.
