### PR TITLE
Put the SwiftUI example input bar on top of the keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 - Add tests for `TypingIndicator` and `TypingBubble`, which cover the dot layout and spacing, the animation state flags, the animation layers and the pulse layers, and had no tests before by [@martinpucik](https://github.com/martinpucik)
 ### Fixed
 
+- Fix the input bar in the SwiftUI example sitting a home indicator inset above the keyboard rather than on top of it. `ignoresSafeArea(.keyboard, edges: .bottom)` left the bottom container inset in place, which stopped the view short of the screen edge, and the keyboard manager positions the bar a whole keyboard height above that edge by [@martinpucik](https://github.com/martinpucik)
 - **Breaking Change** Annotate `MessageCellDelegate` and `MessageLabelDelegate` with `@MainActor`. Their sibling delegate protocols `MessagesDataSource`, `MessagesLayoutDelegate` and `MessagesDisplayDelegate` already carried the annotation, so consumers building in the Swift 6 language mode had to work around these two with `@preconcurrency` by [@martinpucik](https://github.com/martinpucik)
 - Fix `make format`, `make lint` and the pre-commit hook, which still called the removed SwiftPM plugins by [@martinpucik](https://github.com/martinpucik)
 - Adopt the scene lifecycle in the example app, which crashed on launch on iOS 26 and later by [@martinpucik](https://github.com/martinpucik)

--- a/Example/Sources/Views/SwiftUI/SwiftUIExampleView.swift
+++ b/Example/Sources/Views/SwiftUI/SwiftUIExampleView.swift
@@ -23,8 +23,14 @@ struct SwiftUIExampleView: View {
       cleanupSocket()
     }
     .navigationBarTitle("SwiftUI Example", displayMode: .inline)
-    // Fixes the InputBarAccessoryView placement when the keyboard appears
-    .ignoresSafeArea(.keyboard, edges: .bottom)
+    /// `MessagesViewController` pins its collection view and its input bar to
+    /// `view.bottomAnchor`, and the keyboard manager places the input bar a
+    /// whole keyboard height above that anchor. So the view has to reach the
+    /// bottom of the screen: leave the home indicator inset in place and the
+    /// bar settles that inset above the keyboard instead of on top of it.
+    /// Ignoring `.keyboard` alone is not enough, because that region covers
+    /// only the keyboard.
+    .ignoresSafeArea(edges: .bottom)
   }
 
   // MARK: Private


### PR DESCRIPTION
Closes #1798, closes #1861.

## Summary

The input bar in the SwiftUI example floated **34 pt above the keyboard** on any device with a home indicator. One line, measured before and after on a simulator.

`MessagesViewController` pins both its collection view and its input bar to `view.bottomAnchor`, and `KeyboardManager` places the bar a whole keyboard height above that anchor:

```swift
constraints?.bottom?.constant = min(-34, -keyboardHeight + bottomGap) - (additionalBottomSpace?() ?? 0)
```

The example ignored only the `.keyboard` safe area region, so the bottom **container** inset stayed in place and the representable's view stopped 34 pt short of the screen edge. The bar was then positioned a keyboard height above 840 instead of above 874.

```diff
- // Fixes the InputBarAccessoryView placement when the keyboard appears
- .ignoresSafeArea(.keyboard, edges: .bottom)
+ .ignoresSafeArea(edges: .bottom)
```

## Measurements

iPhone 17 simulator, 402 × 874 pt, 34 pt bottom inset, keyboard region (`inputView`) top edge at 546, real software keyboard raised (29 `Key` nodes in the hierarchy).

| | before | after | Basic Example (reference) |
| --- | --- | --- | --- |
| CollectionView | 116–840 | 116–**874** | 0–874 |
| Input bar container | 462–**512** | 496–**546** | 496–546 |
| TextView | 468–506 | 502–540 | 502–540 |
| **Gap to keyboard** | **34.0 pt** | **0.0 pt** | 0.0 pt |

The anchor arithmetic matches exactly: `840 − 328 = 512` before, `874 − 328 = 546` after. The bar's frame is now identical to the Basic example, to the point.

Text view is fully visible with 6 pt of clearance, not clipped — #1861's "not fully showed" was this gap, not clipping.

## Why ignoring the whole bottom safe area is right

The other examples already reach the screen edge by virtue of not being SwiftUI, and MessageKit handles the home indicator itself: the input bar's background view extends `window.safeAreaInsets.bottom` below its content (`InputBarAccessoryView.setupConstraints(to:)`), and `updateMessageCollectionViewBottomInset` keeps the messages clear of it. Keyboard-down after the change: background 790–874, collection view 116–874 — the bar covers the home indicator exactly as the Basic example does.

## One thing left alone

The 84 pt background view still hangs 34 pt below the keyboard top edge (496–580 with the keyboard up). It is behind the keyboard, so there is no visible defect, and it is InputBarAccessoryView's own constraint rather than MessageKit's. Not touched here.

## Note on a wrong diagnosis I discarded

The first reading of this was that Basic collapses its bar from 84 pt to 50 pt while SwiftUI keeps 84. That is not what happens — **both** have a 50 pt container inside an 84 pt background, in both keyboard states. The bar was only ever mispositioned, never mis-sized, so changing its height or padding would have been the wrong lever.

## Verification

`make lint` passes. Framework tests are untouched by this (example-app only), and CI builds the example app.

## Not addressed

#1867, #1852 and #1831 are a separate defect: `setContentOffset` appears nowhere in the keyboard path, and `differenceOfBottomInset` in `updateMessageCollectionViewBottomInset` is computed but unused — the 3.x offset compensation it fed was dropped in 4.0. That needs its own PR and a mid-conversation repro.
